### PR TITLE
Build headers by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ branch = "master"
 lto = true
 
 [features]
-default = []
+default = ["parse_headers"]
 parse_headers = ["timescale-extension-utils/parse_headers"]


### PR DESCRIPTION
The postgres extension library we use has the option to use cached rust bindings to the postgres headers in order to improve compile times. This was only supposed to be used for development, as using it in other circumstances would carry a risk of using stale headers. Unfortunately, it looks like the commit changing that default got lost so this commit performs that change in our makefile.