### PR TITLE
Add e2e test framework and port golden SQL tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@ dist/*.rpm
 dist/*.deb
 dist/*.tar
 target/
+*/target/
 *.md
 !CHANGELOG.md
 LICENSE

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -76,6 +76,16 @@ jobs:
           cache-from: type=gha,scope=${{matrix.base}}-${{matrix.pgversion}}-${{matrix.tsversion}}
           cache-to: type=gha,mode=max,scope=${{matrix.base}}-${{matrix.pgversion}}-${{matrix.tsversion}}
 
+      - name: Run end-to-end tests
+        uses: actions-rs/cargo@v1
+        # Note: we skip pg12 because the docker images don't work currently. See https://github.com/timescale/promscale_extension/issues/109.
+        if: ${{ matrix.pgversion != 12 }}
+        with:
+          command: test
+          args: -p e2e
+        env:
+          TS_DOCKER_IMAGE: ghcr.io/timescale/dev_promscale_extension:${{steps.metadata.outputs.branch_name}}-ts${{matrix.tsversion}}-pg${{matrix.pgversion}}${{steps.metadata.outputs.build_type_suffix}}
+
   # This allows us to set a single job which must pass in GitHub's branch protection rules,
   # otherwise we have to keep updating them as we add or remove postgres versions etc.
   docker-result:

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 dist/*.rpm
 dist/*.deb
 dist/*.tar
-/target
+target
 hand-written-migration.sql

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,8 +53,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84704cab5b7ae0fd3a9f78ee5eb7b27f3749df445f04623db6633459ae283267"
 dependencies = [
  "askama_shared",
- "proc-macro2",
- "syn",
+ "proc-macro2 1.0.36",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -74,10 +74,10 @@ dependencies = [
  "nom",
  "num-traits",
  "percent-encoding",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
  "serde",
- "syn",
+ "syn 1.0.86",
  "toml",
 ]
 
@@ -87,9 +87,9 @@ version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -190,13 +190,13 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "clap 2.34.0",
- "env_logger",
+ "env_logger 0.9.0",
  "lazy_static",
  "lazycell",
  "log",
  "peeking_take_while",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
  "regex",
  "rustc-hash",
  "shlex",
@@ -235,6 +235,15 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block-buffer"
@@ -338,9 +347,9 @@ checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -378,6 +387,20 @@ checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
 dependencies = [
  "atty",
  "lazy_static",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "console"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c0994e656bba7b922d8dd1245db90672ffb701e684e45be58f20719d69abc5a"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "terminal_size",
+ "termios",
  "winapi 0.3.9",
 ]
 
@@ -484,6 +507,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "cstr_core"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,12 +533,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.0",
  "crypto-common",
  "subtle",
 ]
@@ -531,6 +579,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "e2e"
+version = "0.1.0"
+dependencies = [
+ "build-deps",
+ "insta",
+ "postgres",
+ "pretty_env_logger",
+ "test-generator",
+ "testcontainers",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,14 +607,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
 name = "enum-primitive-derive"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c375b9c5eadb68d0a6efee2999fef292f45854c3444c86f09d8ab086ba942b0e"
 dependencies = [
  "num-traits",
- "quote",
- "syn",
+ "quote 1.0.15",
+ "syn 1.0.86",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime 1.3.0",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -564,7 +643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 2.1.0",
  "log",
  "regex",
  "termcolor",
@@ -693,9 +772,9 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -821,12 +900,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddca131f3e7f2ce2df364b57949a9d47915cfbd35e46cfee355ccebbf794d6a2"
 dependencies = [
- "digest",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -840,6 +935,15 @@ name = "humansize"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
+
+[[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error 1.2.3",
+]
 
 [[package]]
 name = "humantime"
@@ -872,6 +976,20 @@ checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "insta"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617e921abc813f96a3b00958c079e7bf1e2db998f8a04f1546dd967373a418ee"
+dependencies = [
+ "console",
+ "difference",
+ "lazy_static",
+ "serde",
+ "serde_json",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -918,6 +1036,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
 name = "lock_api"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,7 +1080,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6a38fc55c8bbc10058782919516f88826e70320db6d206aebc49611d24216ae"
 dependencies = [
- "digest",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -1107,6 +1231,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,7 +1325,7 @@ dependencies = [
  "pgx-macros",
  "pgx-pg-sys",
  "pgx-utils",
- "quote",
+ "quote 1.0.15",
  "seahash",
  "serde",
  "serde_cbor",
@@ -1213,9 +1343,9 @@ source = "git+https://github.com/timescale/pgx?branch=promscale-staging#ee52db6b
 dependencies = [
  "pgx-utils",
  "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
  "unescape",
 ]
 
@@ -1234,10 +1364,10 @@ dependencies = [
  "once_cell",
  "pgx-macros",
  "pgx-utils",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
  "rayon",
- "syn",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -1273,15 +1403,15 @@ dependencies = [
  "env_proxy",
  "eyre",
  "libloading",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
  "regex",
  "rttp_client",
  "serde",
  "serde-xml-rs",
  "serde_derive",
  "serde_json",
- "syn",
+ "syn 1.0.86",
  "toml",
  "tracing",
  "tracing-error",
@@ -1344,11 +1474,11 @@ dependencies = [
  "byteorder",
  "bytes",
  "fallible-iterator",
- "hmac",
+ "hmac 0.12.0",
  "md-5",
  "memchr",
  "rand 0.8.4",
- "sha2",
+ "sha2 0.10.2",
  "stringprep",
 ]
 
@@ -1370,6 +1500,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
+name = "pretty_env_logger"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
+dependencies = [
+ "env_logger 0.7.1",
+ "log",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1386,9 +1526,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
  "version_check",
 ]
 
@@ -1398,9 +1538,18 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+dependencies = [
+ "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -1409,7 +1558,7 @@ version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
- "unicode-xid",
+ "unicode-xid 0.2.2",
 ]
 
 [[package]]
@@ -1425,7 +1574,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.2",
 ]
 
 [[package]]
@@ -1462,11 +1611,20 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+dependencies = [
+ "proc-macro2 0.4.30",
+]
+
+[[package]]
+name = "quote"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
- "proc-macro2",
+ "proc-macro2 1.0.36",
 ]
 
 [[package]]
@@ -1806,9 +1964,9 @@ version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -1823,6 +1981,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
+dependencies = [
+ "indexmap",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1830,7 +2013,7 @@ checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -1939,13 +2122,24 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
+version = "0.15.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "unicode-xid 0.1.0",
+]
+
+[[package]]
+name = "syn"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "unicode-xid 0.2.2",
 ]
 
 [[package]]
@@ -1969,6 +2163,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "test-generator"
+version = "0.3.0"
+source = "git+https://github.com/JamesGuthrie/test-generator#82e799979980962aec1aa324ec6e0e4cad781f41"
+dependencies = [
+ "glob",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
+name = "testcontainers"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5e3ed6e3598dbf32cba8cb356b881c085e0adea57597f387723430dd94b4084"
+dependencies = [
+ "hex",
+ "hmac 0.10.1",
+ "log",
+ "rand 0.8.4",
+ "serde",
+ "serde_json",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -2001,9 +2240,9 @@ version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -2126,9 +2365,9 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -2227,6 +2466,12 @@ name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
@@ -2384,3 +2629,12 @@ name = "xml-rs"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["e2e"]
+
 [package]
 name = "promscale"
 version = "0.5.0"
@@ -44,3 +47,6 @@ pgx-tests = "0.3.1"
 pgx = { git = "https://github.com/timescale/pgx", branch = "promscale-staging" }
 pgx-macros = { git = "https://github.com/timescale/pgx", branch = "promscale-staging" }
 pgx-tests = { git = "https://github.com/timescale/pgx", branch = "promscale-staging" }
+
+# from e2e workspace
+test-generator = { git = "https://github.com/JamesGuthrie/test-generator" }

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -49,6 +49,7 @@ USER postgres
 # Pre-build extension dependencies
 RUN cd ../ && cargo pgx new promscale && cd promscale
 COPY Cargo.* Makefile /build/promscale/
+COPY e2e /build/promscale/e2e
 RUN --mount=type=cache,uid=70,gid=70,target=/build/promscale/.cargo/registry \
     make dependencies
 
@@ -56,6 +57,7 @@ RUN --mount=type=cache,uid=70,gid=70,target=/build/promscale/.cargo/registry \
 COPY Cargo.* /build/promscale/
 COPY promscale.control Makefile build.rs create-upgrade-symlinks.sh /build/promscale/
 COPY .cargo/ /build/promscale/.cargo/
+COPY e2e/ /build/promscale/e2e/
 COPY src/ /build/promscale/src/
 COPY sql/*.sql /build/promscale/sql/
 COPY migration/ /build/promscale/migration

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "e2e"
+version = "0.1.0"
+edition = "2021"
+
+[dev-dependencies]
+insta = "0.16.1"
+postgres = "0.19.2"
+pretty_env_logger = "0.4"
+testcontainers = "0.12.0"
+test-generator = "0.3.0"
+
+[build-dependencies]
+build-deps = "^0.1"
+

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,32 @@
+# End-to-end testing
+
+This directory contains end-to-end tests for the promscale extension. Tests can be written in Rust,
+or in pure SQL and run as snapshot tests. As the tests run in a Docker container, the `docker` command must be present on the local system.
+
+## Running tests
+
+Run the tests with `cargo test -p e2e`. The tests are run against a docker image. Set the value of
+the `TS_DOCKER_IMAGE` env var to override the default docker image, e.g.:
+
+```
+TS_DOCKER_IMAGE=ghcr.io/timescale/dev_promscale_extension:develop-ts2-pg13 cargo test -p e2e
+```
+
+## Rust tests
+
+Tests of arbitrary complexity can be written in Rust. There is no default setup or teardown, but
+tests  can use Docker to start and stop containers. There is not much infrastructure or convention
+here yet.
+
+## SQL Snapshot tests
+
+Each `.sql` file in the `testdata` directory is executed as its own test, against a fresh database.
+The output of the script is recorded as a snapshot, and compared on the next test run.
+
+To add a new test:
+0. (prerequisite) run `cargo install cargo-insta`
+1. create a new `.sql` file in the `testdata` directory
+2. run the golden tests with `cargo test --test golden-tests`
+3. the tests will fail
+4. validate that the new snapshot output is as you expect it to be
+5. run `cargo insta review` to interactively review the snapshot outputs (or `cargo insta accept` to accept them all) 

--- a/e2e/build.rs
+++ b/e2e/build.rs
@@ -1,0 +1,6 @@
+extern crate build_deps;
+
+fn main() {
+    build_deps::rerun_if_changed_paths("testdata/*.sql").unwrap();
+    build_deps::rerun_if_changed_paths("testdata").unwrap();
+}

--- a/e2e/testdata/info_view.sql
+++ b/e2e/testdata/info_view.sql
@@ -1,0 +1,35 @@
+\set ECHO all
+\set ON_ERROR_STOP 1
+
+CREATE EXTENSION promscale;
+
+SELECT _prom_catalog.get_or_create_metric_table_name('cpu_usage');
+SELECT _prom_catalog.get_or_create_metric_table_name('cpu_total');
+CALL _prom_catalog.finalize_metric_creation();
+INSERT INTO prom_data.cpu_usage
+SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.1 + g, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_usage", "namespace":"dev", "node": "brain"}')
+FROM generate_series(1,10) g;
+INSERT INTO prom_data.cpu_usage
+SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.1 + g, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_usage", "namespace":"production", "node": "pinky", "new_tag":"foo"}')
+FROM generate_series(1,10) g;
+INSERT INTO prom_data.cpu_total
+SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.0, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_total", "namespace":"dev", "node": "brain"}')
+FROM generate_series(1,10) g;
+INSERT INTO prom_data.cpu_total
+SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.0, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_total", "namespace":"production", "node": "pinky", "new_tag_2":"bar"}')
+FROM generate_series(1,10) g;
+
+SELECT id , metric_name , table_name, retention_period, chunk_interval > interval '7 hour', compressed_interval > interval '7 hour', before_compression_bytes, after_compression_bytes, label_keys, total_size, total_size_bytes, compression_ratio, total_chunks, compressed_chunks FROM prom_info.metric ORDER BY id;
+-- compress chunks
+SELECT public.compress_chunk(public.show_chunks('prom_data.cpu_usage'));
+SELECT public.compress_chunk(public.show_chunks('prom_data.cpu_total'));
+-- fetch stats with compressed chunks
+
+SET ROLE prom_reader;
+SELECT id , metric_name , table_name, retention_period, chunk_interval > interval '7 hour', compressed_interval > interval '7 hour', before_compression_bytes, after_compression_bytes, label_keys, total_size, total_size_bytes, compression_ratio, total_chunks, compressed_chunks FROM prom_info.metric ORDER BY id;
+SELECT * FROM prom_info.label ORDER BY key;
+SELECT * FROM prom_info.metric_stats ORDER BY num_series_approx;
+SELECT * FROM prom_info.system_stats;
+SELECT prom_api.label_cardinality(1);
+SELECT prom_api.label_cardinality(2);
+SELECT prom_api.label_cardinality(1) + prom_api.label_cardinality(2);

--- a/e2e/testdata/support.sql
+++ b/e2e/testdata/support.sql
@@ -1,0 +1,25 @@
+\set ECHO all
+\set ON_ERROR_STOP 1
+
+CREATE EXTENSION promscale;
+
+SELECT _prom_catalog.get_or_create_metric_table_name('cpu_usage');
+SELECT _prom_catalog.get_or_create_metric_table_name('cpu_total');
+CALL _prom_catalog.finalize_metric_creation();
+INSERT INTO prom_data.cpu_usage
+SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.1 + g, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_usage", "namespace":"dev", "node": "brain"}')
+FROM generate_series(1,10) g;
+INSERT INTO prom_data.cpu_usage
+SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.1 + g, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_usage", "namespace":"production", "node": "pinky", "new_tag":"foo"}')
+FROM generate_series(1,10) g;
+INSERT INTO prom_data.cpu_total
+SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.0, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_total", "namespace":"dev", "node": "brain"}')
+FROM generate_series(1,10) g;
+INSERT INTO prom_data.cpu_total
+SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.0, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_total", "namespace":"production", "node": "pinky", "new_tag_2":"bar"}')
+FROM generate_series(1,10) g;
+
+--this should use a subquery with the Promscale extension but not without
+--this is thanks to the support function make_call_subquery_support
+ANALYZE;
+EXPLAIN (costs off) SELECT time, value, jsonb(labels), val(namespace_id) FROM cpu_usage WHERE labels ? ('namespace' !== 'dev' ) ORDER BY time, series_id LIMIT 5;

--- a/e2e/testdata/views.sql
+++ b/e2e/testdata/views.sql
@@ -1,0 +1,31 @@
+\set ECHO all
+\set ON_ERROR_STOP 1
+
+CREATE EXTENSION promscale;
+
+SELECT _prom_catalog.get_or_create_metric_table_name('cpu_usage');
+SELECT _prom_catalog.get_or_create_metric_table_name('cpu_total');
+CALL _prom_catalog.finalize_metric_creation();
+INSERT INTO prom_data.cpu_usage
+  SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.1 + g, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_usage", "namespace":"dev", "node": "brain"}')
+  FROM generate_series(1,10) g;
+INSERT INTO prom_data.cpu_usage
+  SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.1 + g, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_usage", "namespace":"production", "node": "pinky", "new_tag":"foo"}')
+  FROM generate_series(1,10) g;
+INSERT INTO prom_data.cpu_total
+  SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.0, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_total", "namespace":"dev", "node": "brain"}')
+  FROM generate_series(1,10) g;
+INSERT INTO prom_data.cpu_total
+  SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.0, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_total", "namespace":"production", "node": "pinky", "new_tag_2":"bar"}')
+  FROM generate_series(1,10) g;
+
+SELECT * FROM prom_info.label ORDER BY key;
+
+\set ON_ERROR_STOP 0
+SELECT count(public.compress_chunk(i)) from public.show_chunks('prom_data.cpu_usage') i;
+\set ON_ERROR_STOP 0
+
+SET role prom_reader;
+SELECT * FROM cpu_usage ORDER BY time, series_id LIMIT 5;
+SELECT time, value, jsonb(labels), val(namespace_id) FROM cpu_usage ORDER BY time, series_id LIMIT 5;
+SELECT * FROM prom_series.cpu_usage ORDER BY series_id;

--- a/e2e/tests/common/mod.rs
+++ b/e2e/tests/common/mod.rs
@@ -1,0 +1,66 @@
+use postgres::Client;
+use std::env;
+use std::process::{Command, Stdio};
+use std::str::from_utf8;
+use testcontainers::clients::Cli;
+use testcontainers::images::generic::{GenericImage, WaitFor};
+use testcontainers::{images, Container, Docker};
+
+pub const DB: &str = "postgres-db-test";
+pub const USER: &str = "postgres-user-test";
+pub const PASSWORD: &str = "postgres-password-test";
+
+pub fn run_postgres(client: &Cli) -> Container<Cli, GenericImage> {
+    let docker_image = env::var("TS_DOCKER_IMAGE").unwrap_or(String::from(
+        "ghcr.io/timescale/dev_promscale_extension:develop-ts2-pg14",
+    ));
+
+    let src = concat!(env!("CARGO_MANIFEST_DIR"), "/testdata");
+    let dest = "/testdata";
+
+    let generic_postgres = images::generic::GenericImage::new(docker_image)
+        .with_wait_for(WaitFor::message_on_stderr(
+            "database system is ready to accept connections",
+        ))
+        .with_env_var("POSTGRES_DB", DB)
+        .with_env_var("POSTGRES_USER", USER)
+        .with_env_var("POSTGRES_PASSWORD", PASSWORD)
+        .with_volume(src, dest);
+
+    client.run(generic_postgres)
+}
+
+#[allow(dead_code)]
+pub fn connect(node: &Container<Cli, GenericImage>) -> Client {
+    let connection_string = &format!(
+        "postgres://{}:{}@localhost:{}/{}",
+        USER,
+        PASSWORD,
+        node.get_host_port(5432).unwrap(),
+        DB
+    );
+
+    postgres::Client::connect(connection_string, postgres::NoTls).unwrap()
+}
+
+#[allow(dead_code)]
+pub fn exec_sql_script(node: &Container<Cli, GenericImage>, script_path: &str) -> String {
+    let id = node.id();
+    let abs_script_path = "/".to_owned() + script_path;
+    let output = Command::new("docker")
+        .arg("exec")
+        .arg(id)
+        .arg("psql")
+        .arg("-U")
+        .arg(USER)
+        .arg("-d")
+        .arg(DB)
+        .arg("-f")
+        .arg(&abs_script_path)
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap()
+        .wait_with_output()
+        .unwrap();
+    from_utf8(&output.stdout).unwrap().to_string()
+}

--- a/e2e/tests/golden-tests.rs
+++ b/e2e/tests/golden-tests.rs
@@ -1,0 +1,16 @@
+use crate::common::{exec_sql_script, run_postgres};
+use insta::assert_snapshot;
+use std::env;
+use test_generator::test_resources;
+use testcontainers::clients;
+
+mod common;
+
+#[test_resources("testdata/*.sql")]
+fn golden_test(resource: &str) {
+    let docker = clients::Cli::default();
+    let node = run_postgres(&docker);
+    let query_result = exec_sql_script(&node, resource);
+
+    assert_snapshot!(query_result);
+}

--- a/e2e/tests/snapshots/golden_tests__golden_test_testdata_info_view_sql.snap
+++ b/e2e/tests/snapshots/golden_tests__golden_test_testdata_info_view_sql.snap
@@ -1,0 +1,109 @@
+---
+source: e2e/tests/golden-tests.rs
+expression: query_result
+---
+\set ON_ERROR_STOP 1
+CREATE EXTENSION promscale;
+CREATE EXTENSION
+SELECT _prom_catalog.get_or_create_metric_table_name('cpu_usage');
+ get_or_create_metric_table_name 
+---------------------------------
+ (1,cpu_usage,t)
+(1 row)
+
+SELECT _prom_catalog.get_or_create_metric_table_name('cpu_total');
+ get_or_create_metric_table_name 
+---------------------------------
+ (2,cpu_total,t)
+(1 row)
+
+CALL _prom_catalog.finalize_metric_creation();
+CALL
+INSERT INTO prom_data.cpu_usage
+SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.1 + g, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_usage", "namespace":"dev", "node": "brain"}')
+FROM generate_series(1,10) g;
+INSERT 0 10
+INSERT INTO prom_data.cpu_usage
+SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.1 + g, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_usage", "namespace":"production", "node": "pinky", "new_tag":"foo"}')
+FROM generate_series(1,10) g;
+INSERT 0 10
+INSERT INTO prom_data.cpu_total
+SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.0, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_total", "namespace":"dev", "node": "brain"}')
+FROM generate_series(1,10) g;
+INSERT 0 10
+INSERT INTO prom_data.cpu_total
+SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.0, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_total", "namespace":"production", "node": "pinky", "new_tag_2":"bar"}')
+FROM generate_series(1,10) g;
+INSERT 0 10
+SELECT id , metric_name , table_name, retention_period, chunk_interval > interval '7 hour', compressed_interval > interval '7 hour', before_compression_bytes, after_compression_bytes, label_keys, total_size, total_size_bytes, compression_ratio, total_chunks, compressed_chunks FROM prom_info.metric ORDER BY id;
+ id | metric_name | table_name | retention_period | ?column? | ?column? | before_compression_bytes | after_compression_bytes |             label_keys              | total_size | total_size_bytes | compression_ratio | total_chunks | compressed_chunks 
+----+-------------+------------+------------------+----------+----------+--------------------------+-------------------------+-------------------------------------+------------+------------------+-------------------+--------------+-------------------
+  1 | cpu_usage   | cpu_usage  | 90 days          | t        | f        |                          |                         | {__name__,namespace,new_tag,node}   | 32 kB      |            32768 |                   |            1 |                 0
+  2 | cpu_total   | cpu_total  | 90 days          | t        | f        |                          |                         | {__name__,namespace,new_tag_2,node} | 32 kB      |            32768 |                   |            1 |                 0
+(2 rows)
+
+-- compress chunks
+SELECT public.compress_chunk(public.show_chunks('prom_data.cpu_usage'));
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_10_1_chunk
+(1 row)
+
+SELECT public.compress_chunk(public.show_chunks('prom_data.cpu_total'));
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_12_2_chunk
+(1 row)
+
+-- fetch stats with compressed chunks
+SET ROLE prom_reader;
+SET
+SELECT id , metric_name , table_name, retention_period, chunk_interval > interval '7 hour', compressed_interval > interval '7 hour', before_compression_bytes, after_compression_bytes, label_keys, total_size, total_size_bytes, compression_ratio, total_chunks, compressed_chunks FROM prom_info.metric ORDER BY id;
+ id | metric_name | table_name | retention_period | ?column? | ?column? | before_compression_bytes | after_compression_bytes |             label_keys              | total_size | total_size_bytes |  compression_ratio   | total_chunks | compressed_chunks 
+----+-------------+------------+------------------+----------+----------+--------------------------+-------------------------+-------------------------------------+------------+------------------+----------------------+--------------+-------------------
+  1 | cpu_usage   | cpu_usage  | 90 days          | t        | t        |                    24576 |                   32768 | {__name__,namespace,new_tag,node}   | 48 kB      |            49152 | -33.3333333333333300 |            1 |                 1
+  2 | cpu_total   | cpu_total  | 90 days          | t        | t        |                    24576 |                   32768 | {__name__,namespace,new_tag_2,node} | 48 kB      |            49152 | -33.3333333333333300 |            1 |                 1
+(2 rows)
+
+SELECT * FROM prom_info.label ORDER BY key;
+    key    | value_column_name | id_column_name |        values         | num_values 
+-----------+-------------------+----------------+-----------------------+------------
+ __name__  | __name__          | __name___id    | {cpu_total,cpu_usage} |          2
+ namespace | namespace         | namespace_id   | {dev,production}      |          2
+ new_tag   | new_tag           | new_tag_id     | {foo}                 |          1
+ new_tag_2 | new_tag_2         | new_tag_2_id   | {bar}                 |          1
+ node      | node              | node_id        | {brain,pinky}         |          2
+(5 rows)
+
+SELECT * FROM prom_info.metric_stats ORDER BY num_series_approx;
+ metric_name | num_series_approx | num_samples_approx 
+-------------+-------------------+--------------------
+ cpu_total   |                 0 |                 20
+ cpu_usage   |                 0 |                 20
+(2 rows)
+
+SELECT * FROM prom_info.system_stats;
+ num_series_approx | num_metric | num_label_keys | num_labels 
+-------------------+------------+----------------+------------
+                 0 |          2 |              5 |          8
+(1 row)
+
+SELECT prom_api.label_cardinality(1);
+ label_cardinality 
+-------------------
+                 2
+(1 row)
+
+SELECT prom_api.label_cardinality(2);
+ label_cardinality 
+-------------------
+                 2
+(1 row)
+
+SELECT prom_api.label_cardinality(1) + prom_api.label_cardinality(2);
+ ?column? 
+----------
+        4
+(1 row)
+
+

--- a/e2e/tests/snapshots/golden_tests__golden_test_testdata_support_sql.snap
+++ b/e2e/tests/snapshots/golden_tests__golden_test_testdata_support_sql.snap
@@ -1,0 +1,59 @@
+---
+source: e2e/tests/golden-tests.rs
+expression: query_result
+---
+\set ON_ERROR_STOP 1
+CREATE EXTENSION promscale;
+CREATE EXTENSION
+SELECT _prom_catalog.get_or_create_metric_table_name('cpu_usage');
+ get_or_create_metric_table_name 
+---------------------------------
+ (1,cpu_usage,t)
+(1 row)
+
+SELECT _prom_catalog.get_or_create_metric_table_name('cpu_total');
+ get_or_create_metric_table_name 
+---------------------------------
+ (2,cpu_total,t)
+(1 row)
+
+CALL _prom_catalog.finalize_metric_creation();
+CALL
+INSERT INTO prom_data.cpu_usage
+SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.1 + g, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_usage", "namespace":"dev", "node": "brain"}')
+FROM generate_series(1,10) g;
+INSERT 0 10
+INSERT INTO prom_data.cpu_usage
+SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.1 + g, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_usage", "namespace":"production", "node": "pinky", "new_tag":"foo"}')
+FROM generate_series(1,10) g;
+INSERT 0 10
+INSERT INTO prom_data.cpu_total
+SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.0, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_total", "namespace":"dev", "node": "brain"}')
+FROM generate_series(1,10) g;
+INSERT 0 10
+INSERT INTO prom_data.cpu_total
+SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.0, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_total", "namespace":"production", "node": "pinky", "new_tag_2":"bar"}')
+FROM generate_series(1,10) g;
+INSERT 0 10
+--this should use a subquery with the Promscale extension but not without
+--this is thanks to the support function make_call_subquery_support
+ANALYZE;
+ANALYZE
+EXPLAIN (costs off) SELECT time, value, jsonb(labels), val(namespace_id) FROM cpu_usage WHERE labels ? ('namespace' !== 'dev' ) ORDER BY time, series_id LIMIT 5;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Limit
+   InitPlan 1 (returns $0)
+     ->  Result
+   ->  Result
+         ->  Sort
+               Sort Key: data."time", data.series_id
+               ->  Hash Join
+                     Hash Cond: (data.series_id = series.id)
+                     ->  Seq Scan on _hyper_10_1_chunk data
+                     ->  Hash
+                           ->  Seq Scan on cpu_usage series
+                                 Filter: (NOT ((labels)::integer[] && ($0)::integer[]))
+(12 rows)
+
+

--- a/e2e/tests/snapshots/golden_tests__golden_test_testdata_views_sql.snap
+++ b/e2e/tests/snapshots/golden_tests__golden_test_testdata_views_sql.snap
@@ -1,0 +1,85 @@
+---
+source: e2e/tests/golden-tests.rs
+expression: query_result
+---
+\set ON_ERROR_STOP 1
+CREATE EXTENSION promscale;
+CREATE EXTENSION
+SELECT _prom_catalog.get_or_create_metric_table_name('cpu_usage');
+ get_or_create_metric_table_name 
+---------------------------------
+ (1,cpu_usage,t)
+(1 row)
+
+SELECT _prom_catalog.get_or_create_metric_table_name('cpu_total');
+ get_or_create_metric_table_name 
+---------------------------------
+ (2,cpu_total,t)
+(1 row)
+
+CALL _prom_catalog.finalize_metric_creation();
+CALL
+INSERT INTO prom_data.cpu_usage
+  SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.1 + g, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_usage", "namespace":"dev", "node": "brain"}')
+  FROM generate_series(1,10) g;
+INSERT 0 10
+INSERT INTO prom_data.cpu_usage
+  SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.1 + g, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_usage", "namespace":"production", "node": "pinky", "new_tag":"foo"}')
+  FROM generate_series(1,10) g;
+INSERT 0 10
+INSERT INTO prom_data.cpu_total
+  SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.0, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_total", "namespace":"dev", "node": "brain"}')
+  FROM generate_series(1,10) g;
+INSERT 0 10
+INSERT INTO prom_data.cpu_total
+  SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.0, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_total", "namespace":"production", "node": "pinky", "new_tag_2":"bar"}')
+  FROM generate_series(1,10) g;
+INSERT 0 10
+SELECT * FROM prom_info.label ORDER BY key;
+    key    | value_column_name | id_column_name |        values         | num_values 
+-----------+-------------------+----------------+-----------------------+------------
+ __name__  | __name__          | __name___id    | {cpu_total,cpu_usage} |          2
+ namespace | namespace         | namespace_id   | {dev,production}      |          2
+ new_tag   | new_tag           | new_tag_id     | {foo}                 |          1
+ new_tag_2 | new_tag_2         | new_tag_2_id   | {bar}                 |          1
+ node      | node              | node_id        | {brain,pinky}         |          2
+(5 rows)
+
+\set ON_ERROR_STOP 0
+SELECT count(public.compress_chunk(i)) from public.show_chunks('prom_data.cpu_usage') i;
+ count 
+-------
+     1
+(1 row)
+
+\set ON_ERROR_STOP 0
+SET role prom_reader;
+SET
+SELECT * FROM cpu_usage ORDER BY time, series_id LIMIT 5;
+          time          | value | series_id |  labels   | node_id | namespace_id | new_tag_id 
+------------------------+-------+-----------+-----------+---------+--------------+------------
+ 2000-01-01 02:03:05+00 | 101.1 |         1 | {1,3,4}   |       3 |            4 |           
+ 2000-01-01 02:03:05+00 | 101.1 |         2 | {1,5,7,6} |       5 |            7 |          6
+ 2000-01-01 02:03:06+00 | 102.1 |         1 | {1,3,4}   |       3 |            4 |           
+ 2000-01-01 02:03:06+00 | 102.1 |         2 | {1,5,7,6} |       5 |            7 |          6
+ 2000-01-01 02:03:07+00 | 103.1 |         1 | {1,3,4}   |       3 |            4 |           
+(5 rows)
+
+SELECT time, value, jsonb(labels), val(namespace_id) FROM cpu_usage ORDER BY time, series_id LIMIT 5;
+          time          | value |                                          jsonb                                          |    val     
+------------------------+-------+-----------------------------------------------------------------------------------------+------------
+ 2000-01-01 02:03:05+00 | 101.1 | {"node": "brain", "__name__": "cpu_usage", "namespace": "dev"}                          | dev
+ 2000-01-01 02:03:05+00 | 101.1 | {"node": "pinky", "new_tag": "foo", "__name__": "cpu_usage", "namespace": "production"} | production
+ 2000-01-01 02:03:06+00 | 102.1 | {"node": "brain", "__name__": "cpu_usage", "namespace": "dev"}                          | dev
+ 2000-01-01 02:03:06+00 | 102.1 | {"node": "pinky", "new_tag": "foo", "__name__": "cpu_usage", "namespace": "production"} | production
+ 2000-01-01 02:03:07+00 | 103.1 | {"node": "brain", "__name__": "cpu_usage", "namespace": "dev"}                          | dev
+(5 rows)
+
+SELECT * FROM prom_series.cpu_usage ORDER BY series_id;
+ series_id |  labels   | node  | namespace  | new_tag 
+-----------+-----------+-------+------------+---------
+         1 | {1,3,4}   | brain | dev        | 
+         2 | {1,5,7,6} | pinky | production | foo
+(2 rows)
+
+

--- a/e2e/tests/test.rs
+++ b/e2e/tests/test.rs
@@ -1,0 +1,17 @@
+use crate::common::run_postgres;
+use testcontainers::clients;
+
+mod common;
+
+#[test]
+fn create_promscale_extension() {
+    let _ = pretty_env_logger::try_init();
+
+    let docker = clients::Cli::default();
+    let node = run_postgres(&docker);
+
+    let mut client = common::connect(&node);
+    let result = client.simple_query("CREATE EXTENSION promscale;").unwrap();
+
+    assert_eq!(result.len(), 1);
+}

--- a/ha.Dockerfile
+++ b/ha.Dockerfile
@@ -46,6 +46,7 @@ USER postgres
 COPY --chown=postgres:postgres Cargo.* /build/promscale/
 COPY --chown=postgres:postgres promscale.control Makefile build.rs create-upgrade-symlinks.sh /build/promscale/
 COPY --chown=postgres:postgres .cargo/ /build/promscale/.cargo/
+COPY --chown=postgres:postgres e2e/ /build/promscale/e2e/
 COPY --chown=postgres:postgres src/ /build/promscale/src/
 COPY --chown=postgres:postgres sql/*.sql /build/promscale/sql/
 COPY --chown=postgres:postgres migration/ /build/promscale/migration


### PR DESCRIPTION
This change adds a dedicated e2e workspace which can be used to run
end-to-end tests against the promscale extension.

This change also also ports the golden SQL tests from the promscale
repository.