### PR TITLE
Optimize maintenance jobs by using TS catalog tables

### DIFF
--- a/migration/idempotent/001-base.sql
+++ b/migration/idempotent/001-base.sql
@@ -2899,13 +2899,14 @@ BEGIN
         chunk_full_name text;
     BEGIN
         SELECT
-            format('%I.%I', chunk_schema, chunk_name)
+            format('%I.%I', ch.schema_name, ch.table_name)
         INTO chunk_full_name
-        FROM timescaledb_information.chunks
-        WHERE hypertable_schema = 'prom_data'
-          AND hypertable_name = metric_table
-          AND chunk_schema = chunk_schema_name
-          AND chunk_name = chunk_table_name;
+        FROM _timescaledb_catalog.chunk ch
+            JOIN _timescaledb_catalog.hypertable ht ON ht.id = ch.hypertable_id
+        WHERE ht.schema_name = 'prom_data'
+          AND ht.table_name = metric_table
+          AND ch.schema_name = chunk_schema_name
+          AND ch.table_name = chunk_table_name;
 
         PERFORM public.compress_chunk(chunk_full_name, if_not_compressed => true);
     END;
@@ -2927,15 +2928,20 @@ BEGIN
     BEGIN
         FOR chunk_schema_name, chunk_table_name, chunk_range_end, chunk_num IN
             SELECT
-                chunk_schema,
-                chunk_name,
-                range_end,
-                row_number() OVER (ORDER BY range_end DESC)
-            FROM timescaledb_information.chunks
-            WHERE hypertable_schema = 'prom_data'
-                AND hypertable_name = metric_table
-                AND NOT is_compressed
-            ORDER BY range_end ASC
+                ch.schema_name as chunk_schema,
+                ch.table_name AS chunk_name,
+                _timescaledb_internal.to_timestamp(dimsl.range_end) as range_end,
+                row_number() OVER (ORDER BY dimsl.range_end DESC)
+            FROM _timescaledb_catalog.chunk ch
+                JOIN _timescaledb_catalog.hypertable ht ON ht.id = ch.hypertable_id
+                JOIN _timescaledb_catalog.chunk_constraint chcons ON ch.id = chcons.chunk_id
+                JOIN _timescaledb_catalog.dimension dim ON ch.hypertable_id = dim.hypertable_id
+                JOIN _timescaledb_catalog.dimension_slice dimsl ON dim.id = dimsl.dimension_id AND chcons.dimension_slice_id = dimsl.id
+            WHERE ch.dropped IS FALSE
+                AND (ch.status & 1) != 1 -- only check for uncompressed chunks
+                AND ht.schema_name = 'prom_data'
+                AND ht.table_name = metric_table
+            ORDER BY 3 ASC
         LOOP
             CONTINUE WHEN chunk_num <= 1 OR chunk_range_end > compress_before;
             PERFORM _prom_catalog.compress_chunk_for_metric(metric_table, chunk_schema_name, chunk_table_name);


### PR DESCRIPTION
Currently, we are using `timescaledb_information.chunks` view which can be
slow for systems that have a lot of metrics. By switching to using catalog
tables directly, we can improve the performance of queries used there.