### PR TITLE
Move CODEOWNERS to .github

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @timescale/o11y-eng

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ src/*.bc
 src/*.d
 promscale.so
 /target
+.idea/

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-/ @timescale/o11y-eng


### PR DESCRIPTION
Move CODEOWNERS to .github dir since it only applies to GitHub and we want the root dir clean.