### PR TITLE
Fix incorrect GRANT EXECUTE

### DIFF
--- a/migration/idempotent/007-tracing-tags.sql
+++ b/migration/idempotent/007-tracing-tags.sql
@@ -445,7 +445,7 @@ AS $func$
     ) a on (true)
 $func$
 LANGUAGE SQL STABLE PARALLEL SAFE STRICT;
-GRANT EXECUTE ON FUNCTION ps_trace.jsonb(ps_trace.tag_map) TO prom_reader;
+GRANT EXECUTE ON FUNCTION ps_trace.jsonb(ps_trace.tag_map, ps_trace.tag_k[]) TO prom_reader;
 
 -------------------------------------------------------------------------------
 -- val


### PR DESCRIPTION
The signature of the GRANT EXECUTE doesn't match up with the function
definition.