### PR TITLE
Custom type for trace_id

### DIFF
--- a/e2e/tests/snapshots/golden_tests__golden_test_testdata_info_view_sql.snap
+++ b/e2e/tests/snapshots/golden_tests__golden_test_testdata_info_view_sql.snap
@@ -46,13 +46,13 @@ SELECT id , metric_name , table_name, retention_period, chunk_interval > interva
 SELECT public.compress_chunk(public.show_chunks('prom_data.cpu_usage'));
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_10_1_chunk
+ _timescaledb_internal._hyper_13_1_chunk
 (1 row)
 
 SELECT public.compress_chunk(public.show_chunks('prom_data.cpu_total'));
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_12_2_chunk
+ _timescaledb_internal._hyper_15_2_chunk
 (1 row)
 
 -- fetch stats with compressed chunks

--- a/e2e/tests/snapshots/golden_tests__golden_test_testdata_support_sql.snap
+++ b/e2e/tests/snapshots/golden_tests__golden_test_testdata_support_sql.snap
@@ -50,7 +50,7 @@ EXPLAIN (costs off) SELECT time, value, jsonb(labels), val(namespace_id) FROM cp
                Sort Key: data."time", data.series_id
                ->  Hash Join
                      Hash Cond: (data.series_id = series.id)
-                     ->  Seq Scan on _hyper_10_1_chunk data
+                     ->  Seq Scan on _hyper_13_1_chunk data
                      ->  Hash
                            ->  Seq Scan on cpu_usage series
                                  Filter: (NOT ((labels)::integer[] && ($0)::integer[]))

--- a/migration/idempotent/009-tracing-views.sql
+++ b/migration/idempotent/009-tracing-views.sql
@@ -58,7 +58,7 @@ SELECT
     s.status_code,
     s.status_message
 FROM _ps_trace.event e
-LEFT OUTER JOIN _ps_trace.span s on (e.span_id = s.span_id AND e.trace_id = s.trace_id)
+LEFT OUTER JOIN _ps_trace.span s on (e.span_id = s.span_id AND e.trace_id OPERATOR(ps_trace.=) s.trace_id)
 LEFT OUTER JOIN _ps_trace.operation o ON (s.operation_id = o.id)
 LEFT OUTER JOIN _ps_trace.tag t ON (o.service_name_id = t.id AND t.key = 'service.name') -- partition elimination
 ;
@@ -119,7 +119,7 @@ SELECT
     k.tags as link_tags,
     k.dropped_tags_count as dropped_link_tags_count
 FROM _ps_trace.link k
-LEFT OUTER JOIN ps_trace.span s1 on (k.span_id = s1.span_id and k.trace_id = s1.trace_id)
-LEFT OUTER JOIN ps_trace.span s2 on (k.linked_span_id = s2.span_id and k.linked_trace_id = s2.trace_id)
+LEFT OUTER JOIN ps_trace.span s1 on (k.span_id = s1.span_id and k.trace_id OPERATOR(ps_trace.=) s1.trace_id)
+LEFT OUTER JOIN ps_trace.span s2 on (k.linked_span_id = s2.span_id and k.linked_trace_id OPERATOR(ps_trace.=) s2.trace_id)
 ;
 GRANT SELECT ON ps_trace.link to prom_reader;

