### PR TITLE
SHA512 based JSONB digest function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,11 +460,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -485,13 +486,12 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "digest"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer",
  "crypto-common",
- "generic-array",
  "subtle",
 ]
 
@@ -1394,6 +1394,7 @@ dependencies = [
  "pgx-tests",
  "serde",
  "serde_json",
+ "sha2",
 ]
 
 [[package]]
@@ -1730,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bit_field"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,6 +597,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +622,12 @@ dependencies = [
  "libc",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -1392,10 +1422,43 @@ dependencies = [
  "pgx",
  "pgx-macros",
  "pgx-tests",
+ "proptest",
  "serde",
  "serde_json",
  "sha2",
 ]
+
+[[package]]
+name = "proptest"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.1",
+ "rand 0.8.4",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -1488,6 +1551,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
 name = "rayon"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,6 +1630,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "riscv"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,6 +1704,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
  "semver 0.11.0",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -1853,6 +1946,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2185,6 +2292,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
 dependencies = [
  "vcell",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@ panic = "unwind"
 lto = "thin"
 
 [features]
-default = []
+default = ["pg14", "serde_json", "proptest"] # used by rust-analyzer in VSCode
 pg12 = ["pgx/pg12", "pgx-tests/pg12"]
 pg13 = ["pgx/pg13", "pgx-tests/pg13"]
 pg14 = ["pgx/pg14", "pgx-tests/pg14"]
-pg_test = ["serde_json"]
+pg_test = ["serde_json", "proptest"]
 
 [dependencies]
 bincode = "1.3.1"
@@ -32,6 +32,7 @@ num_cpus = "1.13.1"
 sha2 = "0.10.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.70", optional = true }
+proptest  = { version = "1.0.0", optional = true }
 
 [build-dependencies]
 askama = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ bincode = "1.3.1"
 pgx = "0.3.1"
 pgx-macros = "0.3.1"
 num_cpus = "1.13.1"
+sha2 = "0.10.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.70", optional = true }
 

