### PR TITLE
Provide docker-quick-ts2-{12,13,14} target for quick iteration on SQL

### DIFF
--- a/Dockerfile.quick
+++ b/Dockerfile.quick
@@ -1,0 +1,10 @@
+# This dockerfile is a helper for quick iteration on the extension SQL
+# To use, first run: `make docker-image-ts2-14`, then edit SQL and run `make docker-quick-ts2-14`
+ARG PG_VERSION_TAG
+ARG TIMESCALEDB_VERSION
+ARG EXTENSION_VERSION
+FROM timescaledev/promscale-extension:${EXTENSION_VERSION}-${TIMESCALEDB_VERSION}-${PG_VERSION_TAG}
+
+ARG EXTENSION_VERSION
+COPY sql/promscale-${EXTENSION_VERSION}.sql /usr/local/share/postgresql/extension/promscale--${EXTENSION_VERSION}.sql
+

--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,36 @@ docker-image-ts2-14: docker-image-build-2-14
 .PHONY: docker-image
 docker-image: docker-image-ts2-14 docker-image-ts2-13 docker-image-ts2-12 ## Build Timescale images with the extension
 
+.PHONY: docker-quick-build-2-12 docker-quick-build-2-13 docker-quick-build-2-14
+docker-quick-build-2-12 docker-quick-build-2-13 docker-quick-build-2-14: ## A quick way to rebuild the extension image with only SQL changes
+	cargo pgx schema $(PG_VER)
+	docker build -f Dockerfile.quick \
+		--build-arg TIMESCALEDB_VERSION=$(TIMESCALEDB_VER) \
+		--build-arg PG_VERSION_TAG=$(PG_VER) \
+		--build-arg EXTENSION_VERSION=$(EXT_VERSION) \
+		-t $(IMAGE_NAME):$(EXT_VERSION)-$(TIMESCALEDB_VER)-$(PG_VER) \
+		-t $(IMAGE_NAME):$(EXT_VERSION)-ts$(TIMESCALEDB_MAJOR)-$(PG_VER) \
+		-t $(IMAGE_NAME):latest-ts$(TIMESCALEDB_MAJOR)-$(PG_VER) \
+		.
+
+.PHONY: docker-quick-ts2-14
+docker-quick-ts2-14: PG_VER=pg14
+docker-quick-ts2-14: TIMESCALEDB_MAJOR=2
+docker-quick-ts2-14: TIMESCALEDB_VER=2.5.2
+docker-quick-ts2-14: docker-quick-build-2-14
+
+.PHONY: docker-quick-ts2-13
+docker-quick-ts2-13: PG_VER=pg13
+docker-quick-ts2-13: TIMESCALEDB_MAJOR=2
+docker-quick-ts2-13: TIMESCALEDB_VER=2.5.2
+docker-quick-ts2-13: docker-quick-build-2-13
+
+.PHONY: docker-quick-ts2-12
+docker-quick-ts2-12: PG_VER=pg12
+docker-quick-ts2-12: TIMESCALEDB_MAJOR=2
+docker-quick-ts2-12: TIMESCALEDB_VER=2.5.2
+docker-quick-ts2-12: docker-quick-build-2-12
+
 .PHONY: setup-buildx
 setup-buildx: ## Setup a Buildx builder
 	@if ! docker buildx ls | grep buildx-builder >/dev/null; then \


### PR DESCRIPTION
To use, first run: `make docker-image-ts2-14`. Then you can edit the SQL
and run `make docker-quick-ts2-14`.