### PR TITLE
Create version upgrade symlinks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,11 +50,11 @@ USER postgres
 RUN cd ../ && cargo pgx new promscale && cd promscale
 COPY Cargo.* Makefile /build/promscale/
 RUN --mount=type=cache,uid=70,gid=70,target=/build/promscale/.cargo/registry \
-    make package
+    make dependencies
 
 # Build extension
 COPY Cargo.* /build/promscale/
-COPY promscale.control Makefile build.rs /build/promscale/
+COPY promscale.control Makefile build.rs create-upgrade-symlinks.sh /build/promscale/
 COPY .cargo/ /build/promscale/.cargo/
 COPY src/ /build/promscale/src/
 COPY sql/*.sql /build/promscale/sql/

--- a/Dockerfile.quick
+++ b/Dockerfile.quick
@@ -7,4 +7,6 @@ FROM timescaledev/promscale-extension:${EXTENSION_VERSION}-${TIMESCALEDB_VERSION
 
 ARG EXTENSION_VERSION
 COPY sql/promscale-${EXTENSION_VERSION}.sql /usr/local/share/postgresql/extension/promscale--${EXTENSION_VERSION}.sql
+# TODO (james): This probably needs to be extended to be created for all `upgradeable_from` in promscale.control
+COPY sql/promscale-${EXTENSION_VERSION}.sql /usr/local/share/postgresql/extension/promscale--0.0.0--${EXTENSION_VERSION}.sql
 

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 .DEFAULT_GOAL := help
 
-ARCH ?= `uname -m`
-EXT_VERSION ?= `cargo pkgid | cut -d':' -f3`
+ARCH ?= $(shell uname -m)
+EXT_VERSION ?= $(shell cargo pkgid | cut -d':' -f3)
 IMAGE_NAME ?= timescaledev/promscale-extension
 OS_NAME ?= debian
 OS_VERSION ?= 11
-RUST_VERSION ?= `rustc --version | cut -d' ' -f2`
+RUST_VERSION ?= $(shell rustc --version | cut -d' ' -f2)
 PG_CONFIG ?= pg_config
-PG_VERSION ?= `${PG_CONFIG} --version | awk -F'[ \. ]' '{print $$2}'`
-PG_VER ?= pg${PG_VERSION}
+PG_VERSION = $(shell ${PG_CONFIG} --version | awk -F'[ \. ]' '{print $$2}')
+PG_VER = pg${PG_VERSION}
 # If set to a non-empty value, docker builds will be pushed to the registry
 PUSH ?=
 TIMESCALEDB_MAJOR=2

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,10 @@ OS_NAME ?= debian
 OS_VERSION ?= 11
 RUST_VERSION ?= $(shell rustc --version | cut -d' ' -f2)
 PG_CONFIG ?= pg_config
-PG_VERSION = $(shell ${PG_CONFIG} --version | awk -F'[ \. ]' '{print $$2}')
-PG_VER = pg${PG_VERSION}
+PG_RELEASE_VERSION ?= $(shell ${PG_CONFIG} --version | awk -F'[ \. ]' '{print $$2}')
+PG_BUILD_VERSION = $(shell ${PG_CONFIG} --version | awk -F'[ \. ]' '{print $$2}')
+PG_RELEASE_VER = pg${PG_RELEASE_VERSION}
+PG_BUILD_VER = pg${PG_BUILD_VERSION}
 # If set to a non-empty value, docker builds will be pushed to the registry
 PUSH ?=
 TIMESCALEDB_MAJOR=2
@@ -42,19 +44,19 @@ ifeq ($(OS_NAME),fedora)
 	DOCKERFILE = rpm.dockerfile
 	PKG_TYPE = rpm
 endif
-RELEASE_IMAGE_NAME = promscale-extension-pkg:$(EXT_VERSION)-$(OS_NAME)$(OS_VERSION)-$(PG_VER)
-RELEASE_FILE_NAME = promscale_extension-$(EXT_VERSION).$(PG_VER).$(OS_NAME)$(OS_VERSION).$(ARCH).$(PKG_TYPE)
-TESTER_NAME = pg$(PG_VERSION)-$(OS_NAME)$(OS_VERSION)
+RELEASE_IMAGE_NAME = promscale-extension-pkg:$(EXT_VERSION)-$(OS_NAME)$(OS_VERSION)-$(PG_RELEASE_VER)
+RELEASE_FILE_NAME = promscale_extension-$(EXT_VERSION).$(PG_RELEASE_VER).$(OS_NAME)$(OS_VERSION).$(ARCH).$(PKG_TYPE)
+TESTER_NAME = $(PG_RELEASE_VER)-$(OS_NAME)$(OS_VERSION)
 
 .PHONY: help
 help:
-	@echo "promscale_extension $(EXT_VERSION) (pg$(PG_VERSION))"
+	@echo "promscale_extension $(EXT_VERSION)"
 	@perl -nle'print $& if m{^[a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: build
 build: ## Build the extension
-	cargo build --release --features pg${PG_VERSION} $(EXTRA_RUST_ARGS)
-	cargo pgx schema -f pg${PG_VERSION} --release
+	cargo build --release --features pg${PG_BUILD_VERSION} $(EXTRA_RUST_ARGS)
+	cargo pgx schema -f pg${PG_BUILD_VERSION} --release
 
 .PHONY: clean
 clean: ## Clean up latest build
@@ -70,13 +72,13 @@ install: ## Install the extension in the Postgres found via pg_config
 
 
 .PHONY: release
-release: release-builder ## Produces release artifacts based on OS_NAME, OS_VERSION, and PG_VERSION
+release: release-builder ## Produces release artifacts based on OS_NAME, OS_VERSION, and PG_RELEASE_VERSION
 	@container="$$(docker create $(RELEASE_IMAGE_NAME))"; \
 	docker cp "$${container}:/dist/$(RELEASE_FILE_NAME)" ./dist/; \
 	docker rm -f "$${container}"
 
 .PHONY: release-builder
-release-builder: dist/$(DOCKERFILE) ## Build image with the release artifact for OS_NAME, OS_VERSION, and PG_VERSION
+release-builder: dist/$(DOCKERFILE) ## Build image with the release artifact for OS_NAME, OS_VERSION, and PG_RELEASE_VERSION
 ifndef DOCKERFILE
 	$(error Unsupported OS_NAME '$(OS_NAME)'! Expected one of debian,ubuntu,centos,rhel,fedora)
 endif
@@ -86,7 +88,7 @@ endif
 	docker buildx build --load --platform $(DOCKER_PLATFORM) \
 		--build-arg OS_NAME=$(OS_NAME) \
 		--build-arg OS_VERSION=$(OS_VERSION) \
-		--build-arg PG_VERSION=$(PG_VERSION) \
+		--build-arg PG_VERSION=$(PG_RELEASE_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg RELEASE_FILE_NAME=$(RELEASE_FILE_NAME) \
 		--target packager \
@@ -105,7 +107,7 @@ endif
 	docker buildx build --load --platform $(DOCKER_PLATFORM) \
 		--build-arg OS_NAME=$(OS_NAME) \
 		--build-arg OS_VERSION=$(OS_VERSION) \
-		--build-arg PG_VERSION=$(PG_VERSION) \
+		--build-arg PG_VERSION=$(PG_RELEASE_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg RELEASE_FILE_NAME=$(RELEASE_FILE_NAME) \
 		--target tester \
@@ -125,22 +127,22 @@ release-test: release-tester ## Test the currently selected release package
 docker-image-build-12 docker-image-build-13 docker-image-build-14: Dockerfile $(SQL_FILES) $(SRCS) Cargo.toml Cargo.lock $(RUST_SRCS)
 	docker buildx build $(if $(PUSH),--push,--load) \
 		--build-arg TIMESCALEDB_VERSION=$(TIMESCALEDB_VER) \
-		--build-arg PG_VERSION_TAG=$(PG_VER) \
-		-t $(IMAGE_NAME):$(EXT_VERSION)-$(TIMESCALEDB_VER)-$(PG_VER) \
-		-t $(IMAGE_NAME):$(EXT_VERSION)-ts$(TIMESCALEDB_MAJOR)-$(PG_VER) \
-		-t $(IMAGE_NAME):latest-ts$(TIMESCALEDB_MAJOR)-$(PG_VER) \
+		--build-arg PG_VERSION_TAG=$(PG_BUILD_VER) \
+		-t $(IMAGE_NAME):$(EXT_VERSION)-$(TIMESCALEDB_VER)-$(PG_BUILD_VER) \
+		-t $(IMAGE_NAME):$(EXT_VERSION)-ts$(TIMESCALEDB_MAJOR)-$(PG_BUILD_VER) \
+		-t $(IMAGE_NAME):latest-ts$(TIMESCALEDB_MAJOR)-$(PG_BUILD_VER) \
 		.
 
 .PHONY: docker-image-12
-docker-image-12: PG_VER=pg12
+docker-image-12: PG_BUILD_VER=pg12
 docker-image-12: docker-image-build-12
 
 .PHONY: docker-image-13
-docker-image-13: PG_VER=pg13
+docker-image-13: PG_BUILD_VER=pg13
 docker-image-13: docker-image-build-13
 
 .PHONY: docker-image-14
-docker-image-14: PG_VER=pg14
+docker-image-14: PG_BUILD_VER=pg14
 docker-image-14: docker-image-build-14
 
 .PHONY: docker-image
@@ -148,26 +150,26 @@ docker-image: docker-image-14 docker-image-13 docker-image-12 ## Build Timescale
 
 .PHONY: docker-quick-build-12 docker-quick-build-13 docker-quick-build-14
 docker-quick-build-12 docker-quick-build-13 docker-quick-build-14: ## A quick way to rebuild the extension image with only SQL changes
-	cargo pgx schema $(PG_VER)
+	cargo pgx schema $(PG_BUILD_VER)
 	docker build -f Dockerfile.quick \
 		--build-arg TIMESCALEDB_VERSION=$(TIMESCALEDB_VER) \
-		--build-arg PG_VERSION_TAG=$(PG_VER) \
+		--build-arg PG_VERSION_TAG=$(PG_BUILD_VER) \
 		--build-arg EXTENSION_VERSION=$(EXT_VERSION) \
-		-t $(IMAGE_NAME):$(EXT_VERSION)-$(TIMESCALEDB_VER)-$(PG_VER) \
-		-t $(IMAGE_NAME):$(EXT_VERSION)-ts$(TIMESCALEDB_MAJOR)-$(PG_VER) \
-		-t $(IMAGE_NAME):latest-ts$(TIMESCALEDB_MAJOR)-$(PG_VER) \
+		-t $(IMAGE_NAME):$(EXT_VERSION)-$(TIMESCALEDB_VER)-$(PG_BUILD_VER) \
+		-t $(IMAGE_NAME):$(EXT_VERSION)-ts$(TIMESCALEDB_MAJOR)-$(PG_BUILD_VER) \
+		-t $(IMAGE_NAME):latest-ts$(TIMESCALEDB_MAJOR)-$(PG_BUILD_VER) \
 		.
 
 .PHONY: docker-quick-14
-docker-quick-14: PG_VER=pg14
+docker-quick-14: PG_BUILD_VER=pg14
 docker-quick-14: docker-quick-build-14
 
 .PHONY: docker-quick-13
-docker-quick-13: PG_VER=pg13
+docker-quick-13: PG_BUILD_VER=pg13
 docker-quick-13: docker-quick-build-13
 
 .PHONY: docker-quick-12
-docker-quick-12: PG_VER=pg12
+docker-quick-12: PG_BUILD_VER=pg12
 docker-quick-12: docker-quick-build-12
 
 .PHONY: setup-buildx

--- a/create-upgrade-symlinks.sh
+++ b/create-upgrade-symlinks.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+prev_versions=$(cat promscale.control | sed -n 's/# upgradeable_from = \(.*\)/\1/p' | sed "s/[[:space:]']//g" | tr ',' '\n')
+cur_version=$(cargo pkgid | cut -d'#' -f2 | cut -d':' -f2)
+
+for prev_version in $prev_versions; do
+  if [ -n "${prev_version}" ] && [ -n "${cur_version}" ]; then
+    ln -s -f "promscale--${cur_version}.sql" "sql/promscale--${prev_version}--${cur_version}.sql"
+  fi
+done

--- a/promscale.control
+++ b/promscale.control
@@ -8,4 +8,4 @@ superuser = true
 trusted = true
 # comma-separated list of previous versions this version can be upgraded from
 # directly. This is used to generate upgrade scripts.
-# upgradeable_from = '0.3.0'
+# upgradeable_from = '0.0.0'


### PR DESCRIPTION
When a new extension version is published, we require both a SQL schema
file for the new version (e.g. promscale--0.8.0.sql), as well as an
upgrade schema file (e.g. promscale--0.7.0--0.8.0.sql).

Because we're versioning the shared object, we actually require an
upgrade schema file for every previously-published version to the new
version (otherwise function definitions reference a .so which is not
present).

The fact that our major-version SQL schema file has an internal
migration mechanism making it effectively idempotent means that we can
reuse the major-version SQL schema file as the upgrade file to that
version.

This commit adds machinery to automatically create symlinks pointing to
the major-version SQL schema.