--- a/src/iterable_jsonb.rs
+++ b/src/iterable_jsonb.rs
@@ -1,0 +1,231 @@
+use pg_sys::*;
+use pgx::FromDatum;
+use pgx::*;
+
+// Trick DDL generator into recognizing our implementation of a built-in type.
+extension_sql!(
+    "",
+    name = "iterable_jsonb_pseudotype",
+    creates = [Type(Jsonb)],
+);
+
+/// A custom wrapper for a JSONB `Datum`.
+/// In contrast with [`pgx::JsonB`] that parses the entire underlying JSON
+/// this type focuses on providing access to its contents via [`Iterator`].
+///
+/// Handles ownership if the underlying `Datum` is copied during de-TOASTing.
+/// Otherwise data is likely to be bound to the current memory context, hence
+/// the `'a` lifetime.
+pub struct Jsonb<'a> {
+    pg_jsonb: *mut pg_sys::Jsonb,
+    needs_drop: bool,
+    _marker: std::marker::PhantomData<&'a pg_sys::Jsonb>,
+}
+
+impl<'a> Jsonb<'a> {
+    /// Traverses the entire JSON object recursively, emitting [`Token`] objects.
+    pub fn tokens(&'a self) -> TokenIterator<'a> {
+        unsafe {
+            let pg_jsonb_iter =
+                JsonbIteratorInit(&mut (*self.pg_jsonb).root as *mut JsonbContainer);
+            TokenIterator {
+                pg_jsonb_iter,
+                _marker: std::marker::PhantomData,
+            }
+        }
+    }
+}
+
+impl<'a> FromDatum for Jsonb<'a> {
+    const NEEDS_TYPID: bool = false;
+
+    unsafe fn from_datum(datum: Datum, is_null: bool, _: Oid) -> Option<Jsonb<'a>> {
+        if is_null {
+            None
+        } else if datum == 0 {
+            panic!("a jsonb Datum was flagged as non-null but the datum is zero")
+        } else {
+            let varlena = datum as *mut pg_sys::varlena;
+            let detoasted = pg_detoast_datum(varlena);
+
+            Some(Jsonb {
+                pg_jsonb: detoasted as *mut pg_sys::Jsonb,
+                // free the detoasted datum if it turned out to be a copy
+                needs_drop: detoasted != varlena,
+                _marker: std::marker::PhantomData,
+            })
+        }
+    }
+
+    unsafe fn from_datum_in_memory_context(
+        mut memory_context: PgMemoryContexts,
+        datum: usize,
+        is_null: bool,
+        _typoid: u32,
+    ) -> Option<Jsonb<'a>> {
+        if is_null {
+            None
+        } else if datum == 0 {
+            panic!("a jsonb Datum was flagged as non-null but the datum is zero")
+        } else {
+            memory_context.switch_to(|_| {
+                let detoasted = pg_detoast_datum_copy(datum as *mut pg_sys::varlena);
+                Some(Jsonb {
+                    pg_jsonb: detoasted as *mut pg_sys::Jsonb,
+                    needs_drop: true,
+                    _marker: std::marker::PhantomData,
+                })
+            })
+        }
+    }
+}
+
+impl Drop for Jsonb<'_> {
+    fn drop(&mut self) {
+        if self.needs_drop {
+            unsafe {
+                pfree(self.pg_jsonb as void_mut_ptr);
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Token<'a> {
+    BeginArray,
+    EndArray,
+    BeginObject,
+    EndObject,
+    /// Reresents a key in a JSON object.
+    /// Always followed a non-key [`Token`],
+    /// representing an associated value.
+    Key(&'a str),
+    // Scalar values used as array elements and object values
+    Null,
+    Bool(bool),
+    String(&'a str),
+    Numeric(JsonbNormalizedNumeric), // Normalized with numeric_normalize
+}
+
+pub struct TokenIterator<'a> {
+    pg_jsonb_iter: *mut JsonbIterator,
+    _marker: std::marker::PhantomData<Jsonb<'a>>,
+}
+
+impl<'a> Iterator for TokenIterator<'a> {
+    type Item = Token<'a>;
+
+    #[allow(non_upper_case_globals)]
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut jsonb_val = JsonbValue::default();
+        let r: JsonbIteratorToken = unsafe {
+            JsonbIteratorNext(
+                &mut self.pg_jsonb_iter as *mut *mut JsonbIterator,
+                &mut jsonb_val as *mut JsonbValue,
+                false,
+            )
+        };
+        match r {
+            JsonbIteratorToken_WJB_DONE => None,
+            JsonbIteratorToken_WJB_BEGIN_ARRAY => Some(Token::BeginArray),
+            JsonbIteratorToken_WJB_END_ARRAY => Some(Token::EndArray),
+            JsonbIteratorToken_WJB_BEGIN_OBJECT => Some(Token::BeginObject),
+            JsonbIteratorToken_WJB_END_OBJECT => Some(Token::EndObject),
+            JsonbIteratorToken_WJB_KEY => {
+                match TokenIterator::extract_value_token(&mut jsonb_val) {
+                    Token::String(str) => Some(Token::Key(str)),
+                    _ => {
+                        elog(PgLogLevel::ERROR, "Unexpected token while expecting a key");
+                        None
+                    }
+                }
+            }
+            JsonbIteratorToken_WJB_VALUE | JsonbIteratorToken_WJB_ELEM => {
+                Some(TokenIterator::extract_value_token(&mut jsonb_val))
+            }
+            _ => {
+                elog(
+                    PgLogLevel::ERROR,
+                    format!("invalid JsonbIteratorNext rc: {}", r).as_str(),
+                );
+                None
+            }
+        }
+    }
+}
+
+impl<'a> TokenIterator<'a> {
+    #[inline]
+    fn extract_string_value(jsonb_val: &mut JsonbValue) -> &'a str {
+        unsafe {
+            let str_val = jsonb_val.val.string;
+
+            std::str::from_utf8_unchecked(std::slice::from_raw_parts::<'a, _>(
+                str_val.val as *mut u8,
+                str_val.len as usize,
+            ))
+        }
+    }
+
+    #[inline]
+    #[allow(non_upper_case_globals)]
+    fn extract_value_token(jsonb_val: &mut JsonbValue) -> Token<'a> {
+        match jsonb_val.type_ as jbvType {
+            jbvType_jbvNull => Token::Null,
+            jbvType_jbvString => Token::String(TokenIterator::extract_string_value(jsonb_val)),
+            jbvType_jbvNumeric => Token::Numeric(JsonbNormalizedNumeric::new(unsafe {
+                jsonb_val.val.numeric
+            })),
+            jbvType_jbvBool => Token::Bool(unsafe { jsonb_val.val.boolean }),
+            t => {
+                panic!("invalid scalar jsonb type: {}", t)
+            }
+        }
+    }
+}
+
+/// Consumes iterator completely to free allocated memory
+impl Drop for TokenIterator<'_> {
+    #[inline]
+    fn drop(&mut self) {
+        if self.next().is_some() {
+            let _ = self.last();
+        }
+    }
+}
+
+/// The intent of this is to represent values that are equal if
+/// and only if the input numeric values compare equal.
+///
+/// An additional wrapper is introduced to avoid allocating [`String`]
+/// unless absolutely required.
+#[derive(Debug)]
+pub struct JsonbNormalizedNumeric {
+    numeric_str: *mut std::os::raw::c_char,
+}
+
+impl JsonbNormalizedNumeric {
+    #[inline]
+    fn new(numeric_data: pg_sys::Numeric) -> JsonbNormalizedNumeric {
+        let numeric_str = unsafe { numeric_normalize(numeric_data) };
+        JsonbNormalizedNumeric { numeric_str }
+    }
+
+    #[inline]
+    pub fn to_str(&self) -> &str {
+        unsafe { std::ffi::CStr::from_ptr(self.numeric_str) }
+            .to_str()
+            .unwrap()
+    }
+
+    #[allow(dead_code)]
+    pub fn to_pgx_numeric(&self) -> pgx::Numeric {
+        pgx::Numeric(self.to_str().to_string())
+    }
+}
+
+impl Drop for JsonbNormalizedNumeric {
+    fn drop(&mut self) {
+        unsafe { pfree(self.numeric_str as void_mut_ptr) }
+    }
+}