--- a/migration/idempotent/014-trace-id-functions.sql
+++ b/migration/idempotent/014-trace-id-functions.sql
@@ -1,0 +1,84 @@
+-- functions for trace_id custom type which is a wrapper around PG UUID type
+CREATE OR REPLACE FUNCTION _ps_trace.trace_id_in(cstring)
+RETURNS ps_trace.trace_id
+LANGUAGE internal
+IMMUTABLE PARALLEL SAFE STRICT
+AS $function$uuid_in$function$;
+GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_in(cstring) TO prom_reader;
+
+CREATE OR REPLACE FUNCTION _ps_trace.trace_id_out(ps_trace.trace_id)
+RETURNS cstring
+LANGUAGE internal
+IMMUTABLE PARALLEL SAFE STRICT
+AS $function$uuid_out$function$;
+GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_out(ps_trace.trace_id) TO prom_reader;
+
+CREATE OR REPLACE FUNCTION _ps_trace.trace_id_send(ps_trace.trace_id)
+RETURNS bytea
+LANGUAGE internal
+IMMUTABLE PARALLEL SAFE STRICT
+AS $function$uuid_send$function$;
+GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_send(ps_trace.trace_id) TO prom_reader;
+
+CREATE OR REPLACE FUNCTION _ps_trace.trace_id_recv(internal)
+RETURNS ps_trace.trace_id
+LANGUAGE internal
+IMMUTABLE PARALLEL SAFE STRICT
+AS $function$uuid_recv$function$;
+GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_recv(internal) TO prom_reader;
+
+CREATE OR REPLACE FUNCTION _ps_trace.trace_id_ne(ps_trace.trace_id, ps_trace.trace_id)
+RETURNS bool
+LANGUAGE internal
+IMMUTABLE PARALLEL SAFE STRICT
+AS $function$uuid_ne$function$;
+GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_ne(ps_trace.trace_id, ps_trace.trace_id) TO prom_reader;
+
+CREATE OR REPLACE FUNCTION _ps_trace.trace_id_eq(ps_trace.trace_id, ps_trace.trace_id)
+RETURNS bool
+LANGUAGE internal
+IMMUTABLE PARALLEL SAFE STRICT
+AS $function$uuid_eq$function$;
+GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_eq(ps_trace.trace_id, ps_trace.trace_id) TO prom_reader;
+
+CREATE OR REPLACE FUNCTION _ps_trace.trace_id_ge(ps_trace.trace_id, ps_trace.trace_id)
+RETURNS bool
+LANGUAGE internal
+IMMUTABLE PARALLEL SAFE STRICT
+AS $function$uuid_ge$function$;
+GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_ge(ps_trace.trace_id, ps_trace.trace_id) TO prom_reader;
+
+CREATE OR REPLACE FUNCTION _ps_trace.trace_id_le(ps_trace.trace_id, ps_trace.trace_id)
+RETURNS bool
+LANGUAGE internal
+IMMUTABLE PARALLEL SAFE STRICT
+AS $function$uuid_le$function$;
+GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_le(ps_trace.trace_id, ps_trace.trace_id) TO prom_reader;
+
+CREATE OR REPLACE FUNCTION _ps_trace.trace_id_gt(ps_trace.trace_id, ps_trace.trace_id)
+RETURNS bool
+LANGUAGE internal
+IMMUTABLE PARALLEL SAFE STRICT
+AS $function$uuid_gt$function$;
+GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_gt(ps_trace.trace_id, ps_trace.trace_id) TO prom_reader;
+
+CREATE OR REPLACE FUNCTION _ps_trace.trace_id_lt(ps_trace.trace_id, ps_trace.trace_id)
+RETURNS bool
+LANGUAGE internal
+IMMUTABLE PARALLEL SAFE STRICT
+AS $function$uuid_lt$function$;
+GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_lt(ps_trace.trace_id, ps_trace.trace_id) TO prom_reader;
+
+CREATE OR REPLACE FUNCTION _ps_trace.trace_id_cmp(ps_trace.trace_id, ps_trace.trace_id)
+RETURNS int
+LANGUAGE internal
+IMMUTABLE PARALLEL SAFE STRICT
+AS $function$uuid_cmp$function$;
+GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_cmp(ps_trace.trace_id, ps_trace.trace_id) TO prom_reader;
+
+CREATE OR REPLACE FUNCTION _ps_trace.trace_id_hash(ps_trace.trace_id)
+RETURNS int
+LANGUAGE internal
+IMMUTABLE PARALLEL SAFE STRICT
+AS $function$uuid_hash$function$;
+GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_hash(ps_trace.trace_id) TO prom_reader;


### PR DESCRIPTION
Using domain type didn't play nicely with TimescaleDB planner: some pushdowns
were not working well on compressed data (https://github.com/timescale/timescaledb/issues/4179). 
Here we add custom type that wrapps around PG UUID type.
The idea is to later on customize this type - eg. string representation.
Since trace_id is used for data partitioning this change is not backwards
compatible.

Closes https://github.com/timescale/promscale_extension/issues/134