### PR TITLE
Fix for uniqueness constraint on large tag values.

### DIFF
--- a/migration/idempotent/007-tracing-tags.sql
+++ b/migration/idempotent/007-tracing-tags.sql
@@ -186,6 +186,7 @@ AS $func$
     SELECT jsonb_build_object(a.key_id, a.id)
     FROM _ps_trace.tag a
     WHERE a.key = _op.tag_key
+    AND _prom_ext.jsonb_digest(a.value) = _prom_ext.jsonb_digest(_op.value)
     AND a.value = _op.value
     LIMIT 1
 $func$

--- a/migration/idempotent/013-apply-config.sql
+++ b/migration/idempotent/013-apply-config.sql
@@ -64,6 +64,7 @@ $block$;
 -- TODO (james): possibly move these grants closer to their definitions? At
 --  definition time, the roles which we grant here haven't been created yet.
 GRANT EXECUTE ON FUNCTION _prom_ext.num_cpus() TO prom_reader;
+GRANT EXECUTE ON FUNCTION _prom_ext.jsonb_digest(JSONB) TO prom_reader;
 GRANT EXECUTE ON FUNCTION _prom_ext.prom_delta(TIMESTAMPTZ, TIMESTAMPTZ, BIGINT, BIGINT, TIMESTAMPTZ, DOUBLE PRECISION) TO prom_reader;
 GRANT EXECUTE ON FUNCTION _prom_ext.prom_increase(TIMESTAMPTZ, TIMESTAMPTZ, BIGINT, BIGINT, TIMESTAMPTZ, DOUBLE PRECISION) TO prom_reader;
 GRANT EXECUTE ON FUNCTION _prom_ext.prom_rate(TIMESTAMPTZ, TIMESTAMPTZ, BIGINT, BIGINT, TIMESTAMPTZ, DOUBLE PRECISION) TO prom_reader;

--- a/migration/migration/015-tracing-large-tags-fix.sql
+++ b/migration/migration/015-tracing-large-tags-fix.sql
@@ -1,0 +1,2 @@
+ALTER TABLE _ps_trace.tag DROP CONSTRAINT tag_key_value_id_key_id_key;
+CREATE UNIQUE INDEX tag_key_value_id_key_id_key ON _ps_trace.tag (key, _prom_ext.jsonb_digest(value)) INCLUDE (id, key_id);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,132 @@ mod util;
 
 pg_module_magic!();
 