--- a/src/jsonb_digest.rs
+++ b/src/jsonb_digest.rs
@@ -1,0 +1,169 @@
+use crate::iterable_jsonb::*;
+use pgx::*;
+use sha2::{Digest, Sha512};
+
+/// A custom SHA512 based JSONB digest.
+///
+/// Save for hash collisions, for any pair of `j1` and `j2` the statement
+/// `SELECT jsonb_digest(j1) == jsonb_digest(j2)`
+/// is true iff `j1 == j2` are _semantically_ equivalent.
+///
+/// There is a couple of alternatives, unfortunately neither
+/// should be used in a UNIQUE index.
+///
+/// `pg_catalog.sha512(json_value::text::bytea)` has two drawbacks:
+/// - There isn't enough control over `jsonb` -> `text` conversion.
+///   Although, the existing implementation relies on the same mechanism
+///   as [`jsonb_digest`] and should always keep object keys in the fixed
+///   order, there's no way to explicitly set specifics of its behaviour
+///   like indentation or white-space padding.
+/// - JSONB stores all numeric values in PostgreSQL `numeric` type.
+///   It's not just precise, it accurately preserves trailing fractional zeroes.
+///   In other words, values `1.01` and `1.010` will be represented differently,
+///   despite being equal.
+///  
+/// There's also `jsonb_hash_extended` that addresses the shortcomings,
+/// described above. Unfortunately, it is limited to 64 bit: good enough
+/// for hash tables, probably a bad idea for a UNIQUE index. This
+/// implementation is largely based on `jsonb_hash_extended`.
+#[pg_extern(immutable, strict, parallel_safe)]
+pub fn jsonb_digest(jsonb: Jsonb) -> Vec<u8> {
+    use Token::*;
+
+    // Based on https://github.com/postgres/postgres/blob/27b77ecf9f4d5be211900eda54d8155ada50d696/src/include/utils/jsonb.h#L193
+    // I'm making an assumption here, that object key order
+    // should remain stable in the foreseeble future.
+    //
+    // Additionally, there's a test that checks that a hardcoded value didn't change.
+    let mut hasher = Sha512::new();
+    jsonb.tokens().enumerate().for_each(|(idx, token)| {
+        hasher.update(idx.to_le_bytes());
+        match token {
+            Null => hasher.update(0x01u8.to_le_bytes()),
+            Bool(true) => hasher.update(0x02u8.to_le_bytes()),
+            Bool(false) => hasher.update(0x03u8.to_le_bytes()),
+            String(str) => {
+                hasher.update(0x04u8.to_le_bytes());
+                hasher.update(str.as_bytes())
+            }
+            Token::Numeric(numeric) => {
+                hasher.update(0x05u8.to_le_bytes());
+                hasher.update(numeric.to_str().as_bytes())
+            }
+            //
+            Key(str) => {
+                hasher.update(0x0Au8.to_le_bytes());
+                hasher.update(str.as_bytes())
+            }
+            BeginObject => hasher.update(0x0Bu8.to_le_bytes()),
+            EndObject => hasher.update(0x0Cu8.to_le_bytes()),
+            //
+            BeginArray => hasher.update(0x0Du8.to_le_bytes()),
+            EndArray => hasher.update(0x0Eu8.to_le_bytes()),
+        }
+    });
+
+    Vec::from(hasher.finalize().as_slice())
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use pgx::*;
+    use std::collections::HashSet;
+    use std::iter::FromIterator;
+
+    #[pg_test]
+    fn test_jsonb_digest_simple_values() {
+        assert!(Spi::get_one::<Vec<u8>>(r#" SELECT jsonb_digest(NULL) "#,).is_none());
+
+        let inputs = vec![
+            "{}",
+            "[]",
+            "1",
+            "-1.01",
+            "1.01",
+            "true",
+            r#""""#,
+            r#""x""#,
+            r#"{"a": "b"}"#,
+            r#"{"b": "a"}"#,
+            r#"{"a": {}}"#,
+            r#"{"a": {"b": {}}}"#,
+            r#"[1, {}, [], {"a": [true, false]}]"#,
+        ];
+        let digests = inputs
+            .iter()
+            .map(|test_val| {
+                let digest = Spi::get_one::<Vec<u8>>(
+                    format!("SELECT jsonb_digest('{}'::jsonb)", test_val).as_str(),
+                )
+                .expect("SQL query failed");
+
+                assert_eq!(digest.len(), 64);
+                format!("{:?}", digest)
+            })
+            .collect::<Vec<String>>();
+
+        // all hashes are unique
+        let distinct_digests: HashSet<String> = HashSet::from_iter(digests.iter().cloned());
+        assert_eq!(distinct_digests.len(), inputs.len());
+    }
+
+    #[pg_test]
+    fn test_jsonb_digest_equal_values() {
+        let inputs = vec![
+            ("1.01", "1.010"),
+            (r#"{"a": "b", "c": "d"}"#, r#"{"c": "d", "a": "b"}"#),
+        ];
+
+        inputs.into_iter().for_each(|(v1, v2)| {
+            let [d1, d2] = [v1, v2]
+                .map(|v| format!("SELECT jsonb_digest('{}'::jsonb)::text", v))
+                .map(|q| Spi::get_one::<String>(q.as_str()).expect("SQL query failed"));
+            assert_eq!(d1, d2);
+        });
+    }
+
+    #[pg_test]
+    fn test_jsonb_digest_big_value() {
+        let digest = Spi::get_one::<String>(
+            r#"
+            SELECT jsonb_digest(gen.json)::text
+			FROM (
+                SELECT jsonb_object_agg(n::text, n) AS json
+                FROM generate_series(1, 2000) AS gs (n)
+			) AS gen
+            "#,
+        )
+        .expect("SQL query failed");
+
+        // The expected value is hardcoded intentionally: it's the only way for
+        // us to notice if the function's behaviour suddenly changes.
+        assert_eq!(
+            digest,
+            "\\xd83ab57e672b815fbd877547a29135fa8c8eb9d3dae0b05229e89d60b352fce19442504cf809733fee3ef26de90620af693f3c87a1425b63ad308504487ae093"
+        );
+    }
+
+    #[pg_test]
+    fn test_jsonb_digest_toasted_value() {
+        Spi::run(
+            r#"
+            CREATE TABLE json_digest_test(j JSONB);
+            INSERT INTO json_digest_test (j) 
+            SELECT jsonb_object_agg(n::text, n)
+            FROM generate_series(1, 20000) AS gs (n);
+        "#,
+        );
+        let digest = Spi::get_one::<Vec<u8>>(
+            r#"
+            SELECT jsonb_digest(t.j)
+			FROM json_digest_test AS t
+            "#,
+        )
+        .expect("SQL query failed");
+
+        assert_eq!(digest.len(), 64);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@ use pgx::*;
 
 mod aggregate_utils;
 mod aggregates;
+mod iterable_jsonb;
+mod jsonb_digest;
 mod palloc;
 mod raw;
 mod schema;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -6,7 +6,7 @@ use pgx::*;
 extension_sql!(
     "",
     name = "pseudo_create_types",
-    creates = [Type(bytea), Type(TimestampTz),],
+    creates = [Type(bytea), Type(TimestampTz)],
 );
 
 macro_rules! raw_type {


### PR DESCRIPTION
A custom SHA512 based JSONB digest.

Save for hash collisions, for any pair of `j1` and `j2` the statement `SELECT jsonb_digest(j1) = jsonb_digest(j2)` is true iff `j1 == j2` are _semantically_ equivalent.

There is a couple of alternatives, unfortunately neither should be used in a UNIQUE index.

`pg_catalog.sha512(json_value::text::bytea)` has two drawbacks:
- There isn't enough control over `jsonb` -> `text` conversion.
  Although, the existing implementation relies on the same mechanism
  as `jsonb_digest` and should always keep object keys in the fixed
  order, there's no way to explicitly set specifics of its behaviour
  like indentation or white-space padding.
- JSONB stores all numeric values in PostgreSQL `numeric` type.
  It's not just precise, it accurately preserves trailing fractional zeroes.
  In other words, values `1.01` and `1.010` will be represented differently,
  despite being equal.
 
There's also `jsonb_hash_extended` that addresses the shortcomings, described above. Unfortunately, it is limited to 64 bit: good enough for hash tables, probably a bad idea for a UNIQUE index. This implementation is largely based on `jsonb_hash_extended`.

A prerequisite for #130 