### PR TITLE
Remove timescaledb 1.x docker image build

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,7 +17,6 @@ jobs:
         - docker-image-ts2-14
         - docker-image-ts2-13
         - docker-image-ts2-12
-        - docker-image-ts1
     steps:
       - uses: actions/checkout@v2
 

--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,8 @@ release-test: release-tester ## Test the currently selected release package
 	fi; \
 	docker rm -f "$(TESTER_NAME)"
 
-.PHONY: docker-image-build-1 docker-image-build-2-12 docker-image-build-2-13 docker-image-build-2-14
-docker-image-build-1 docker-image-build-2-12 docker-image-build-2-13 docker-image-build-2-14: Dockerfile $(SQL_FILES) $(SRCS) Cargo.toml Cargo.lock $(RUST_SRCS)
+.PHONY: docker-image-build-2-12 docker-image-build-2-13 docker-image-build-2-14
+docker-image-build-2-12 docker-image-build-2-13 docker-image-build-2-14: Dockerfile $(SQL_FILES) $(SRCS) Cargo.toml Cargo.lock $(RUST_SRCS)
 	docker buildx build $(if $(PUSH),--push,--load) \
 		--build-arg TIMESCALEDB_VERSION=$(TIMESCALEDB_VER) \
 		--build-arg PG_VERSION_TAG=$(PG_VER) \
@@ -128,12 +128,6 @@ docker-image-build-1 docker-image-build-2-12 docker-image-build-2-13 docker-imag
 		-t $(IMAGE_NAME):$(EXT_VERSION)-ts$(TIMESCALEDB_MAJOR)-$(PG_VER) \
 		-t $(IMAGE_NAME):latest-ts$(TIMESCALEDB_MAJOR)-$(PG_VER) \
 		.
-
-.PHONY: docker-image-ts1
-docker-image-ts1: PG_VER=pg12
-docker-image-ts1: TIMESCALEDB_MAJOR=1
-docker-image-ts1: TIMESCALEDB_VER=1.7.5
-docker-image-ts1: docker-image-build-1
 
 .PHONY: docker-image-ts2-12
 docker-image-ts2-12: PG_VER=pg12
@@ -154,7 +148,7 @@ docker-image-ts2-14: TIMESCALEDB_VER=2.5.2
 docker-image-ts2-14: docker-image-build-2-14
 
 .PHONY: docker-image
-docker-image: docker-image-ts2-14 docker-image-ts2-13 docker-image-ts2-12 docker-image-ts1 ## Build Timescale images with the extension
+docker-image: docker-image-ts2-14 docker-image-ts2-13 docker-image-ts2-12 ## Build Timescale images with the extension
 
 .PHONY: setup-buildx
 setup-buildx: ## Setup a Buildx builder


### PR DESCRIPTION
This is in line with recent changes in the promscale repo: https://github.com/timescale/promscale/pull/1199