+/// TODO: presently, we deliberate on how to structure SQL-only tests.
+/// As soon as we agree on something these tests should be moved over.
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use pgx::*;
+    use serde_json::json;
+    use std::collections::HashSet;
+    use std::iter::FromIterator;
+
+    #[pg_test]
+    fn test_very_large_values_in_put_tag() {
+        let tag_id = Spi::get_one::<i64>(
+            r#"
+            SELECT put_tag('service.namespace', gen.kilobytes_of_garbage::jsonb, resource_tag_type())
+			FROM (
+				SELECT string_agg(n::text, '') AS kilobytes_of_garbage
+				FROM generate_series(1, 2000) AS gs (n)
+			) AS gen
+            "#,
+        )
+        .expect("SQL query failed");
+
+        let (res_id, res_val) = Spi::get_two_with_args::<i64, String>(
+            r#"
+                SELECT id, value::text
+                FROM _ps_trace.tag 
+                WHERE id = $1
+                "#,
+            vec![(PgBuiltInOids::INT8OID.oid(), tag_id.into_datum())],
+        );
+
+        assert_eq!(res_id, Some(tag_id));
+        match res_val {
+            Some(v) if v.len() > 2704 => {}
+            _ => assert!(
+                false,
+                "tag value is shorter than btree's version 4 maximum row size for an index"
+            ),
+        };
+    }
+
+    #[pg_test]
+    fn test_put_tag_same_value() {
+        let tag_ids: Vec<i64> = vec!["service.namespace", "faas.name"]
+            .into_iter()
+            .map(|key| {
+                Spi::get_one_with_args::<i64>(
+                    r#" SELECT put_tag($1, '"testvalue"', resource_tag_type()); "#,
+                    vec![(PgBuiltInOids::TEXTOID.oid(), key.into_datum())],
+                )
+                .expect("SQL query failed")
+            })
+            .collect();
+
+        // tag ids are distinct
+        let distinct_digests: HashSet<i64> = HashSet::from_iter(tag_ids.iter().cloned());
+        assert_eq!(distinct_digests.len(), tag_ids.len());
+    }
+
+    #[pg_test]
+    fn test_put_tag_same_key() {
+        let tag_ids: Vec<i64> = vec![1, 2]
+            .into_iter()
+            .map(|v| JsonB(json!({ "testvalue": v })))
+            .map(|jsonb| {
+                Spi::get_one_with_args::<i64>(
+                    r#" SELECT put_tag('service.namespace', $1::text::jsonb, resource_tag_type()); "#,
+                    vec![(PgBuiltInOids::JSONBOID.oid(), jsonb.into_datum())],
+                )
+                .expect("SQL query failed")
+            })
+            .collect();
+
+        // tag ids are distinct
+        let distinct_digests: HashSet<i64> = HashSet::from_iter(tag_ids.iter().cloned());
+        assert_eq!(distinct_digests.len(), tag_ids.len());
+    }
+
+    #[pg_test]
+    fn test_tag_funs() {
+        let op_tag_id = Spi::get_one::<i64>(
+            r#"SELECT put_operation('myservice', 'test', 'SPAN_KIND_UNSPECIFIED');"#,
+        )
+        .expect("SQL query failed");
+
+        let srvc_tag_id = Spi::get_one::<i64>(
+            r#"SELECT put_tag('service.name', '"myservice"'::jsonb, resource_tag_type())"#,
+        )
+        .expect("SQL query failed");
+
+        let op_tag_id_stored = Spi::get_one_with_args::<i64>(
+            r#"
+            SELECT id
+            FROM _ps_trace.operation
+            WHERE service_name_id = $1
+            AND span_kind = 'SPAN_KIND_UNSPECIFIED'
+            AND span_name = 'test'; 
+            "#,
+            vec![(PgBuiltInOids::INT8OID.oid(), srvc_tag_id.into_datum())],
+        )
+        .expect("SQL query failed");
+        assert_eq!(op_tag_id, op_tag_id_stored);
+
+        let host_tag_id = Spi::get_one::<i64>(
+            r#"SELECT put_tag('host.name', '"foobar"'::jsonb, resource_tag_type())"#,
+        )
+        .expect("SQL query failed");
+
+        let get_tag_res =
+            Spi::get_one::<JsonB>(r#"SELECT get_tag_map(('{"host.name": "foobar", "service.name": "myservice"}')::jsonb)"#)
+                .expect("SQL query failed");
+        assert_eq!(
+            get_tag_res.0,
+            serde_json::json!({ "1": srvc_tag_id, "33": host_tag_id })
+        );
+
+        let eval_eq_res = Spi::get_one::<JsonB>(
+            r#"SELECT _ps_trace.eval_equals(ROW('service.name', '"myservice"'::jsonb));"#,
+        )
+        .expect("SQL query failed");
+        assert_eq!(eval_eq_res.0, serde_json::json!({ "1": srvc_tag_id }));
+    }
+}
+
 #[cfg(test)]
 #[pg_schema]
 pub mod pg_test {


### PR DESCRIPTION
This addresses #128 by replacing `value` attribute within the UNIQUE constraint with `sha512` hash of its textual representation.

I ran the following SQL as a microbenchmark:

```sql
SELECT put_tag('service.name', n::text::jsonb, resource_tag_type())
FROM generate_series(1, 20000) AS gs (n)
```

and

```sql
SELECT get_tag_map(('{"service.name": ' || n::text || '}')::jsonb)
FROM generate_series(1, 20000) AS gs (n)
```

~There doesn't seem to be a significant performance difference on the insertion path. Unmodified get_tag_map became roughly twice as slow, so I had to alter it as well. This hints at possible performance degradation elsewhere.~ 

I think I was able to chase down all functions that relied on an index covering `(key, value)`  and augmented these places with an additional check `jsonb_digest(a.value) = ...` to make use of the new index. Unfortunately, some of these functions might become marginally slower, as they'd need to access both the index (for `key, jsonb_digest(value)`) and heap (to fetch `value` for hits). In the end performance hit appears to be ~10%.