### PR TITLE
Add vectorSelector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "atty",
  "humantime",
@@ -653,9 +653,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.96"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5600b4e6efc5421841a2138a6b082e07fe12f9aaa12783d50e5d13325b26b4fc"
+checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "libloading"
@@ -745,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.11"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
  "log",
@@ -805,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "opaque-debug"
@@ -855,7 +855,7 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 [[package]]
 name = "pgx"
 version = "0.1.19"
-source = "git+https://github.com/JLockerman/pgx.git?branch=timescale#87e0460e6e88d6ffa9b9eb37dce4b71e4336e31e"
+source = "git+https://github.com/JLockerman/pgx.git?branch=guardless#c82482493be32c7029498b057f22259e68675405"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -877,7 +877,7 @@ dependencies = [
 [[package]]
 name = "pgx-macros"
 version = "0.1.19"
-source = "git+https://github.com/JLockerman/pgx.git?branch=timescale#87e0460e6e88d6ffa9b9eb37dce4b71e4336e31e"
+source = "git+https://github.com/JLockerman/pgx.git?branch=guardless#c82482493be32c7029498b057f22259e68675405"
 dependencies = [
  "pgx-utils",
  "proc-macro2",
@@ -889,7 +889,7 @@ dependencies = [
 [[package]]
 name = "pgx-pg-sys"
 version = "0.1.19"
-source = "git+https://github.com/JLockerman/pgx.git?branch=timescale#87e0460e6e88d6ffa9b9eb37dce4b71e4336e31e"
+source = "git+https://github.com/JLockerman/pgx.git?branch=guardless#c82482493be32c7029498b057f22259e68675405"
 dependencies = [
  "bindgen",
  "build-deps",
@@ -908,7 +908,7 @@ dependencies = [
 [[package]]
 name = "pgx-tests"
 version = "0.1.19"
-source = "git+https://github.com/JLockerman/pgx.git?branch=timescale#87e0460e6e88d6ffa9b9eb37dce4b71e4336e31e"
+source = "git+https://github.com/JLockerman/pgx.git?branch=guardless#c82482493be32c7029498b057f22259e68675405"
 dependencies = [
  "colored",
  "lazy_static",
@@ -927,7 +927,7 @@ dependencies = [
 [[package]]
 name = "pgx-utils"
 version = "0.1.19"
-source = "git+https://github.com/JLockerman/pgx.git?branch=timescale#87e0460e6e88d6ffa9b9eb37dce4b71e4336e31e"
+source = "git+https://github.com/JLockerman/pgx.git?branch=guardless#c82482493be32c7029498b057f22259e68675405"
 dependencies = [
  "colored",
  "dirs",
@@ -1003,7 +1003,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand 0.8.3",
+ "rand 0.8.4",
  "sha2",
  "stringprep",
 ]
@@ -1081,14 +1081,14 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
- "rand_core 0.6.2",
- "rand_hc 0.3.0",
+ "rand_core 0.6.3",
+ "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -1108,7 +1108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1122,9 +1122,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom 0.2.3",
 ]
@@ -1140,11 +1140,11 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1174,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
 dependencies = [
  "bitflags",
 ]
@@ -1534,9 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a8cbfbf47955132d0202d1662f49b2423ae35862aee471f3ba4b133358f372"
+checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
 dependencies = [
  "const_fn",
  "libc",
@@ -1559,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros-impl"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
+checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -1587,9 +1587,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a38d31d7831c6ed7aad00aa4c12d9375fd225a6dd77da1d25b707346319a975"
+checksum = "c79ba603c337335df6ba6dd6afc38c38a7d5e1b0c871678439ea973cd62a118e"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1597,6 +1597,7 @@ dependencies = [
  "memchr",
  "mio",
  "pin-project-lite",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ pg13 = ["pgx/pg13", "pgx-tests/pg13"]
 [dependencies]
 bincode = "1.3.1"
 serde = { version = "1.0", features = ["derive"] }
-pgx = {git="https://github.com/JLockerman/pgx.git", branch="timescale"}
-pgx-macros = {git="https://github.com/JLockerman/pgx.git", branch="timescale"}
+pgx = {git="https://github.com/JLockerman/pgx.git", branch="guardless"}
+pgx-macros = {git="https://github.com/JLockerman/pgx.git", branch="guardless"}
 
 [dev-dependencies]
-pgx-tests = {git="https://github.com/JLockerman/pgx.git", branch="timescale"}
+pgx-tests = {git="https://github.com/JLockerman/pgx.git", branch="guardless"}

--- a/sql/promscale--0.1.2--0.1.3-beta.sql
+++ b/sql/promscale--0.1.2--0.1.3-beta.sql
@@ -1,36 +1,36 @@
-CREATE FUNCTION @extschema@.prom_delta_transition(state internal, lowest_time timestamptz,
+CREATE OR REPLACE FUNCTION @extschema@.prom_delta_transition(state internal, lowest_time timestamptz,
     greatest_time timestamptz, step bigint, range bigint,
     sample_time timestamptz, sample_value double precision)
 RETURNS internal AS '$libdir/promscale', 'prom_delta_transition_wrapper'
 LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE FUNCTION @extschema@.prom_rate_transition(state internal, lowest_time timestamptz,
+CREATE OR REPLACE FUNCTION @extschema@.prom_rate_transition(state internal, lowest_time timestamptz,
     greatest_time timestamptz, step bigint, range bigint,
     sample_time timestamptz, sample_value double precision)
 RETURNS internal AS '$libdir/promscale', 'prom_rate_transition_wrapper'
 LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE FUNCTION @extschema@.prom_increase_transition(state internal, lowest_time timestamptz,
+CREATE OR REPLACE FUNCTION @extschema@.prom_increase_transition(state internal, lowest_time timestamptz,
     greatest_time timestamptz, step bigint, range bigint,
     sample_time timestamptz, sample_value double precision)
 RETURNS internal AS '$libdir/promscale', 'prom_increase_transition_wrapper'
 LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE FUNCTION @extschema@.prom_extrapolate_final(state internal)
+CREATE OR REPLACE FUNCTION @extschema@.prom_extrapolate_final(state internal)
 RETURNS DOUBLE PRECISION[]
 AS '$libdir/promscale', 'prom_delta_final_wrapper'
 LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE OR REPLACE FUNCTION "vector_selector_transition"("state" internal, "start_time" TimestampTz, "end_time" TimestampTz, "bucket_width" bigint, "lookback" bigint, "time" TimestampTz, "val" double precision) RETURNS internal IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_transition_wrapper';
+CREATE OR REPLACE FUNCTION @extschema@."vector_selector_transition"("state" internal, "start_time" TimestampTz, "end_time" TimestampTz, "bucket_width" bigint, "lookback" bigint, "time" TimestampTz, "val" double precision) RETURNS internal IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_transition_wrapper';
 -- ./src/lib.rs:337:0
-CREATE OR REPLACE FUNCTION "vector_selector_final"("state" internal) RETURNS double precision[] IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_final_wrapper';
+CREATE OR REPLACE FUNCTION @extschema@."vector_selector_final"("state" internal) RETURNS double precision[] IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_final_wrapper';
 -- ./src/lib.rs:345:0
-CREATE OR REPLACE FUNCTION "vector_selector_serialize"("state" internal) RETURNS bytea IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_serialize_wrapper';
+CREATE OR REPLACE FUNCTION @extschema@."vector_selector_serialize"("state" internal) RETURNS bytea IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_serialize_wrapper';
 -- ./src/lib.rs:350:0
-CREATE OR REPLACE FUNCTION "vector_selector_deserialize"("bytes" bytea, "_internal" internal) RETURNS internal IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_deserialize_wrapper';
+CREATE OR REPLACE FUNCTION @extschema@."vector_selector_deserialize"("bytes" bytea, "_internal" internal) RETURNS internal IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_deserialize_wrapper';
 -- ./src/lib.rs:358:0
-CREATE OR REPLACE FUNCTION "vector_selector_combine"("state1" internal, "state2" internal) RETURNS internal IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_combine_wrapper';
-CREATE AGGREGATE vector_selector(
+CREATE OR REPLACE FUNCTION @extschema@."vector_selector_combine"("state1" internal, "state2" internal) RETURNS internal IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_combine_wrapper';
+CREATE AGGREGATE @extschema@.vector_selector(
     start_time timestamptz,
     end_time timestamptz,
     bucket_width bigint,

--- a/sql/promscale--0.1.2--0.1.3-beta.sql
+++ b/sql/promscale--0.1.2--0.1.3-beta.sql
@@ -20,3 +20,29 @@ CREATE FUNCTION @extschema@.prom_extrapolate_final(state internal)
 RETURNS DOUBLE PRECISION[]
 AS '$libdir/promscale', 'prom_delta_final_wrapper'
 LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION "vector_selector_transition"("state" internal, "start_time" TimestampTz, "end_time" TimestampTz, "bucket_width" bigint, "lookback" bigint, "time" TimestampTz, "val" double precision) RETURNS internal IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_transition_wrapper';
+-- ./src/lib.rs:337:0
+CREATE OR REPLACE FUNCTION "vector_selector_final"("state" internal) RETURNS double precision[] IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_final_wrapper';
+-- ./src/lib.rs:345:0
+CREATE OR REPLACE FUNCTION "vector_selector_serialize"("state" internal) RETURNS bytea IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_serialize_wrapper';
+-- ./src/lib.rs:350:0
+CREATE OR REPLACE FUNCTION "vector_selector_deserialize"("bytes" bytea, "_internal" internal) RETURNS internal IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_deserialize_wrapper';
+-- ./src/lib.rs:358:0
+CREATE OR REPLACE FUNCTION "vector_selector_combine"("state1" internal, "state2" internal) RETURNS internal IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_combine_wrapper';
+CREATE AGGREGATE vector_selector(
+    start_time timestamptz,
+    end_time timestamptz,
+    bucket_width bigint,
+    lookback bigint,
+    sample_time timestamptz,
+    sample_value DOUBLE PRECISION)
+(
+    sfunc = vector_selector_transition,
+    stype = internal,
+    finalfunc = vector_selector_final,
+    combinefunc = vector_selector_combine,
+    serialfunc = vector_selector_serialize,
+    deserialfunc = vector_selector_deserialize,
+    parallel = safe
+);

--- a/sql/promscale--0.1.3-beta.sql
+++ b/sql/promscale--0.1.3-beta.sql
@@ -230,3 +230,29 @@ CREATE AGGREGATE @extschema@.prom_increase(
     stype=internal,
     finalfunc=@extschema@.prom_extrapolate_final
 );
+
+CREATE OR REPLACE FUNCTION "vector_selector_transition"("state" internal, "start_time" TimestampTz, "end_time" TimestampTz, "bucket_width" bigint, "lookback" bigint, "time" TimestampTz, "val" double precision) RETURNS internal IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_transition_wrapper';
+-- ./src/lib.rs:337:0
+CREATE OR REPLACE FUNCTION "vector_selector_final"("state" internal) RETURNS double precision[] IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_final_wrapper';
+-- ./src/lib.rs:345:0
+CREATE OR REPLACE FUNCTION "vector_selector_serialize"("state" internal) RETURNS bytea IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_serialize_wrapper';
+-- ./src/lib.rs:350:0
+CREATE OR REPLACE FUNCTION "vector_selector_deserialize"("bytes" bytea, "_internal" internal) RETURNS internal IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_deserialize_wrapper';
+-- ./src/lib.rs:358:0
+CREATE OR REPLACE FUNCTION "vector_selector_combine"("state1" internal, "state2" internal) RETURNS internal IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_combine_wrapper';
+CREATE AGGREGATE vector_selector(
+    start_time timestamptz,
+    end_time timestamptz,
+    bucket_width bigint,
+    lookback bigint,
+    sample_time timestamptz,
+    sample_value DOUBLE PRECISION)
+(
+    sfunc = vector_selector_transition,
+    stype = internal,
+    finalfunc = vector_selector_final,
+    combinefunc = vector_selector_combine,
+    serialfunc = vector_selector_serialize,
+    deserialfunc = vector_selector_deserialize,
+    parallel = safe
+);

--- a/sql/promscale--0.1.3-beta.sql
+++ b/sql/promscale--0.1.3-beta.sql
@@ -231,16 +231,16 @@ CREATE AGGREGATE @extschema@.prom_increase(
     finalfunc=@extschema@.prom_extrapolate_final
 );
 
-CREATE OR REPLACE FUNCTION "vector_selector_transition"("state" internal, "start_time" TimestampTz, "end_time" TimestampTz, "bucket_width" bigint, "lookback" bigint, "time" TimestampTz, "val" double precision) RETURNS internal IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_transition_wrapper';
+CREATE OR REPLACE FUNCTION @extschema@."vector_selector_transition"("state" internal, "start_time" TimestampTz, "end_time" TimestampTz, "bucket_width" bigint, "lookback" bigint, "time" TimestampTz, "val" double precision) RETURNS internal IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_transition_wrapper';
 -- ./src/lib.rs:337:0
-CREATE OR REPLACE FUNCTION "vector_selector_final"("state" internal) RETURNS double precision[] IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_final_wrapper';
+CREATE OR REPLACE FUNCTION @extschema@."vector_selector_final"("state" internal) RETURNS double precision[] IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_final_wrapper';
 -- ./src/lib.rs:345:0
-CREATE OR REPLACE FUNCTION "vector_selector_serialize"("state" internal) RETURNS bytea IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_serialize_wrapper';
+CREATE OR REPLACE FUNCTION @extschema@."vector_selector_serialize"("state" internal) RETURNS bytea IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_serialize_wrapper';
 -- ./src/lib.rs:350:0
-CREATE OR REPLACE FUNCTION "vector_selector_deserialize"("bytes" bytea, "_internal" internal) RETURNS internal IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_deserialize_wrapper';
+CREATE OR REPLACE FUNCTION @extschema@."vector_selector_deserialize"("bytes" bytea, "_internal" internal) RETURNS internal IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_deserialize_wrapper';
 -- ./src/lib.rs:358:0
-CREATE OR REPLACE FUNCTION "vector_selector_combine"("state1" internal, "state2" internal) RETURNS internal IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_combine_wrapper';
-CREATE AGGREGATE vector_selector(
+CREATE OR REPLACE FUNCTION @extschema@."vector_selector_combine"("state1" internal, "state2" internal) RETURNS internal IMMUTABLE PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', 'vector_selector_combine_wrapper';
+CREATE AGGREGATE @extschema@.vector_selector(
     start_time timestamptz,
     end_time timestamptz,
     bucket_width bigint,

--- a/src/type_builder.rs
+++ b/src/type_builder.rs
@@ -1,0 +1,67 @@
+#[repr(u8)]
+pub enum SerializationType {
+    Default = 1,
+}
+
+#[macro_export]
+macro_rules! do_serialize {
+    ($state: ident) => {
+        {
+            $crate::do_serialize!($state, version: 1)
+        }
+    };
+    ($state: ident, version: $version: expr) => {
+        {
+            use $crate::type_builder::SerializationType;
+
+            let state = &*$state;
+            let serialized_size = bincode::serialized_size(state)
+                .unwrap_or_else(|e| pgx::error!("serialization error {}", e));
+            let size = serialized_size + 2; // size of serialized data + our version flags
+            let mut bytes = Vec::with_capacity(size as usize + 4);
+            let varsize = [0; 4];
+            bytes.extend_from_slice(&varsize);
+            // type version
+            bytes.push($version);
+            // serialization version; 1 for bincode is currently the only option
+            bytes.push(SerializationType::Default as u8);
+            bincode::serialize_into(&mut bytes, state)
+                .unwrap_or_else(|e| pgx::error!("serialization error {}", e));
+            unsafe {
+                ::pgx::set_varsize(bytes.as_mut_ptr() as *mut _, bytes.len() as i32);
+            }
+            bytes.leak().as_mut_ptr() as pg_sys::Datum
+        }
+    };
+}
+#[macro_export]
+macro_rules! do_deserialize {
+    ($bytes: ident, $t: ty) => {{
+        use $crate::type_builder::SerializationType;
+
+        let state: $t = unsafe {
+            let detoasted = pg_sys::pg_detoast_datum_packed($bytes as *mut _);
+            let len = pgx::varsize_any_exhdr(detoasted);
+            let data = pgx::vardata_any(detoasted);
+            let bytes = std::slice::from_raw_parts(data as *mut u8, len);
+            if bytes.len() < 1 {
+                pgx::error!("deserialization error, no bytes")
+            }
+            if bytes[0] != 1 {
+                pgx::error!(
+                    "deserialization error, invalid serialization version {}",
+                    bytes[0]
+                )
+            }
+            if bytes[1] != SerializationType::Default as u8 {
+                pgx::error!(
+                    "deserialization error, invalid serialization type {}",
+                    bytes[1]
+                )
+            }
+            bincode::deserialize(&bytes[2..])
+                .unwrap_or_else(|e| pgx::error!("deserialization error {}", e))
+        };
+        state.into()
+    }};
+}


### PR DESCRIPTION
a vector selector aggregate has the same semantics as parse.VectorSelector processing
in Prometheus. Namely, for all timestamps ts in the series:
     ts := ev.startTimestamp; ts <= ev.endTimestamp; ts += ev.interval
we return the last sample.value such that the time sample.time <= ts and sample.time >= ts-lookback.
if such a sample doesn't exist return NULL (None).
thus, the vector selector returns a regular series of values corresponding to all the points in the
ts series above.

Note that for performance, this aggregate is parallel-izable, combinable, and does not expect ordered inputs.

Relies on #14 