### PR TITLE
Fully-qualify objects in hand-written SQL

### DIFF
--- a/migration/idempotent/001-base.sql
+++ b/migration/idempotent/001-base.sql
@@ -658,7 +658,7 @@ AS
 $$
 BEGIN
     IF _prom_catalog.get_timescale_major_version() >= 2 THEN
-        RETURN (SELECT * FROM approximate_row_count(table_name_input));
+        RETURN (SELECT * FROM public.approximate_row_count(table_name_input));
     ELSE
         IF _prom_catalog.is_timescaledb_installed()
             AND (SELECT count(*) > 0
@@ -869,7 +869,7 @@ RETURNS prom_api.label_array AS $$
               _prom_catalog.get_or_create_label_key_pos(js->>'__name__', e.key)) idx,
             coalesce(l.id,
               _prom_catalog.get_or_create_label_id(e.key, e.value)) val
-        FROM label_jsonb_each_text(js) e
+        FROM _prom_catalog.label_jsonb_each_text(js) e
              LEFT JOIN _prom_catalog.label l
                ON (l.key = e.key AND l.value = e.value)
             LEFT JOIN _prom_catalog.label_key_position lkp

--- a/migration/idempotent/003-matcher-functions.sql
+++ b/migration/idempotent/003-matcher-functions.sql
@@ -3,7 +3,7 @@ RETURNS prom_api.matcher_positive
 AS $func$
     SELECT ARRAY(
            SELECT coalesce(l.id, -1) -- -1 indicates no such label
-           FROM label_jsonb_each_text(labels-'__name__') e
+           FROM _prom_catalog.label_jsonb_each_text(labels-'__name__') e
            LEFT JOIN _prom_catalog.label l
                ON (l.key = e.key AND l.value = e.value)
         )::prom_api.matcher_positive

--- a/migration/idempotent/010-telemetry.sql
+++ b/migration/idempotent/010-telemetry.sql
@@ -72,10 +72,10 @@ $$
         SELECT count(*)::TEXT INTO result FROM _prom_catalog.metric;
         PERFORM _ps_catalog.apply_telemetry('metrics_total', result);
 
-        SELECT sum(hypertable_size(format('prom_data.%I', table_name)))::TEXT INTO result FROM _prom_catalog.metric;
+        SELECT sum(public.hypertable_size(format('prom_data.%I', table_name)))::TEXT INTO result FROM _prom_catalog.metric;
         PERFORM _ps_catalog.apply_telemetry('metrics_bytes_total', result);
 
-        SELECT approximate_row_count('_prom_catalog.series')::TEXT INTO result;
+        SELECT public.approximate_row_count('_prom_catalog.series')::TEXT INTO result;
         PERFORM _ps_catalog.apply_telemetry('metrics_series_total_approx', result);
 
         SELECT count(*)::TEXT INTO result FROM _prom_catalog.label WHERE key = '__tenant__';
@@ -106,16 +106,16 @@ $$
                         n_distinct
                     ELSE
                         --negative values represent number of distinct elements as a proportion of the total
-                        -n_distinct * approximate_row_count('_ps_trace.span')
+                        -n_distinct * public.approximate_row_count('_ps_trace.span')
                 END)::TEXT INTO result
         FROM pg_stats
         WHERE schemaname='_ps_trace' AND tablename='span' AND attname='trace_id' AND inherited;
         PERFORM _ps_catalog.apply_telemetry('traces_total_approx', result);
 
-        SELECT approximate_row_count('_ps_trace.span')::TEXT INTO result;
+        SELECT public.approximate_row_count('_ps_trace.span')::TEXT INTO result;
         PERFORM _ps_catalog.apply_telemetry('traces_spans_total_approx', result);
 
-        SELECT hypertable_size('_ps_trace.span')::TEXT INTO result;
+        SELECT public.hypertable_size('_ps_trace.span')::TEXT INTO result;
         PERFORM _ps_catalog.apply_telemetry('traces_spans_bytes_total', result);
 
         -- Others.

--- a/migration/migration/001-utils.sql
+++ b/migration/migration/001-utils.sql
@@ -22,7 +22,7 @@ BEGIN
 
     EXECUTE command;
     BEGIN
-        CALL distributed_exec(command);
+        CALL public.distributed_exec(command);
     EXCEPTION
         WHEN undefined_function THEN
             -- we're not on Timescale 2, just return

--- a/migration/migration/006-matcher-operators.sql
+++ b/migration/migration/006-matcher-operators.sql
@@ -29,7 +29,7 @@ RETURNS prom_api.matcher_positive
 AS $func$
     SELECT ARRAY(
            SELECT coalesce(l.id, -1) -- -1 indicates no such label
-           FROM label_jsonb_each_text(labels-'__name__') e
+           FROM _prom_catalog.label_jsonb_each_text(labels-'__name__') e
            LEFT JOIN _prom_catalog.label l
                ON (l.key = e.key AND l.value = e.value)
         )::prom_api.matcher_positive

--- a/migration/migration/010-tables-exemplar.sql
+++ b/migration/migration/010-tables-exemplar.sql
@@ -16,4 +16,4 @@ CREATE TABLE IF NOT EXISTS _prom_catalog.exemplar (
 GRANT SELECT ON TABLE _prom_catalog.exemplar TO prom_reader;
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE _prom_catalog.exemplar TO prom_writer;
 
-GRANT USAGE, SELECT ON SEQUENCE exemplar_id_seq TO prom_writer;
+GRANT USAGE, SELECT ON SEQUENCE _prom_catalog.exemplar_id_seq TO prom_writer;


### PR DESCRIPTION
With the removal of default search paths from the extension SQL, some
objects must be fully-qualified to work correctly.