### PR TITLE
Remove SECURITY DEFINER from _prom_catalog.execute_everywhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,7 @@ docker-quick-build-12 docker-quick-build-13 docker-quick-build-14: ## A quick wa
 		--build-arg TIMESCALEDB_VERSION=$(TIMESCALEDB_VER) \
 		--build-arg PG_VERSION_TAG=$(PG_BUILD_VER) \
 		--build-arg EXTENSION_VERSION=$(EXT_VERSION) \
+		-t local/dev_promscale_extension:head-ts2-$(PG_BUILD_VER) \
 		-t $(IMAGE_NAME):$(EXT_VERSION)-$(TIMESCALEDB_VER)-$(PG_BUILD_VER) \
 		-t $(IMAGE_NAME):$(EXT_VERSION)-ts$(TIMESCALEDB_MAJOR)-$(PG_BUILD_VER) \
 		-t $(IMAGE_NAME):latest-ts$(TIMESCALEDB_MAJOR)-$(PG_BUILD_VER) \

--- a/migration/idempotent/001-base.sql
+++ b/migration/idempotent/001-base.sql
@@ -21,11 +21,7 @@ BEGIN
             RETURN;
     END;
 END
-$func$ LANGUAGE PLPGSQL
---security definer to add jobs as the logged-in user
-SECURITY DEFINER
---search path must be set for security definer
-SET search_path = pg_temp;
+$func$ LANGUAGE PLPGSQL;
 GRANT EXECUTE ON PROCEDURE _prom_catalog.execute_everywhere(text, text, boolean) TO prom_admin;
 
 CREATE OR REPLACE PROCEDURE _prom_catalog.update_execute_everywhere_entry(command_key text, command TEXT, transactional BOOLEAN = true)
@@ -37,11 +33,7 @@ BEGIN
         transactional=update_execute_everywhere_entry.transactional
     WHERE key = command_key;
 END
-$func$ LANGUAGE PLPGSQL
---security definer to add jobs as the logged-in user
-SECURITY DEFINER
---search path must be set for security definer
-SET search_path = pg_temp;
+$func$ LANGUAGE PLPGSQL;
 GRANT EXECUTE ON PROCEDURE _prom_catalog.update_execute_everywhere_entry(text, text, boolean) TO prom_admin;
 
 CREATE OR REPLACE FUNCTION _prom_catalog.get_default_chunk_interval()

--- a/migration/migration/002-utils.sql
+++ b/migration/migration/002-utils.sql
@@ -8,8 +8,6 @@ CREATE TABLE _prom_catalog.remote_commands(
     transactional BOOLEAN,
     command TEXT
 );
-GRANT ALL ON TABLE _prom_catalog.remote_commands to @extowner@;
-GRANT ALL ON SEQUENCE _prom_catalog.remote_commands_seq_seq to @extowner@;
 
 CREATE OR REPLACE PROCEDURE _prom_catalog.execute_everywhere(command_key text, command TEXT, transactional BOOLEAN = true)
 AS $func$
@@ -31,12 +29,7 @@ BEGIN
             RETURN;
     END;
 END
-$func$ LANGUAGE PLPGSQL
---security definer to add jobs as the logged-in user
-SECURITY DEFINER
---search path must be set for security definer
-SET search_path = pg_temp;
---redundant given schema settings but extra caution for security definers
+$func$ LANGUAGE PLPGSQL;
 REVOKE ALL ON PROCEDURE _prom_catalog.execute_everywhere(text, text, boolean) FROM PUBLIC;
 
 CREATE OR REPLACE PROCEDURE _prom_catalog.update_execute_everywhere_entry(command_key text, command TEXT, transactional BOOLEAN = true)
@@ -48,10 +41,5 @@ BEGIN
         transactional=update_execute_everywhere_entry.transactional
     WHERE key = command_key;
 END
-$func$ LANGUAGE PLPGSQL
---security definer to add jobs as the logged-in user
-SECURITY DEFINER
---search path must be set for security definer
-SET search_path = pg_temp;
---redundant given schema settings but extra caution for security definers
+$func$ LANGUAGE PLPGSQL;
 REVOKE ALL ON PROCEDURE _prom_catalog.update_execute_everywhere_entry(text, text, boolean) FROM PUBLIC;


### PR DESCRIPTION
The commands stored in the remote_commands table are executed by the extension/superuser. Making execute_everywhere security definer is a vulnerability. Remove the security definer.

Also, adjusted the "quick" targets in the Makefile so that they tag the image with all the same tags the "non-quick" targets do.