### PR TITLE
Add DROP EXTENSION to test

### DIFF
--- a/e2e/tests/test.rs
+++ b/e2e/tests/test.rs
@@ -4,7 +4,7 @@ use testcontainers::clients;
 mod common;
 
 #[test]
-fn create_promscale_extension() {
+fn create_drop_promscale_extension() {
     let _ = pretty_env_logger::try_init();
 
     let docker = clients::Cli::default();
@@ -12,6 +12,9 @@ fn create_promscale_extension() {
 
     let mut client = common::connect(&node);
     let result = client.simple_query("CREATE EXTENSION promscale;").unwrap();
+    assert_eq!(result.len(), 1);
+
+    let result = client.simple_query("DROP EXTENSION promscale;").unwrap();
 
     assert_eq!(result.len(), 1);
 }


### PR DESCRIPTION
Before timescaledb 2.6.1 it was not possible to drop the extension. Now
that we've bumped to 2.6.1 we can add a test case.

Fixes #95