### PR TITLE
Use correct approximate row count function

### DIFF
--- a/migration/idempotent/001-base.sql
+++ b/migration/idempotent/001-base.sql
@@ -688,7 +688,7 @@ BEGIN
                 FROM _timescaledb_catalog.hypertable
                 WHERE format('%I.%I', schema_name, table_name)::regclass=table_name_input)
         THEN
-                RETURN (SELECT row_estimate FROM hypertable_approximate_row_count(table_name_input));
+                RETURN (SELECT public.approximate_row_count(table_name_input));
         END IF;
         RETURN (SELECT reltuples::BIGINT FROM pg_class WHERE oid=table_name_input);
     END IF;


### PR DESCRIPTION
`hypertable_approximate_row_count` was dropped in Timescale 2.0 [1].

[1]: https://github.com/timescale/timescaledb/blob/332dffeebc72cf16afbde802e2f19aead9bd7836/sql/updates/1.7.5--2.0.0-rc1.sql#L13