### PR TITLE
Remove irrelevant .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,2 @@
-.deps
-src/*.o
-src/*.bc
-src/*.d
-promscale.so
 /target
 .idea/


### PR DESCRIPTION
These entries became irrelevant when we stopped compiling and linking C
and Rust sources manually.