### PR TITLE
Make trusted extension optional (for PG12)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,8 @@ jobs:
       matrix:
         postgres:
         - version: "14"
+        - version: "13"
+        - version: "12"
     steps:
       - uses: actions/checkout@v2
       - name: Install latest nightly
@@ -37,7 +39,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.pgx
-          key: dot-pgx
+          key: dot-pgx-${{ matrix.postgres.version }}-cargo-${{ hashFiles('**/Cargo.*') }}
 
       - name: Initialize pgx
         if: ${{ steps.cache-pgx.outputs.cache-hit != 'true' }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -20,18 +20,12 @@ jobs:
         pgversion:
         - 14
         - 13
+        - 12
         tsversion:
         - 2.6.0
         base:
         - ha
         - alpine
-        include:
-        - pgversion: 12
-          tsversion: 2.5.0
-          base: ha
-        - pgversion: 12
-          tsversion: 2.5.0
-          base: alpine
     steps:
       - uses: actions/checkout@v2
 
@@ -78,8 +72,6 @@ jobs:
 
       - name: Run end-to-end tests
         uses: actions-rs/cargo@v1
-        # Note: we skip pg12 because the docker images don't work currently. See https://github.com/timescale/promscale_extension/issues/109.
-        if: ${{ matrix.pgversion != 12 }}
         with:
           command: test
           args: -p e2e

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/*.deb
 dist/*.tar
 target
 hand-written-migration.sql
+/promscale.control

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -54,14 +54,14 @@ RUN --mount=type=cache,uid=70,gid=70,target=/build/promscale/.cargo/registry \
     make dependencies
 
 # Build extension
-COPY Cargo.* /build/promscale/
-COPY promscale.control Makefile build.rs create-upgrade-symlinks.sh /build/promscale/
-COPY .cargo/ /build/promscale/.cargo/
-COPY e2e/ /build/promscale/e2e/
-COPY src/ /build/promscale/src/
-COPY sql/*.sql /build/promscale/sql/
-COPY migration/ /build/promscale/migration
-COPY templates/ /build/promscale/templates/
+COPY --chown=postgres:postgres Cargo.* /build/promscale/
+COPY --chown=postgres:postgres Makefile build.rs create-upgrade-symlinks.sh /build/promscale/
+COPY --chown=postgres:postgres .cargo/ /build/promscale/.cargo/
+COPY --chown=postgres:postgres e2e/ /build/promscale/e2e/
+COPY --chown=postgres:postgres src/ /build/promscale/src/
+COPY --chown=postgres:postgres sql/*.sql /build/promscale/sql/
+COPY --chown=postgres:postgres migration/ /build/promscale/migration
+COPY --chown=postgres:postgres templates/ /build/promscale/templates/
 
 RUN --mount=type=cache,uid=70,gid=70,target=/build/promscale/.cargo/registry \
     make package

--- a/migration/migration/003-users.sql
+++ b/migration/migration/003-users.sql
@@ -65,14 +65,21 @@ CALL _prom_catalog.execute_everywhere('grant_prom_reader_prom_writer',$ee$
     $$;
 $ee$);
 
-CALL _prom_catalog.execute_everywhere('grant_all_roles_to_extowner',$ee$
+CALL _prom_catalog.execute_everywhere('grant_all_roles_to_extowner',
+format(
+$ee$
     DO $$
     BEGIN
-        GRANT prom_reader TO @extowner@ WITH ADMIN OPTION;
-        GRANT prom_writer TO @extowner@ WITH ADMIN OPTION;
-        GRANT prom_maintenance TO @extowner@ WITH ADMIN OPTION;
-        GRANT prom_modifier TO @extowner@ WITH ADMIN OPTION;
-        GRANT prom_admin TO @extowner@ WITH ADMIN OPTION;
+        GRANT prom_reader TO %1$s WITH ADMIN OPTION;
+        GRANT prom_writer TO %1$s WITH ADMIN OPTION;
+        GRANT prom_maintenance TO %1$s WITH ADMIN OPTION;
+        GRANT prom_modifier TO %1$s WITH ADMIN OPTION;
+        GRANT prom_admin TO %1$s WITH ADMIN OPTION;
     END
     $$;
-$ee$);
+$ee$, CASE
+        WHEN current_setting('server_version_num')::INT < 130000 THEN quote_ident(current_user)
+        ELSE '@extowner@' -- proper quotation is handled by the pg itself
+      END
+)
+);

--- a/sql/promscale--0.0.0.sql
+++ b/sql/promscale--0.0.0.sql
@@ -454,19 +454,23 @@ END
 $block$
 ;
 
+-- Duplicates a section of 003-users
 CALL _prom_catalog.execute_everywhere('grant_all_roles_to_extowner',
 format(
 $ee$
     DO $$
     BEGIN
-        GRANT prom_reader TO %1$I WITH ADMIN OPTION;
-        GRANT prom_writer TO %1$I WITH ADMIN OPTION;
-        GRANT prom_maintenance TO %1$I WITH ADMIN OPTION;
-        GRANT prom_modifier TO %1$I WITH ADMIN OPTION;
-        GRANT prom_admin TO %1$I WITH ADMIN OPTION;
+        GRANT prom_reader TO %1$s WITH ADMIN OPTION;
+        GRANT prom_writer TO %1$s WITH ADMIN OPTION;
+        GRANT prom_maintenance TO %1$s WITH ADMIN OPTION;
+        GRANT prom_modifier TO %1$s WITH ADMIN OPTION;
+        GRANT prom_admin TO %1$s WITH ADMIN OPTION;
     END
     $$;
-$ee$, '@extowner@'
+$ee$, CASE
+        WHEN current_setting('server_version_num')::INT < 130000 THEN quote_ident(current_user)
+        ELSE '@extowner@' -- proper quotation is handled by the pg itself
+      END
 )
 );
 

--- a/templates/promscale.control
+++ b/templates/promscale.control
@@ -5,7 +5,9 @@ module_pathname = '$libdir/promscale'
 relocatable = false
 schema = _prom_ext
 superuser = true
+{%if !is_pg_12 -%}
 trusted = true
+{%-endif%}
 # comma-separated list of previous versions this version can be upgraded from
 # directly. This is used to generate upgrade scripts.
 # upgradeable_from = '0.0.0'


### PR DESCRIPTION
- `promscale.control` is generated via `build.rs` based on pg version
- CI tests and image builds are re-enabled on pg12
- Migrations, involving `@extowner@`, had to be altered to be compatible with pg12.
- Some tests had to be generalized to pass on both pg14 and pg12

Addresses #109 

Upgrade and e2e tests pass https://github.com/timescale/promscale/pull/1287