### PR TITLE
Make superuser owner of metric tables and views

### DIFF
--- a/migration/idempotent/012-remote-commands.sql
+++ b/migration/idempotent/012-remote-commands.sql
@@ -45,3 +45,7 @@ FROM
 ) z
 WHERE u.key = z.key
 ;
+
+PERFORM setval('_prom_catalog.remote_commands_seq_seq'::regclass, max(seq) + 1, false)
+FROM _prom_catalog.remote_commands
+;

--- a/migration/migration/002-utils.sql
+++ b/migration/migration/002-utils.sql
@@ -8,6 +8,7 @@ CREATE TABLE _prom_catalog.remote_commands(
     transactional BOOLEAN,
     command TEXT
 );
+GRANT ALL ON SEQUENCE _prom_catalog.remote_commands_seq_seq TO current_user;
 
 CREATE OR REPLACE PROCEDURE _prom_catalog.execute_everywhere(command_key text, command TEXT, transactional BOOLEAN = true)
 AS $func$

--- a/quick.Dockerfile
+++ b/quick.Dockerfile
@@ -9,4 +9,5 @@ ARG EXTENSION_VERSION
 COPY sql/promscale-${EXTENSION_VERSION}.sql /usr/local/share/postgresql/extension/promscale--${EXTENSION_VERSION}.sql
 # TODO (james): This probably needs to be extended to be created for all `upgradeable_from` in promscale.control
 COPY sql/promscale-${EXTENSION_VERSION}.sql /usr/local/share/postgresql/extension/promscale--0.0.0--${EXTENSION_VERSION}.sql
-
+# TODO (john): for now, we need the "takeover" script copied too since it's still not final
+COPY sql/promscale--0.0.0.sql /usr/local/share/postgresql/extension/promscale--0.0.0.sql

--- a/sql/promscale--0.0.0.sql
+++ b/sql/promscale--0.0.0.sql
@@ -431,8 +431,10 @@ BEGIN
     CREATE TABLE _ps_catalog.migration(
       name TEXT NOT NULL PRIMARY KEY
     , applied_at_version TEXT
+    , body TEXT
     , applied_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp()
     );
+    CREATE UNIQUE INDEX ON _ps_catalog.migration(name);
     PERFORM pg_catalog.pg_extension_config_dump('_ps_catalog.migration', '');
 
     -- Bring migrations table up to speed


### PR DESCRIPTION
Metric tables/views are created dynamically by extension-owned functions. These objects should be owned by the superuser (typically promscale). This makes them more secure and allows us to better control what can be done with/to these objects. Existing metric tables/views need to be discovered in the takeover script (0.0.0) and have their ownership altered to the superuser.

https://github.com/timescale/promscale_extension/issues/138