### PR TITLE
Wrap migration SQL in migration do-block, emit with pgx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/*.rpm
 dist/*.deb
 dist/*.tar
 /target
+hand-written-migration.sql

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "askama"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d8f355701c672c2ba3d718acbd213f740beea577cc4eae66accdffe15be1882"
+dependencies = [
+ "askama_derive",
+ "askama_escape",
+ "askama_shared",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84704cab5b7ae0fd3a9f78ee5eb7b27f3749df445f04623db6633459ae283267"
+dependencies = [
+ "askama_shared",
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a1bb320f97e6edf9f756bf015900038e43c7700e059688e5724a928c8f3b8d5"
+
+[[package]]
+name = "askama_shared"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae03eebba55a2697a376e58b573a29fe36893157173ac8df312ad85f3c0e012"
+dependencies = [
+ "askama_escape",
+ "humansize",
+ "nom",
+ "num-traits",
+ "percent-encoding",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "toml",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,6 +806,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
+name = "humansize"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "num_threads"
-version = "0.1.3"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+checksum = "71a1eb3a36534514077c1e079ada2fb170ef30c47d203aa6916138cf882ecd52"
 dependencies = [
  "libc",
 ]
@@ -1334,6 +1386,7 @@ dependencies = [
 name = "promscale"
 version = "0.3.1"
 dependencies = [
+ "askama",
  "bincode",
  "num_cpus",
  "pgx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ num_cpus = "1.13.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.70", optional = true }
 
+[build-dependencies]
+askama = "0.11.0"
+
 [dev-dependencies]
 pgx-tests = "0.3.1"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,10 +54,12 @@ RUN --mount=type=cache,uid=70,gid=70,target=/build/promscale/.cargo/registry \
 
 # Build extension
 COPY Cargo.* /build/promscale/
-COPY promscale.control Makefile /build/promscale/
+COPY promscale.control Makefile build.rs /build/promscale/
 COPY .cargo/ /build/promscale/.cargo/
 COPY src/ /build/promscale/src/
 COPY sql/*.sql /build/promscale/sql/
+COPY migration/ /build/promscale/migration
+COPY templates/ /build/promscale/templates/
 
 RUN --mount=type=cache,uid=70,gid=70,target=/build/promscale/.cargo/registry \
     make package

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,122 @@
+use crate::SqlType::{Idempotent, Migration};
+use askama::Template;
+use std::fs::File;
+use std::io::{Error, Read, Write};
+use std::path::{Path, PathBuf};
+use std::string::String;
+use std::{env, fs};
+
+#[derive(Template)]
+#[template(path = "migration-wrapper.sql", escape = "none")]
+struct MigrationWrapper<'a> {
+    filename: &'a str,
+    version: &'a str,
+    body: String,
+}
+
+#[derive(Template)]
+#[template(path = "idempotent-wrapper.sql", escape = "none")]
+struct IdempotentWrapper<'a> {
+    filename: &'a str,
+    body: String,
+}
+
+const MIGRATION_FILE_NAME: &str = "hand-written-migration.sql";
+
+/// This build script reads the SQL files placed in the `migration/{idempotent,migration}`
+/// directories, wraps each file in its respective template (in the `templates` directory), and
+/// outputs the whole contents as one long SQL file (`MIGRATION_FILE_NAME`) in the root directory.
+fn main() {
+    println!("cargo:rerun-if-changed=Cargo.lock");
+    // Note: directories are not traversed, instead Cargo looks at the mtime of the directory.
+    println!("cargo:rerun-if-changed=migration");
+    println!("cargo:rerun-if-changed=migration/migration");
+    println!("cargo:rerun-if-changed=migration/idempotent");
+    println!("cargo:rerun-if-changed=templates");
+
+    let mut sql = include_str!("migration/migration-table.sql").to_string();
+    let rendered_sql = render_sql().expect("unable to render migrations");
+    sql.push_str(rendered_sql.as_str());
+
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let mut out_path = PathBuf::from(manifest_dir);
+    out_path.push(MIGRATION_FILE_NAME);
+    let mut file = File::create(out_path).unwrap();
+    file.write_all(sql.as_bytes())
+        .expect("unable to write file contents");
+}
+
+fn render_sql() -> Result<String, Error> {
+    let mut migration_dir = env::current_dir()?;
+    migration_dir.push("migration");
+    let mut result = String::new();
+    for sql_type in &[Migration, Idempotent] {
+        let mut path = migration_dir.clone();
+        path.push(dir_for_type(sql_type));
+        result += render_file(path, sql_type)?.as_str();
+    }
+    Ok(result)
+}
+
+fn dir_for_type(sql_type: &SqlType) -> String {
+    match sql_type {
+        Migration => "migration".to_string(),
+        Idempotent => "idempotent".to_string(),
+    }
+}
+
+fn render_file(path: PathBuf, sql_type: &SqlType) -> Result<String, Error> {
+    let mut result = String::new();
+    let mut paths: Vec<PathBuf> = fs::read_dir(path)?.map(|f| f.unwrap().path()).collect();
+    paths.sort();
+    paths.into_iter().for_each(|path| {
+        result += wrap(&path, sql_type).as_str();
+    });
+    Ok(result)
+}
+
+#[derive(Copy, Clone, Debug)]
+enum SqlType {
+    Migration,
+    Idempotent,
+}
+
+fn wrap(path: &Path, sql_type: &SqlType) -> String {
+    let filename = path
+        .file_name()
+        .expect("invalid path")
+        .to_str()
+        .expect("unable to convert file path to str");
+    let version = env!("CARGO_PKG_VERSION");
+    let body = read_file(path);
+    match sql_type {
+        SqlType::Migration => wrap_migration_file(filename, version, body),
+        SqlType::Idempotent => wrap_idempotent_file(filename, version, body),
+    }
+}
+
+fn wrap_idempotent_file(filename: &str, _version: &str, body: String) -> String {
+    let idempotent_wrapper = IdempotentWrapper { filename, body };
+    idempotent_wrapper
+        .render()
+        .expect("unable to render template")
+}
+
+fn wrap_migration_file(filename: &str, version: &str, body: String) -> String {
+    let migration_wrapper = MigrationWrapper {
+        filename,
+        version,
+        body,
+    };
+    migration_wrapper
+        .render()
+        .expect("unable to render template")
+}
+
+fn read_file(path: &Path) -> String {
+    let mut contents = String::new();
+    let mut file = File::open(path).expect("unable to open file");
+    file.read_to_string(&mut contents)
+        .expect("unable to read file");
+    contents
+}

--- a/migration/migration-table.sql
+++ b/migration/migration-table.sql
@@ -1,0 +1,54 @@
+-- migration-table.sql
+DO
+$migration_table$
+    DECLARE
+        _current_user_id oid = NULL;
+        _ps_catalog_schema_owner_id oid = NULL;
+        _migration_table_owner_id text = NULL;
+    BEGIN
+        SELECT pg_user.usesysid
+        INTO STRICT _current_user_id
+        FROM pg_catalog.pg_user
+        WHERE pg_user.usename = current_user;
+
+        SELECT pg_namespace.nspowner
+        INTO _ps_catalog_schema_owner_id
+        FROM pg_catalog.pg_namespace
+        WHERE pg_namespace.nspname = '_ps_catalog';
+
+        IF _ps_catalog_schema_owner_id IS NOT NULL THEN
+            IF _ps_catalog_schema_owner_id != _current_user_id  THEN
+                -- We require that the superuser is the schema owner, otherwise
+                -- there is a privilege escalation path available. We also know
+                -- that the current user must be superuser, otherwise they
+                -- wouldn't be able to install the extension.
+                RAISE 'Only the owner of the "_ps_catalog" schema can install/upgrade this extension';
+                RETURN;
+            END IF;
+            RAISE LOG 'Schema "_ps_catalog" is already present, skipping creation';
+        ELSE
+            CREATE SCHEMA _ps_catalog;
+        END IF;
+
+        SELECT pg_class.relowner
+        INTO _migration_table_owner_id
+        FROM pg_catalog.pg_class
+          JOIN pg_catalog.pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+        WHERE pg_class.relname = 'migration' AND pg_namespace.nspname = '_ps_catalog';
+
+        IF _migration_table_owner_id IS NOT NULL THEN
+            IF _migration_table_owner_id != _current_user_id THEN
+                -- We require that the superuser owns this table, see above.
+                RAISE 'Only the owner of the "_ps_catalog.migration" table can install/upgrade this extension';
+                RETURN;
+            END IF;
+            RAISE LOG 'Table "_ps_catalog.migration" is already present, skipping creation';
+        ELSE
+            CREATE TABLE _ps_catalog.migration(
+                  name TEXT NOT NULL PRIMARY KEY
+                , applied_at_version TEXT
+                , applied_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp()
+            );
+        END IF;
+    END;
+$migration_table$;

--- a/migration/migration/012-tracing-well-known-tags.sql
+++ b/migration/migration/012-tracing-well-known-tags.sql
@@ -179,4 +179,4 @@ VALUES
     (173, 'exception.stacktrace', 15),
     (174, 'exception.escaped', 15)
 ;
-SELECT setval('_ps_trace.tag_key_id_seq', 1000);
+PERFORM setval('_ps_trace.tag_key_id_seq', 1000);

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -3,4 +3,5 @@
 
 mod estimates;
 mod setup;
+mod sql;
 mod support;

--- a/src/schema/sql.rs
+++ b/src/schema/sql.rs
@@ -1,0 +1,7 @@
+use pgx_macros::extension_sql_file;
+
+extension_sql_file!(
+    "../../hand-written-migration.sql",
+    name = "migration",
+    finalize
+);

--- a/templates/idempotent-wrapper.sql
+++ b/templates/idempotent-wrapper.sql
@@ -1,0 +1,9 @@
+
+-- {{filename}}
+DO
+$outer_idempotent_block$
+    BEGIN
+        {{body|indent(8)}}
+        RAISE LOG 'Applied idempotent {{filename}}';
+    END;
+$outer_idempotent_block$;

--- a/templates/migration-wrapper.sql
+++ b/templates/migration-wrapper.sql
@@ -1,0 +1,27 @@
+
+-- {{filename}}
+DO
+$outer_migration_block$
+    DECLARE
+        _already_applied bool = false;
+        _migration       _ps_catalog.migration = row ('{{filename}}', '{{version}}');
+    BEGIN
+        SELECT count(*) FILTER (WHERE name = _migration.name) > 0
+        INTO STRICT _already_applied
+        FROM _ps_catalog.migration;
+        IF _already_applied THEN
+            RAISE LOG 'Migration "{{filename}}" already applied, skipping';
+            RETURN;
+        END IF;
+
+        DO
+        $inner_migration_block$
+            BEGIN
+                {{body|indent(16)}}
+            END;
+        $inner_migration_block$;
+
+        INSERT INTO _ps_catalog.migration (name, applied_at_version) VALUES (_migration.name, _migration.applied_at_version);
+        RAISE LOG 'Applied migration {{filename}}';
+    END;
+$outer_migration_block$;


### PR DESCRIPTION
This change introduces a build script which wraps the contents of each
SQL file in the `migrations` directory in a DO block which conditionally
applies the migration if it has not yet been applied to the database.

The build script outputs its contents to `migration.sql`, which in turn
is included in the generated SQL which pgx outputs.