### PR TITLE
ci: run tests on pull_request events

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,47 @@
+name: ci
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        postgres:
+        - version: "14"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            override: true
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Install cargo-pgx
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-pgx
+
+      - name: Cache pgx
+        id: cache-pgx
+        uses: actions/cache@v2
+        with:
+          path: ~/.pgx
+          key: dot-pgx
+
+      - name: Initialize pgx
+        if: ${{ steps.cache-pgx.outputs.cache-hit != 'true' }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: pgx
+          args: init --pg${{ matrix.postgres.version }} download
+      
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: pgx
+          args: test pg${{ matrix.postgres.version }}
+


### PR DESCRIPTION
Add GHA workflow to run tests for the extension against Postgres 14. We can add support for other Postgres versions once we've sorted out how to handle test output differences that currently cause the tests to fail when run under versions other than 14.