### PR TITLE
Add more detailed installation instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,7 +19,7 @@ To compile the extension (see instructions below):
 The extension is installed by default on the
 [`timescaledev/promscale-extension:latest-pg12`](https://hub.docker.com/r/timescaledev/promscale-extension) docker image.
 
-To compile and install from source follow the steps:
+For bare-metal installations, the full instructions for setting up PostgreSQL, TimescaleDB, and the Promscale Extension are:
 1) [Add the PostgreSQL APT repository (Ubuntu)](https://www.postgresql.org/download/linux/ubuntu/)
 ```bash
 echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -c -s)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list

--- a/Readme.md
+++ b/Readme.md
@@ -71,13 +71,10 @@ sudo make install
 sudo -u postgres psql -c "CREATE USER promscale SUPERUSER PASSWORD 'promscale';"
 sudo -u postgres psql -c "CREATE DATABASE promscale OWNER promscale;"
 ```
-1) Download promscale
+1) [Download and run promscale (it will install the extension in the PostgreSQL database)](https://github.com/timescale/promscale/blob/master/docs/bare-metal-promscale-stack.md#2-deploying-promscale)
 ```bash
 LATEST_VERSION=$(curl -s https://api.github.com/repos/timescale/promscale/releases/latest | grep "tag_name" | cut -d'"' -f4)
 curl -L -o promscale "https://github.com/timescale/promscale/releases/download/${LATEST_VERSION}/promscale_${LATEST_VERSION}_Linux_x86_64"
-```
-1) Run promscale (it will install the extension in the PostgreSQL database)
-```bash
 chmod +x promscale
 ./promscale --db-name promscale --db-password promscale --db-user promscale --db-ssl-mode allow --install-extensions
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -20,9 +20,67 @@ The extension is installed by default on the
 [`timescaledev/promscale-extension:latest-pg12`](https://hub.docker.com/r/timescaledev/promscale-extension) docker image.
 
 To compile and install from source follow the steps:
+1) [Add the PostgreSQL APT repository (Ubuntu)](https://www.postgresql.org/download/linux/ubuntu/)
+```bash
+echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -c -s)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+sudo apt-get update
+```
+1) Install PostgreSQL 13 and TimescaleDB
+```bash
+sudo add-apt-repository ppa:timescale/timescaledb-ppa
+sudo apt-get update
+sudo apt-get install timescaledb-2-postgresql-13
+```
+1) Tune the PostgreSQL installation
+```bash
+sudo timescaledb-tune --quiet --yes
+sudo service postgresql restart
+```
+1) Install dependencies for the PGX framework and promscale_extension
+```bash
+sudo apt-get install build-essential clang libssl-dev pkg-config libreadline-dev zlib1g-dev postgresql-server-dev-13
+```
 1) [Install rust](https://www.rust-lang.org/tools/install).
-1) Install our fork of the PGX framework `cargo install --git https://github.com/JLockerman/pgx.git --branch timescale cargo-pgx && cargo pgx init`  
-1) Compile and install: `make && make install`.
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source $HOME/.cargo/env
+```
+1) Install our fork of the PGX framework
+```bash
+cargo install --git https://github.com/JLockerman/pgx.git --branch timescale cargo-pgx
+```
+1) Initialize the PGX framework using the PostgreSQL 13 installation
+```bash
+cargo pgx init --pg13=/usr/lib/postgresql/13/bin/pg_config
+```
+1) Download this repo and change directory into it
+```bash
+curl -L -o "promscale_extension.zip" "https://github.com/timescale/promscale_extension/archive/refs/tags/0.2.0.zip"
+sudo apt-get install unzip
+unzip promscale_extension.zip
+cd promscale_extension-0.2.0
+```
+1) Compile and install
+```bash
+make
+sudo make install
+```
+1) Create a PostgreSQL user and database for promscale (use an appropriate password!)
+```bash
+sudo -u postgres psql -c "CREATE USER promscale SUPERUSER PASSWORD 'promscale';"
+sudo -u postgres psql -c "CREATE DATABASE promscale OWNER promscale;"
+```
+1) Download promscale
+```bash
+LATEST_VERSION=$(curl -s https://api.github.com/repos/timescale/promscale/releases/latest | grep "tag_name" | cut -d'"' -f4)
+curl -L -o promscale "https://github.com/timescale/promscale/releases/download/${LATEST_VERSION}/promscale_${LATEST_VERSION}_Linux_x86_64"
+```
+1) Run promscale (it will install the extension in the PostgreSQL database)
+```bash
+chmod +x promscale
+./promscale --db-name promscale --db-password promscale --db-user promscale --db-ssl-mode allow --install-extensions
+```
 
 This extension will be created via `CREATE EXTENSION` automatically by the Promscale connector and should not be created manually.
 


### PR DESCRIPTION
Updated the Readme with more detailed, step-by-step instructions for getting a working instance of promscale with the promscale_extension compiled from source and installed in the database.