### PR TITLE
Fix docker image build

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -53,8 +53,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           build-args: |
-            PG_VER=pg${{ matrix.pgversion }}
-            TIMESCALEDB_VER=${{ matrix.tsversion }}
+            PG_VERSION=${{ matrix.pgversion }}
+            TIMESCALEDB_VERSION=${{ steps.metadata.outputs.tsmajor }}
           context: .
           file: ${{matrix.base}}.Dockerfile
           push: true

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -20,12 +20,18 @@ jobs:
         pgversion:
         - 14
         - 13
-        - 12
         tsversion:
         - 2.6.0
         base:
         - ha
         - alpine
+        include:
+        - pgversion: 12
+          tsversion: 2.5.0
+          base: ha
+        - pgversion: 12
+          tsversion: 2.5.0
+          base: alpine
     steps:
       - uses: actions/checkout@v2
 
@@ -42,10 +48,12 @@ jobs:
       - name: Gather metadata
         id: metadata
         run: |
-          tsmajor=$(echo ${{matrix.tsversion}} | cut -d. -f1)
+          tsmajor=$(echo ${{ matrix.tsversion }} | cut -d. -f1)
+          tsmajmin=$(echo ${{ matrix.tsversion }} | cut -d. -f1,2)
           branch_name=$(echo ${{github.head_ref || github.ref_name}} | sed 's#/#-#')
           build_type_suffix=$(echo "-${{matrix.base}}" | sed 's/-ha//')
           echo "::set-output name=tsmajor::${tsmajor}"
+          echo "::set-output name=tsmajmin::${tsmajmin}"
           echo "::set-output name=branch_name::${branch_name}"
           echo "::set-output name=build_type_suffix::${build_type_suffix}"
 
@@ -54,14 +62,19 @@ jobs:
         with:
           build-args: |
             PG_VERSION=${{ matrix.pgversion }}
-            TIMESCALEDB_VERSION=${{ steps.metadata.outputs.tsmajor }}
+            TIMESCALEDB_VERSION_FULL=${{ matrix.tsversion }}
+            TIMESCALEDB_VERSION_MAJOR=${{ steps.metadata.outputs.tsmajor }}
+            TIMESCALEDB_VERSION_MAJMIN=${{ steps.metadata.outputs.tsmajmin }}
           context: .
           file: ${{matrix.base}}.Dockerfile
           push: true
-          tags: ghcr.io/timescale/dev_promscale_extension:${{steps.metadata.outputs.branch_name}}-ts${{steps.metadata.outputs.tsmajor}}-pg${{matrix.pgversion}}${{steps.metadata.outputs.build_type_suffix}}
+          tags: |
+            ghcr.io/timescale/dev_promscale_extension:${{steps.metadata.outputs.branch_name}}-ts${{matrix.tsversion}}-pg${{matrix.pgversion}}${{steps.metadata.outputs.build_type_suffix}}
+            ghcr.io/timescale/dev_promscale_extension:${{steps.metadata.outputs.branch_name}}-ts${{steps.metadata.outputs.tsmajor}}-pg${{matrix.pgversion}}${{steps.metadata.outputs.build_type_suffix}}
+            ghcr.io/timescale/dev_promscale_extension:${{steps.metadata.outputs.branch_name}}-ts${{steps.metadata.outputs.tsmajmin}}-pg${{matrix.pgversion}}${{steps.metadata.outputs.build_type_suffix}}
           # Note: it's necessary to use a different cache scope to achieve caching for both Ubuntu and Alpine images
-          cache-from: type=gha,scope=${{matrix.base}}
-          cache-to: type=gha,mode=max,scope=${{matrix.base}}
+          cache-from: type=gha,scope=${{matrix.base}}-${{matrix.pgversion}}-${{matrix.tsversion}}
+          cache-to: type=gha,mode=max,scope=${{matrix.base}}-${{matrix.pgversion}}-${{matrix.tsversion}}
 
   # This allows us to set a single job which must pass in GitHub's branch protection rules,
   # otherwise we have to keep updating them as we add or remove postgres versions etc.

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -1,6 +1,6 @@
 ARG PG_VERSION=14
-ARG TIMESCALEDB_VERSION=2
-FROM timescale/timescaledb:${TIMESCALEDB_VERSION}-pg${PG_VERSION} as builder
+ARG TIMESCALEDB_VERSION_FULL=2.6.0
+FROM timescale/timescaledb:${TIMESCALEDB_VERSION_FULL}-pg${PG_VERSION} as builder
 
 MAINTAINER Timescale https://www.timescale.com
 ARG RUST_VERSION=1.58.1
@@ -64,7 +64,7 @@ COPY templates/ /build/promscale/templates/
 RUN --mount=type=cache,uid=70,gid=70,target=/build/promscale/.cargo/registry \
     make package
 
