### PR TITLE
Mark extension as trusted

### DIFF
--- a/promscale.control
+++ b/promscale.control
@@ -5,6 +5,7 @@ module_pathname = '$libdir/promscale'
 relocatable = false
 schema = _prom_ext
 superuser = true
+trusted = true
 # comma-separated list of previous versions this version can be upgraded from
 # directly. This is used to generate upgrade scripts.
 # upgradeable_from = '0.3.0'


### PR DESCRIPTION
Having the extension marked as trusted allows it to be installed by
non-superuser users.