### PR TITLE
Improve docker image build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,14 @@ RUN --mount=type=cache,uid=70,gid=70,target=/build/promscale/.cargo/registry \
 
 USER root
 WORKDIR /build/promscale
-RUN chown postgres:postgres /build/promscale
+RUN chown -R postgres:postgres /build
 USER postgres
+
+# Pre-build extension dependencies
+RUN cd ../ && cargo pgx new promscale && cd promscale
+COPY Cargo.* Makefile /build/promscale/
+RUN --mount=type=cache,uid=70,gid=70,target=/build/promscale/.cargo/registry \
+    make package
 
 # Build extension
 COPY Cargo.* /build/promscale/


### PR DESCRIPTION
This is a common rust/cargo trick: create a new empty project with the
actual Cargo.{toml,lock} files and build it. This pre-builds all of the
dependencies, a lot of which can be reused in the following steps,
reducing the amount of code compiled when updating source files.

On my machine it reduces rebuild time from ~250s to 80s.