### PR TITLE
Derive extension version from cargo crate version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 PG_CONFIG?=pg_config
 
-EXT_VERSION = $(shell cat promscale.control | grep 'default' | sed "s/^.*'\(.*\)'$\/\1/g")
+EXT_VERSION = $(shell cargo pkgid | cut -d'\#' -f2 | cut -d ':' -f2)
 PG_VERSION = $(shell ${PG_CONFIG} --version | awk -F'[ \.]' '{print $$2}')
 
 .PHONY: build

--- a/promscale.control
+++ b/promscale.control
@@ -1,6 +1,6 @@
 # promscale extension
 comment = 'Promscale support functions'
-default_version = '0.3.1'
+default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/promscale'
 relocatable = false
 schema = _prom_ext


### PR DESCRIPTION
PGX added support to use the cargo version as the extension version. To
enable this, the default_version in the .control file must be replaced
with `@CARGO_VERSION@`.