-FROM timescale/timescaledb:${TIMESCALEDB_VERSION}-pg${PG_VERSION} as pgextwlist-builder
+FROM timescale/timescaledb:${TIMESCALEDB_VERSION_FULL}-pg${PG_VERSION} as pgextwlist-builder
 
 RUN \
     apk add --no-cache --virtual .build-deps \
@@ -82,7 +82,7 @@ RUN \
 
 # COPY over the new files to the image. Done as a seperate stage so we don't
 # ship the build tools.
-FROM timescale/timescaledb:${TIMESCALEDB_VERSION}-pg${PG_VERSION}
+FROM timescale/timescaledb:${TIMESCALEDB_VERSION_FULL}-pg${PG_VERSION}
 ARG PG_VERSION
 
 COPY --from=builder /build/promscale/target/release/promscale-pg${PG_VERSION}/usr/local/lib/postgresql /usr/local/lib/postgresql

--- a/ha.Dockerfile
+++ b/ha.Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1.3-labs
 ARG PG_VERSION=14
+ARG TIMESCALEDB_VERSION=2
 FROM ubuntu:21.10 as builder
 ARG PG_VERSION
 
@@ -52,7 +53,7 @@ COPY --chown=postgres:postgres templates/ /build/promscale/templates/
 
 RUN make package
 
-FROM timescale/timescaledb-ha:pg${PG_VERSION}-latest
+FROM timescale/timescaledb-ha:pg${PG_VERSION}-ts${TIMESCALEDB_VERSION}-latest
 ARG PG_VERSION
 COPY --from=builder --chown=root:postgres /build/promscale/target/release/promscale-pg${PG_VERSION}/usr/lib/postgresql /usr/lib/postgresql
 COPY --from=builder --chown=root:postgres /build/promscale/target/release/promscale-pg${PG_VERSION}/usr/share/postgresql /usr/share/postgresql

--- a/ha.Dockerfile
+++ b/ha.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3-labs
 ARG PG_VERSION=14
-ARG TIMESCALEDB_VERSION=2
+ARG TIMESCALEDB_VERSION_MAJMIN=2.6
 FROM ubuntu:21.10 as builder
 ARG PG_VERSION
 
@@ -53,7 +53,7 @@ COPY --chown=postgres:postgres templates/ /build/promscale/templates/
 
 RUN make package
 
-FROM timescale/timescaledb-ha:pg${PG_VERSION}-ts${TIMESCALEDB_VERSION}-latest
+FROM timescale/timescaledb-ha:pg${PG_VERSION}-ts${TIMESCALEDB_VERSION_MAJMIN}-latest
 ARG PG_VERSION
 COPY --from=builder --chown=root:postgres /build/promscale/target/release/promscale-pg${PG_VERSION}/usr/lib/postgresql /usr/lib/postgresql
 COPY --from=builder --chown=root:postgres /build/promscale/target/release/promscale-pg${PG_VERSION}/usr/share/postgresql /usr/share/postgresql

--- a/quick.Dockerfile
+++ b/quick.Dockerfile
@@ -1,9 +1,9 @@
 # This dockerfile is a helper for quick iteration on the extension SQL
 # To use, first run: `make docker-image-14`, then edit SQL and run `make docker-quick-14`
-ARG PG_VERSION_TAG
+ARG PG_VERSION
 ARG TIMESCALEDB_VERSION
 ARG EXTENSION_VERSION
-FROM timescaledev/promscale-extension:${EXTENSION_VERSION}-${TIMESCALEDB_VERSION}-${PG_VERSION_TAG}
+FROM timescaledev/promscale-extension:${EXTENSION_VERSION}-${TIMESCALEDB_VERSION}-pg${PG_VERSION}
 
 ARG EXTENSION_VERSION
 COPY sql/promscale-${EXTENSION_VERSION}.sql /usr/local/share/postgresql/extension/promscale--${EXTENSION_VERSION}.sql

--- a/quick.Dockerfile
+++ b/quick.Dockerfile
@@ -1,9 +1,9 @@
 # This dockerfile is a helper for quick iteration on the extension SQL
 # To use, first run: `make docker-image-14`, then edit SQL and run `make docker-quick-14`
 ARG PG_VERSION
-ARG TIMESCALEDB_VERSION
+ARG TIMESCALEDB_VERSION_MAJOR
 ARG EXTENSION_VERSION
-FROM timescaledev/promscale-extension:${EXTENSION_VERSION}-${TIMESCALEDB_VERSION}-pg${PG_VERSION}
+FROM ghcr.io/timescale/dev_promscale_extension:${EXTENSION_VERSION}-ts${TIMESCALEDB_VERSION_MAJOR}-pg${PG_VERSION}
 
 ARG EXTENSION_VERSION
 COPY sql/promscale-${EXTENSION_VERSION}.sql /usr/local/share/postgresql/extension/promscale--${EXTENSION_VERSION}.sql


### PR DESCRIPTION
The environment variables used to control which version of postgres to
build for were not aligned between the alpine and ha images, and not
aligned with the docker workflow. This meant that all images were built
against pg14, but tagged with different PG versions.