### PR TITLE
Ensure that _prom_ext schema created safely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ dist/*.deb
 dist/*.tar
 target
 hand-written-migration.sql
+bootstrap.sql
 /promscale.control

--- a/migration/README.md
+++ b/migration/README.md
@@ -42,6 +42,7 @@ The Promscale extension's approach to securing its SQL consists of the following
 4. Explicitly schema-qualify all objects and operators in functions without `SET search_path = pg_catalog`
 5. Use `SET LOCAL search_path = pg_catalog;` on procedures which perform transaction control
 6. Explicitly `REVOKE ALL ... FROM PUBLIC` for `SECURITY DEFINER` functions and procedures
+7. Use `SET LOCAL search_path = pg_catalog;` at the beginning of the installation script
 
 Step 1. ensures that the bootstrap superuser (on Postgres 13 and 14) or the
 installing superuser (on postgres 12) is the owner of all schemas. If a schema
@@ -70,5 +71,8 @@ not use it for them.
 
 Step 6. is necessary, as by default functions are executable by `PUBLIC`, which
 is undesirable for `SECURITY DEFINER`.
+
+Step 7. ensures that top-level SQL which is executed during the extension
+install is also fully schema-qualified.
 
 [1]: https://www.postgresql.org/docs/current/extend-extensions.html#EXTEND-EXTENSIONS-SECURITY

--- a/migration/bootstrap/000-migration-table.sql
+++ b/migration/bootstrap/000-migration-table.sql
@@ -1,15 +1,12 @@
--- migration-table.sql
+-- 000-migration-table.sql
+SET LOCAL search_path = pg_catalog;
 DO
 $migration_table$
     DECLARE
         _current_user_id oid = NULL;
         _ps_catalog_schema_owner_id oid = NULL;
         _migration_table_owner_id oid = NULL;
-        _old_search_path text;
     BEGIN
-        EXECUTE 'SHOW search_path' INTO STRICT _old_search_path;
-        SET search_path TO pg_catalog;
-
         SELECT pg_user.usesysid
         INTO STRICT _current_user_id
         FROM pg_catalog.pg_user
@@ -56,7 +53,5 @@ $migration_table$
             );
             CREATE UNIQUE INDEX ON _ps_catalog.migration(name);
         END IF;
-
-        EXECUTE format('SET search_path TO %s', _old_search_path);
     END;
 $migration_table$;

--- a/migration/bootstrap/001-create-ext-schema.sql
+++ b/migration/bootstrap/001-create-ext-schema.sql
@@ -1,0 +1,2 @@
+--this schema is needed for the pgx-rendered SQL and is thus rendered separately from the other schemas
+CREATE SCHEMA _prom_ext;

--- a/sql/promscale--0.0.0.sql
+++ b/sql/promscale--0.0.0.sql
@@ -330,10 +330,7 @@ BEGIN
         ) x(objtype, objname)
     )
     LOOP
-        -- extension is installed into _prom_ext schema. thus cannot add it to the extension
-        IF NOT (_rec.objtype = 'SCHEMA' AND _rec.objname = '_prom_ext') THEN
-            EXECUTE format('ALTER EXTENSION promscale ADD %s %s', _rec.objtype, _rec.objname);
-        END IF;
+        EXECUTE format('ALTER EXTENSION promscale ADD %s %s', _rec.objtype, _rec.objname);
         EXECUTE format('ALTER %s %s OWNER TO %I', _rec.objtype, _rec.objname, current_user);
 
         IF _rec.objtype = 'TABLE' THEN
@@ -435,6 +432,7 @@ BEGIN
     -- Bring migrations table up to speed
     INSERT INTO _ps_catalog.migration (name, applied_at_version)
     VALUES
+        ('001-create-ext-schema.sql'      , '0.0.0'),
         ('001-extension.sql'              , '0.0.0'),
         ('002-utils.sql'                  , '0.0.0'),
         ('003-users.sql'                  , '0.0.0'),

--- a/src/aggregates/gapfill_delta.rs
+++ b/src/aggregates/gapfill_delta.rs
@@ -1,189 +1,197 @@
-use crate::aggregates::{Microseconds, Milliseconds, STALE_NAN, USECS_PER_MS, USECS_PER_SEC};
-use crate::palloc::{Inner, InternalAsValue};
 use pgx::*;
-use serde::{Deserialize, Serialize};
-use std::collections::VecDeque;
 
-#[pg_extern(immutable, parallel_safe)]
-pub fn prom_extrapolate_final(state: Internal) -> Option<Vec<Option<f64>>> {
-    prom_extrapolate_final_inner(unsafe { state.to_inner() })
-}
-pub fn prom_extrapolate_final_inner(
-    state: Option<Inner<GapfillDeltaTransition>>,
-) -> Option<Vec<Option<f64>>> {
-    state.map(|mut s| s.as_vec())
-}
+#[pg_schema]
+pub mod _prom_ext {
+    use crate::aggregates::{Microseconds, Milliseconds, STALE_NAN, USECS_PER_MS, USECS_PER_SEC};
+    use crate::palloc::{Inner, InternalAsValue};
+    use pgx::*;
+    use serde::{Deserialize, Serialize};
+    use std::collections::VecDeque;
 
-/// Backwards compatibility
-#[no_mangle]
-pub extern "C" fn pg_finfo_gapfill_delta_final() -> &'static pg_sys::Pg_finfo_record {
-    const V1_API: pg_sys::Pg_finfo_record = pg_sys::Pg_finfo_record { api_version: 1 };
-    &V1_API
-}
+    #[pg_extern(immutable, parallel_safe)]
+    pub fn prom_extrapolate_final(state: Internal) -> Option<Vec<Option<f64>>> {
+        prom_extrapolate_final_inner(unsafe { state.to_inner() })
+    }
 
-#[no_mangle]
-unsafe extern "C" fn gapfill_delta_final(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
-    prom_extrapolate_final_wrapper(fcinfo)
-}
+    pub fn prom_extrapolate_final_inner(
+        state: Option<Inner<GapfillDeltaTransition>>,
+    ) -> Option<Vec<Option<f64>>> {
+        state.map(|mut s| s.as_vec())
+    }
 
-#[derive(Serialize, Deserialize, PostgresType, Debug)]
-#[pgx(sql = false)]
-pub struct GapfillDeltaTransition {
-    window: VecDeque<(pg_sys::TimestampTz, f64)>,
-    // a Datum for each index in the array, 0 by convention if the value is NULL
-    deltas: Vec<Option<f64>>,
-    current_window_max: pg_sys::TimestampTz,
-    current_window_min: pg_sys::TimestampTz,
-    step_size: Microseconds,
-    range: Microseconds,
-    greatest_time: pg_sys::TimestampTz,
-    is_counter: bool,
-    is_rate: bool,
-}
+    /// Backwards compatibility
+    #[no_mangle]
+    pub extern "C" fn pg_finfo_gapfill_delta_final() -> &'static pg_sys::Pg_finfo_record {
+        const V1_API: pg_sys::Pg_finfo_record = pg_sys::Pg_finfo_record { api_version: 1 };
+        &V1_API
+    }
 
-impl GapfillDeltaTransition {
-    pub fn new(
-        lowest_time: pg_sys::TimestampTz,
+    #[no_mangle]
+    unsafe extern "C" fn gapfill_delta_final(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+        prom_extrapolate_final_wrapper(fcinfo)
+    }
+
+    #[derive(Serialize, Deserialize, PostgresType, Debug)]
+    #[pgx(sql = false)]
+    pub struct GapfillDeltaTransition {
+        window: VecDeque<(pg_sys::TimestampTz, f64)>,
+        // a Datum for each index in the array, 0 by convention if the value is NULL
+        deltas: Vec<Option<f64>>,
+        current_window_max: pg_sys::TimestampTz,
+        current_window_min: pg_sys::TimestampTz,
+        step_size: Microseconds,
+        range: Microseconds,
         greatest_time: pg_sys::TimestampTz,
-        range: Milliseconds,
-        step_size: Milliseconds,
         is_counter: bool,
         is_rate: bool,
-    ) -> Self {
-        let mut expected_deltas = (greatest_time - lowest_time) / (step_size * USECS_PER_MS);
-        if (greatest_time - lowest_time) % (step_size * USECS_PER_MS) != 0 {
-            expected_deltas += 1
-        }
-        GapfillDeltaTransition {
-            window: VecDeque::default(),
-            deltas: Vec::with_capacity(expected_deltas as usize),
-            current_window_max: lowest_time + range * USECS_PER_MS,
-            current_window_min: lowest_time,
-            step_size: step_size * USECS_PER_MS,
-            range: range * USECS_PER_MS,
-            greatest_time,
-            is_counter,
-            is_rate,
-        }
     }
 
-    pub(crate) fn add_data_point(&mut self, time: pg_sys::TimestampTz, val: f64) {
-        // skip stale NaNs
-        if val.to_bits() == STALE_NAN {
-            return;
-        };
-
-        while !self.in_current_window(time) {
-            self.flush_current_window()
+    impl GapfillDeltaTransition {
+        pub fn new(
+            lowest_time: pg_sys::TimestampTz,
+            greatest_time: pg_sys::TimestampTz,
+            range: Milliseconds,
+            step_size: Milliseconds,
+            is_counter: bool,
+            is_rate: bool,
+        ) -> Self {
+            let mut expected_deltas = (greatest_time - lowest_time) / (step_size * USECS_PER_MS);
+            if (greatest_time - lowest_time) % (step_size * USECS_PER_MS) != 0 {
+                expected_deltas += 1
+            }
+            GapfillDeltaTransition {
+                window: VecDeque::default(),
+                deltas: Vec::with_capacity(expected_deltas as usize),
+                current_window_max: lowest_time + range * USECS_PER_MS,
+                current_window_min: lowest_time,
+                step_size: step_size * USECS_PER_MS,
+                range: range * USECS_PER_MS,
+                greatest_time,
+                is_counter,
+                is_rate,
+            }
         }
 
-        if self.window.back().map_or(false, |(prev, _)| *prev > time) {
-            error!("inputs must be in ascending time order")
-        }
-        if time >= self.current_window_min {
-            self.window.push_back((time, val));
-        }
-    }
+        pub(crate) fn add_data_point(&mut self, time: pg_sys::TimestampTz, val: f64) {
+            // skip stale NaNs
+            if val.to_bits() == STALE_NAN {
+                return;
+            };
 
-    fn in_current_window(&self, time: pg_sys::TimestampTz) -> bool {
-        time <= self.current_window_max
-    }
+            while !self.in_current_window(time) {
+                self.flush_current_window()
+            }
 
-    fn flush_current_window(&mut self) {
-        self.add_delta_for_current_window();
-
-        self.current_window_min += self.step_size;
-        self.current_window_max += self.step_size;
-
-        let current_window_min = self.current_window_min;
-        while self
-            .window
-            .front()
-            .map_or(false, |(time, _)| *time < current_window_min)
-        {
-            self.window.pop_front();
-        }
-    }
-
-    //based on extrapolatedRate
-    // https://github.com/prometheus/prometheus/blob/e5ffa8c9a08a5ee4185271c8c26051ddc1388b7a/promql/functions.go#L59
-    fn add_delta_for_current_window(&mut self) {
-        if self.window.len() < 2 {
-            // if there are 1 or fewer values in the window, store NULL
-            self.deltas.push(None);
-            return;
+            if self.window.back().map_or(false, |(prev, _)| *prev > time) {
+                error!("inputs must be in ascending time order")
+            }
+            if time >= self.current_window_min {
+                self.window.push_back((time, val));
+            }
         }
 
-        let mut counter_correction = 0.0;
-        if self.is_counter {
-            let mut last_value = 0.0;
-            for (_, sample) in &self.window {
-                if *sample < last_value {
-                    counter_correction += last_value
+        fn in_current_window(&self, time: pg_sys::TimestampTz) -> bool {
+            time <= self.current_window_max
+        }
+
+        fn flush_current_window(&mut self) {
+            self.add_delta_for_current_window();
+
+            self.current_window_min += self.step_size;
+            self.current_window_max += self.step_size;
+
+            let current_window_min = self.current_window_min;
+            while self
+                .window
+                .front()
+                .map_or(false, |(time, _)| *time < current_window_min)
+            {
+                self.window.pop_front();
+            }
+        }
+
+        //based on extrapolatedRate
+        // https://github.com/prometheus/prometheus/blob/e5ffa8c9a08a5ee4185271c8c26051ddc1388b7a/promql/functions.go#L59
+        fn add_delta_for_current_window(&mut self) {
+            if self.window.len() < 2 {
+                // if there are 1 or fewer values in the window, store NULL
+                self.deltas.push(None);
+                return;
+            }
+
+            let mut counter_correction = 0.0;
+            if self.is_counter {
+                let mut last_value = 0.0;
+                for (_, sample) in &self.window {
+                    if *sample < last_value {
+                        counter_correction += last_value
+                    }
+                    last_value = *sample
                 }
-                last_value = *sample
             }
-        }
 
-        let (latest_time, latest_val) = self.window.back().cloned().unwrap();
-        let (earliest_time, earliest_val) = self.window.front().cloned().unwrap();
-        let mut result_val = latest_val - earliest_val + counter_correction;
+            let (latest_time, latest_val) = self.window.back().cloned().unwrap();
+            let (earliest_time, earliest_val) = self.window.front().cloned().unwrap();
+            let mut result_val = latest_val - earliest_val + counter_correction;
 
-        // all calculated durations and interval are in seconds
-        let mut duration_to_start =
-            (earliest_time - self.current_window_min) as f64 / USECS_PER_SEC as f64;
-        let duration_to_end = (self.current_window_max - latest_time) as f64 / USECS_PER_SEC as f64;
+            // all calculated durations and interval are in seconds
+            let mut duration_to_start =
+                (earliest_time - self.current_window_min) as f64 / USECS_PER_SEC as f64;
+            let duration_to_end =
+                (self.current_window_max - latest_time) as f64 / USECS_PER_SEC as f64;
 
-        let sampled_interval = (latest_time - earliest_time) as f64 / USECS_PER_SEC as f64;
-        let avg_duration_between_samples = sampled_interval as f64 / (self.window.len() - 1) as f64;
+            let sampled_interval = (latest_time - earliest_time) as f64 / USECS_PER_SEC as f64;
+            let avg_duration_between_samples =
+                sampled_interval as f64 / (self.window.len() - 1) as f64;
 
-        if self.is_counter && result_val > 0.0 && earliest_val >= 0.0 {
-            // Counters cannot be negative. If we have any slope at
-            // all (i.e. result_val went up), we can extrapolate
-            // the zero point of the counter. If the duration to the
-            // zero point is shorter than the durationToStart, we
-            // take the zero point as the start of the series,
-            // thereby avoiding extrapolation to negative counter
-            // values.
-            let duration_to_zero = sampled_interval * (earliest_val / result_val);
-            if duration_to_zero < duration_to_start {
-                duration_to_start = duration_to_zero
+            if self.is_counter && result_val > 0.0 && earliest_val >= 0.0 {
+                // Counters cannot be negative. If we have any slope at
+                // all (i.e. result_val went up), we can extrapolate
+                // the zero point of the counter. If the duration to the
+                // zero point is shorter than the durationToStart, we
+                // take the zero point as the start of the series,
+                // thereby avoiding extrapolation to negative counter
+                // values.
+                let duration_to_zero = sampled_interval * (earliest_val / result_val);
+                if duration_to_zero < duration_to_start {
+                    duration_to_start = duration_to_zero
+                }
             }
+
+            // If the first/last samples are close to the boundaries of the range,
+            // extrapolate the result. This is as we expect that another sample
+            // will exist given the spacing between samples we've seen thus far,
+            // with an allowance for noise.
+
+            let extrapolation_threshold = avg_duration_between_samples * 1.1;
+            let mut extrapolate_to_interval = sampled_interval;
+
+            if duration_to_start < extrapolation_threshold {
+                extrapolate_to_interval += duration_to_start;
+            } else {
+                extrapolate_to_interval += avg_duration_between_samples / 2.0;
+            }
+
+            if duration_to_end < extrapolation_threshold {
+                extrapolate_to_interval += duration_to_end;
+            } else {
+                extrapolate_to_interval += avg_duration_between_samples / 2.0;
+            }
+
+            result_val *= extrapolate_to_interval / sampled_interval;
+
+            if self.is_rate {
+                result_val /= (self.range / USECS_PER_SEC) as f64;
+            }
+
+            self.deltas.push(Some(result_val));
         }
 
-        // If the first/last samples are close to the boundaries of the range,
-        // extrapolate the result. This is as we expect that another sample
-        // will exist given the spacing between samples we've seen thus far,
-        // with an allowance for noise.
-
-        let extrapolation_threshold = avg_duration_between_samples * 1.1;
-        let mut extrapolate_to_interval = sampled_interval;
-
-        if duration_to_start < extrapolation_threshold {
-            extrapolate_to_interval += duration_to_start;
-        } else {
-            extrapolate_to_interval += avg_duration_between_samples / 2.0;
+        pub fn as_vec(&mut self) -> Vec<Option<f64>> {
+            while self.current_window_max <= self.greatest_time {
+                self.flush_current_window();
+            }
+            self.deltas.clone()
         }
-
-        if duration_to_end < extrapolation_threshold {
-            extrapolate_to_interval += duration_to_end;
-        } else {
-            extrapolate_to_interval += avg_duration_between_samples / 2.0;
-        }
-
-        result_val *= extrapolate_to_interval / sampled_interval;
-
-        if self.is_rate {
-            result_val /= (self.range / USECS_PER_SEC) as f64;
-        }
-
-        self.deltas.push(Some(result_val));
-    }
-
-    pub fn as_vec(&mut self) -> Vec<Option<f64>> {
-        while self.current_window_max <= self.greatest_time {
-            self.flush_current_window();
-        }
-        self.deltas.clone()
     }
 }

--- a/src/aggregates/mod.rs
+++ b/src/aggregates/mod.rs
@@ -1,4 +1,4 @@
-use crate::aggregates::gapfill_delta::GapfillDeltaTransition;
+use crate::aggregates::gapfill_delta::_prom_ext::GapfillDeltaTransition;
 
 mod gapfill_delta;
 mod prom_delta;

--- a/src/aggregates/prom_increase.rs
+++ b/src/aggregates/prom_increase.rs
@@ -1,108 +1,112 @@
-use pgx::error;
-use pgx::Internal;
 use pgx::*;
 
-use crate::aggregate_utils::in_aggregate_context;
-use crate::aggregates::{GapfillDeltaTransition, Milliseconds};
-use crate::palloc::{Inner, InternalAsValue, ToInternal};
+#[pg_schema]
+mod _prom_ext {
+    use pgx::error;
+    use pgx::Internal;
+    use pgx::*;
 
-#[allow(clippy::too_many_arguments)]
-#[pg_extern(immutable, parallel_safe)]
-pub fn prom_increase_transition(
-    state: Internal,
-    lowest_time: pg_sys::TimestampTz,
-    greatest_time: pg_sys::TimestampTz,
-    step_size: Milliseconds, // `prev_now - step_size` is where the next window starts
-    range: Milliseconds,     // the size of a window to delta over
-    sample_time: pg_sys::TimestampTz,
-    sample_value: f64,
-    fc: pg_sys::FunctionCallInfo,
-) -> Internal {
-    prom_increase_transition_inner(
-        unsafe { state.to_inner() },
-        lowest_time,
-        greatest_time,
-        step_size,
-        range,
-        sample_time,
-        sample_value,
-        fc,
-    )
-    .internal()
-}
+    use crate::aggregate_utils::in_aggregate_context;
+    use crate::aggregates::{GapfillDeltaTransition, Milliseconds};
+    use crate::palloc::{Inner, InternalAsValue, ToInternal};
 
-#[allow(clippy::too_many_arguments)]
-fn prom_increase_transition_inner(
-    state: Option<Inner<GapfillDeltaTransition>>,
-    lowest_time: pg_sys::TimestampTz,
-    greatest_time: pg_sys::TimestampTz,
-    step_size: Milliseconds, // `prev_now - step` is where the next window starts
-    range: Milliseconds,     // the size of a window to delta over
-    sample_time: pg_sys::TimestampTz,
-    sample_value: f64,
-    fc: pg_sys::FunctionCallInfo,
-) -> Option<Inner<GapfillDeltaTransition>> {
-    unsafe {
-        in_aggregate_context(fc, || {
-            if sample_time < lowest_time || sample_time > greatest_time {
-                error!("input time less than lowest time")
-            }
-
-            let mut state = state.unwrap_or_else(|| {
-                let state: Inner<_> = GapfillDeltaTransition::new(
-                    lowest_time,
-                    greatest_time,
-                    range,
-                    step_size,
-                    true,
-                    false,
-                )
-                .into();
-                state
-            });
-
-            state.add_data_point(sample_time, sample_value);
-
-            Some(state)
-        })
+    #[allow(clippy::too_many_arguments)]
+    #[pg_extern(immutable, parallel_safe)]
+    pub fn prom_increase_transition(
+        state: Internal,
+        lowest_time: pg_sys::TimestampTz,
+        greatest_time: pg_sys::TimestampTz,
+        step_size: Milliseconds, // `prev_now - step_size` is where the next window starts
+        range: Milliseconds,     // the size of a window to delta over
+        sample_time: pg_sys::TimestampTz,
+        sample_value: f64,
+        fc: pg_sys::FunctionCallInfo,
+    ) -> Internal {
+        prom_increase_transition_inner(
+            unsafe { state.to_inner() },
+            lowest_time,
+            greatest_time,
+            step_size,
+            range,
+            sample_time,
+            sample_value,
+            fc,
+        )
+        .internal()
     }
+
+    #[allow(clippy::too_many_arguments)]
+    fn prom_increase_transition_inner(
+        state: Option<Inner<GapfillDeltaTransition>>,
+        lowest_time: pg_sys::TimestampTz,
+        greatest_time: pg_sys::TimestampTz,
+        step_size: Milliseconds, // `prev_now - step` is where the next window starts
+        range: Milliseconds,     // the size of a window to delta over
+        sample_time: pg_sys::TimestampTz,
+        sample_value: f64,
+        fc: pg_sys::FunctionCallInfo,
+    ) -> Option<Inner<GapfillDeltaTransition>> {
+        unsafe {
+            in_aggregate_context(fc, || {
+                if sample_time < lowest_time || sample_time > greatest_time {
+                    error!("input time less than lowest time")
+                }
+
+                let mut state = state.unwrap_or_else(|| {
+                    let state: Inner<_> = GapfillDeltaTransition::new(
+                        lowest_time,
+                        greatest_time,
+                        range,
+                        step_size,
+                        true,
+                        false,
+                    )
+                    .into();
+                    state
+                });
+
+                state.add_data_point(sample_time, sample_value);
+
+                Some(state)
+            })
+        }
+    }
+
+    /// Backwards compatibility
+    #[no_mangle]
+    pub extern "C" fn pg_finfo_gapfill_increase_transition() -> &'static pg_sys::Pg_finfo_record {
+        const V1_API: pg_sys::Pg_finfo_record = pg_sys::Pg_finfo_record { api_version: 1 };
+        &V1_API
+    }
+
+    #[no_mangle]
+    unsafe extern "C" fn gapfill_increase_transition(
+        fcinfo: pg_sys::FunctionCallInfo,
+    ) -> pg_sys::Datum {
+        prom_increase_transition_wrapper(fcinfo)
+    }
+
+    // implementation of prometheus increase function
+    // for proper behavior the input must be ORDER BY sample_time
+    extension_sql!(
+        r#"
+    CREATE OR REPLACE AGGREGATE _prom_ext.prom_increase(
+        lowest_time TIMESTAMPTZ,
+        greatest_time TIMESTAMPTZ,
+        step_size BIGINT,
+        range BIGINT,
+        sample_time TIMESTAMPTZ,
+        sample_value DOUBLE PRECISION)
+    (
+        sfunc=_prom_ext.prom_increase_transition,
+        stype=internal,
+        finalfunc=_prom_ext.prom_extrapolate_final
+    );
+    "#,
+        name = "create_prom_increase_aggregate",
+        requires = [prom_increase_transition, prom_extrapolate_final]
+    );
 }
-
-/// Backwards compatibility
-#[no_mangle]
-pub extern "C" fn pg_finfo_gapfill_increase_transition() -> &'static pg_sys::Pg_finfo_record {
-    const V1_API: pg_sys::Pg_finfo_record = pg_sys::Pg_finfo_record { api_version: 1 };
-    &V1_API
-}
-
-#[no_mangle]
-unsafe extern "C" fn gapfill_increase_transition(
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> pg_sys::Datum {
-    prom_increase_transition_wrapper(fcinfo)
-}
-
-// implementation of prometheus increase function
-// for proper behavior the input must be ORDER BY sample_time
-extension_sql!(
-    r#"
-CREATE OR REPLACE AGGREGATE _prom_ext.prom_increase(
-    lowest_time TIMESTAMPTZ,
-    greatest_time TIMESTAMPTZ,
-    step_size BIGINT,
-    range BIGINT,
-    sample_time TIMESTAMPTZ,
-    sample_value DOUBLE PRECISION)
-(
-    sfunc=_prom_ext.prom_increase_transition,
-    stype=internal,
-    finalfunc=_prom_ext.prom_extrapolate_final
-);
-"#,
-    name = "create_prom_increase_aggregate",
-    requires = [prom_increase_transition, prom_extrapolate_final]
-);
-
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
 mod tests {

--- a/src/aggregates/prom_rate.rs
+++ b/src/aggregates/prom_rate.rs
@@ -1,109 +1,115 @@
-use pgx::error;
-use pgx::Internal;
 use pgx::*;
 
-use crate::aggregate_utils::in_aggregate_context;
-use crate::aggregates::{GapfillDeltaTransition, Milliseconds};
-use crate::palloc::{Inner, InternalAsValue, ToInternal};
+#[pg_schema]
+mod _prom_ext {
+    use pgx::error;
+    use pgx::Internal;
+    use pgx::*;
 
-#[allow(clippy::too_many_arguments)]
-#[pg_extern(immutable, parallel_safe)]
-pub fn prom_rate_transition(
-    state: Internal,
-    lowest_time: pg_sys::TimestampTz,
-    greatest_time: pg_sys::TimestampTz,
-    step_size: Milliseconds,
-    range: Milliseconds, // the size of a window to calculate over
-    sample_time: pg_sys::TimestampTz,
-    sample_value: f64,
-    fc: pg_sys::FunctionCallInfo,
-) -> Internal {
-    prom_rate_transition_inner(
-        unsafe { state.to_inner() },
-        lowest_time,
-        greatest_time,
-        step_size,
-        range,
-        sample_time,
-        sample_value,
-        fc,
-    )
-    .internal()
-}
+    use crate::aggregate_utils::in_aggregate_context;
+    use crate::aggregates::{GapfillDeltaTransition, Milliseconds};
+    use crate::palloc::{Inner, InternalAsValue, ToInternal};
 
-#[allow(clippy::too_many_arguments)]
-fn prom_rate_transition_inner(
-    state: Option<Inner<GapfillDeltaTransition>>,
-    lowest_time: pg_sys::TimestampTz,
-    greatest_time: pg_sys::TimestampTz,
-    step_size: Milliseconds,
-    range: Milliseconds, // the size of a window to calculate over
-    sample_time: pg_sys::TimestampTz,
-    sample_value: f64,
-    fc: pg_sys::FunctionCallInfo,
-) -> Option<Inner<GapfillDeltaTransition>> {
-    unsafe {
-        in_aggregate_context(fc, || {
-            if sample_time < lowest_time || sample_time > greatest_time {
-                error!(format!(
-                    "input time {} not in bounds [{}, {}]",
-                    sample_time, lowest_time, greatest_time
-                ))
-            }
-
-            let mut state = state.unwrap_or_else(|| {
-                let state: Inner<_> = GapfillDeltaTransition::new(
-                    lowest_time,
-                    greatest_time,
-                    range,
-                    step_size,
-                    true,
-                    true,
-                )
-                .into();
-                state
-            });
-
-            state.add_data_point(sample_time, sample_value);
-
-            Some(state)
-        })
+    #[allow(clippy::too_many_arguments)]
+    #[pg_extern(immutable, parallel_safe)]
+    pub fn prom_rate_transition(
+        state: Internal,
+        lowest_time: pg_sys::TimestampTz,
+        greatest_time: pg_sys::TimestampTz,
+        step_size: Milliseconds,
+        range: Milliseconds, // the size of a window to calculate over
+        sample_time: pg_sys::TimestampTz,
+        sample_value: f64,
+        fc: pg_sys::FunctionCallInfo,
+    ) -> Internal {
+        prom_rate_transition_inner(
+            unsafe { state.to_inner() },
+            lowest_time,
+            greatest_time,
+            step_size,
+            range,
+            sample_time,
+            sample_value,
+            fc,
+        )
+        .internal()
     }
+
+    #[allow(clippy::too_many_arguments)]
+    fn prom_rate_transition_inner(
+        state: Option<Inner<GapfillDeltaTransition>>,
+        lowest_time: pg_sys::TimestampTz,
+        greatest_time: pg_sys::TimestampTz,
+        step_size: Milliseconds,
+        range: Milliseconds, // the size of a window to calculate over
+        sample_time: pg_sys::TimestampTz,
+        sample_value: f64,
+        fc: pg_sys::FunctionCallInfo,
+    ) -> Option<Inner<GapfillDeltaTransition>> {
+        unsafe {
+            in_aggregate_context(fc, || {
+                if sample_time < lowest_time || sample_time > greatest_time {
+                    error!(format!(
+                        "input time {} not in bounds [{}, {}]",
+                        sample_time, lowest_time, greatest_time
+                    ))
+                }
+
+                let mut state = state.unwrap_or_else(|| {
+                    let state: Inner<_> = GapfillDeltaTransition::new(
+                        lowest_time,
+                        greatest_time,
+                        range,
+                        step_size,
+                        true,
+                        true,
+                    )
+                    .into();
+                    state
+                });
+
+                state.add_data_point(sample_time, sample_value);
+
+                Some(state)
+            })
+        }
+    }
+
+    /// Backwards compatibility
+    #[no_mangle]
+    pub extern "C" fn pg_finfo_gapfill_rate_transition() -> &'static pg_sys::Pg_finfo_record {
+        const V1_API: pg_sys::Pg_finfo_record = pg_sys::Pg_finfo_record { api_version: 1 };
+        &V1_API
+    }
+
+    #[no_mangle]
+    unsafe extern "C" fn gapfill_rate_transition(
+        fcinfo: pg_sys::FunctionCallInfo,
+    ) -> pg_sys::Datum {
+        prom_rate_transition_wrapper(fcinfo)
+    }
+
+    // implementation of prometheus rate function
+    // for proper behavior the input must be ORDER BY sample_time
+    extension_sql!(
+        r#"
+    CREATE OR REPLACE AGGREGATE _prom_ext.prom_rate(
+        lowest_time TIMESTAMPTZ,
+        greatest_time TIMESTAMPTZ,
+        step_size BIGINT,
+        range BIGINT,
+        sample_time TIMESTAMPTZ,
+        sample_value DOUBLE PRECISION)
+    (
+        sfunc=_prom_ext.prom_rate_transition,
+        stype=internal,
+        finalfunc=_prom_ext.prom_extrapolate_final
+    );
+    "#,
+        name = "create_prom_rate_aggregate",
+        requires = [prom_rate_transition, prom_extrapolate_final]
+    );
 }
-
-/// Backwards compatibility
-#[no_mangle]
-pub extern "C" fn pg_finfo_gapfill_rate_transition() -> &'static pg_sys::Pg_finfo_record {
-    const V1_API: pg_sys::Pg_finfo_record = pg_sys::Pg_finfo_record { api_version: 1 };
-    &V1_API
-}
-
-#[no_mangle]
-unsafe extern "C" fn gapfill_rate_transition(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
-    prom_rate_transition_wrapper(fcinfo)
-}
-
-// implementation of prometheus rate function
-// for proper behavior the input must be ORDER BY sample_time
-extension_sql!(
-    r#"
-CREATE OR REPLACE AGGREGATE _prom_ext.prom_rate(
-    lowest_time TIMESTAMPTZ,
-    greatest_time TIMESTAMPTZ,
-    step_size BIGINT,
-    range BIGINT,
-    sample_time TIMESTAMPTZ,
-    sample_value DOUBLE PRECISION)
-(
-    sfunc=_prom_ext.prom_rate_transition,
-    stype=internal,
-    finalfunc=_prom_ext.prom_extrapolate_final
-);
-"#,
-    name = "create_prom_rate_aggregate",
-    requires = [prom_rate_transition, prom_extrapolate_final]
-);
-
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
 mod tests {

--- a/src/aggregates/vector_selector.rs
+++ b/src/aggregates/vector_selector.rs
@@ -138,324 +138,332 @@
 //!
 use pgx::*;
 
-use pgx::error;
+#[pg_schema]
+mod _prom_ext {
+    use pgx::*;
 
-use crate::aggregate_utils::in_aggregate_context;
-use crate::aggregates::{Milliseconds, STALE_NAN, USECS_PER_MS};
-use serde::{Deserialize, Serialize};
+    use pgx::error;
 
-use crate::palloc::{Inner, InternalAsValue, ToInternal};
-use crate::raw::bytea;
+    use crate::aggregate_utils::in_aggregate_context;
+    use crate::aggregates::{Milliseconds, STALE_NAN, USECS_PER_MS};
+    use serde::{Deserialize, Serialize};
 
-/// Note that for performance, this aggregate is parallel-izable, combinable, and does not expect
-/// ordered inputs.
-#[allow(clippy::too_many_arguments)]
-#[pg_extern(immutable, parallel_safe)]
-pub fn vector_selector_transition(
-    state: Internal,
-    start_time: pg_sys::TimestampTz,
-    end_time: pg_sys::TimestampTz,
-    bucket_width: Milliseconds,
-    lookback: Milliseconds,
-    time: pg_sys::TimestampTz,
-    value: f64,
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
-    vector_selector_transition_inner(
-        unsafe { state.to_inner() },
-        start_time,
-        end_time,
-        bucket_width,
-        lookback,
-        time,
-        value,
-        fcinfo,
-    )
-    .internal()
-}
+    use crate::palloc::{Inner, InternalAsValue, ToInternal};
+    use crate::raw::bytea;
 
-#[allow(clippy::too_many_arguments)]
-fn vector_selector_transition_inner(
-    state: Option<Inner<VectorSelector>>,
-    start_time: pg_sys::TimestampTz,
-    end_time: pg_sys::TimestampTz,
-    bucket_width: Milliseconds,
-    lookback: Milliseconds,
-    time: pg_sys::TimestampTz,
-    value: f64,
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<Inner<VectorSelector>> {
-    unsafe {
-        in_aggregate_context(fcinfo, || {
-            let mut state = state.unwrap_or_else(|| {
-                let state: Inner<VectorSelector> =
-                    VectorSelector::new(start_time, end_time, bucket_width, lookback).into();
-                state
-            });
-
-            state.insert(time, value);
-
-            Some(state)
-        })
-    }
-}
-
-#[pg_extern(immutable, parallel_safe)]
-pub fn vector_selector_final(
-    state: Internal, /* Option<Inner<VectorSelector>> */
-) -> Option<Vec<Option<f64>>> {
-    let state: Option<Inner<VectorSelector>> = unsafe { state.to_inner() };
-    state.map(|s| s.to_pg_array())
-}
-
-#[pg_extern(immutable, parallel_safe, strict)]
-pub fn vector_selector_serialize(state: Internal) -> bytea {
-    let state: &mut VectorSelector = unsafe {
-        // This is safe as long as this function is defined as `strict`, in
-        // which case PG knows that NULL -> NULL and so it will not call this
-        // function with NULL values
-        state.get_mut().unwrap()
-    };
-    crate::do_serialize!(state)
-}
-
-#[pg_extern(immutable, parallel_safe, strict)]
-pub fn vector_selector_deserialize(bytes: bytea, _internal: Internal) -> Internal {
-    let v: VectorSelector = crate::do_deserialize!(bytes, VectorSelector);
-    Inner::from(v).internal()
-}
-
-#[pg_extern(immutable, parallel_safe)]
-pub fn vector_selector_combine(
-    state1: Internal,
-    state2: Internal,
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
-    vector_selector_combine_inner(
-        unsafe { state1.to_inner() },
-        unsafe { state2.to_inner() },
-        fcinfo,
-    )
-    .internal()
-}
-
-fn vector_selector_combine_inner(
-    state1: Option<Inner<VectorSelector>>,
-    state2: Option<Inner<VectorSelector>>,
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<Inner<VectorSelector>> {
-    unsafe {
-        in_aggregate_context(fcinfo, || {
-            match (state1, state2) {
-                (None, None) => None,
-                (None, Some(state2)) => {
-                    let s = state2.clone();
-                    Some(s.into())
-                }
-                (Some(state1), None) => {
-                    let s = state1.clone();
-                    Some(s.into())
-                } //should I make these return themselves?
-                (Some(state1), Some(state2)) => {
-                    let mut s1 = state1.clone(); // is there a way to avoid if it doesn't need it
-                    s1.combine(&state2);
-                    Some(s1.into())
-                }
-            }
-        })
-    }
-}
-
-extension_sql!(
-    r#"
-CREATE OR REPLACE AGGREGATE _prom_ext.vector_selector(
-    start_time TIMESTAMPTZ,
-    end_time TIMESTAMPTZ,
-    bucket_width BIGINT,
-    lookback BIGINT,
-    sample_time TIMESTAMPTZ,
-    sample_value DOUBLE PRECISION)
-(
-    sfunc = vector_selector_transition,
-    stype = internal,
-    finalfunc = vector_selector_final,
-    combinefunc = vector_selector_combine,
-    serialfunc = vector_selector_serialize,
-    deserialfunc = vector_selector_deserialize,
-    parallel = safe
-);
-"#,
-    name = "create_vector_selector_aggregate",
-    requires = [
-        vector_selector_transition,
-        vector_selector_final,
-        vector_selector_combine,
-        vector_selector_serialize,
-        vector_selector_deserialize
-    ]
-);
-
-// The internal state consists of a vector non-overlapping sample buckets. Each bucket
-// has a corresponding (virtual) timestamp corresponding to the ts series
-// described above. The timestamp represents the maximum value stored in the
-// bucket (inclusive). The minimum value is defined by the maximum value of
-// the previous bucket (exclusive).
-// the value stored inside the bucket is the last sample in the bucket (sample with highest timestamp)
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct VectorSelector {
-    first_bucket_max_time: pg_sys::TimestampTz,
-    last_bucket_max_time: pg_sys::TimestampTz,
-    end_time: pg_sys::TimestampTz, //only used for error checking
-    bucket_width: Milliseconds,
-    lookback: Milliseconds,
-    elements: Vec<Option<(pg_sys::TimestampTz, f64)>>,
-}
-
-impl VectorSelector {
-    pub fn new(
+    /// Note that for performance, this aggregate is parallel-izable, combinable, and does not expect
+    /// ordered inputs.
+    #[allow(clippy::too_many_arguments)]
+    #[pg_extern(immutable, parallel_safe)]
+    pub fn vector_selector_transition(
+        state: Internal,
         start_time: pg_sys::TimestampTz,
         end_time: pg_sys::TimestampTz,
         bucket_width: Milliseconds,
         lookback: Milliseconds,
-    ) -> Self {
-        let (num_buckets, last_bucket_max_time) = {
-            if bucket_width == 0 {
-                (1, end_time)
-            } else {
-                let num_buckets = ((end_time - start_time) / (bucket_width * USECS_PER_MS)) + 1;
-                let max_time = end_time - ((end_time - start_time) % (bucket_width * USECS_PER_MS));
-                (num_buckets, max_time)
-            }
-        };
-
-        VectorSelector {
-            first_bucket_max_time: start_time,
-            last_bucket_max_time,
+        time: pg_sys::TimestampTz,
+        value: f64,
+        fcinfo: pg_sys::FunctionCallInfo,
+    ) -> Internal {
+        vector_selector_transition_inner(
+            unsafe { state.to_inner() },
+            start_time,
             end_time,
             bucket_width,
             lookback,
-            elements: vec![None; num_buckets as usize],
+            time,
+            value,
+            fcinfo,
+        )
+        .internal()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn vector_selector_transition_inner(
+        state: Option<Inner<VectorSelector>>,
+        start_time: pg_sys::TimestampTz,
+        end_time: pg_sys::TimestampTz,
+        bucket_width: Milliseconds,
+        lookback: Milliseconds,
+        time: pg_sys::TimestampTz,
+        value: f64,
+        fcinfo: pg_sys::FunctionCallInfo,
+    ) -> Option<Inner<VectorSelector>> {
+        unsafe {
+            in_aggregate_context(fcinfo, || {
+                let mut state = state.unwrap_or_else(|| {
+                    let state: Inner<VectorSelector> =
+                        VectorSelector::new(start_time, end_time, bucket_width, lookback).into();
+                    state
+                });
+
+                state.insert(time, value);
+
+                Some(state)
+            })
         }
     }
 
-    fn combine(&mut self, other: &Inner<VectorSelector>) {
-        if self.first_bucket_max_time != other.first_bucket_max_time
-            || self.last_bucket_max_time != other.last_bucket_max_time
-            || self.end_time != other.end_time
-            || self.bucket_width != other.bucket_width
-            || self.lookback != other.lookback
-            || self.elements.len() != other.elements.len()
-        {
-            error!("trying to combine incompatible vector selectors")
-        }
+    #[pg_extern(immutable, parallel_safe)]
+    pub fn vector_selector_final(
+        state: Internal, /* Option<Inner<VectorSelector>> */
+    ) -> Option<Vec<Option<f64>>> {
+        let state: Option<Inner<VectorSelector>> = unsafe { state.to_inner() };
+        state.map(|s| s.to_pg_array())
+    }
 
-        for it in self.elements.iter_mut().zip(other.elements.iter()) {
-            let (s, o) = it;
-            match (*s, o) {
-                (None, None) => (),
-                (Some(_), None) => (),
-                (None, Some(other)) => *s = Some(*other),
-                (Some(mine), Some(other)) => {
-                    let (my_t, _): (pg_sys::TimestampTz, f64) = mine;
-                    let (other_t, _): (pg_sys::TimestampTz, f64) = *other;
-                    if other_t > my_t {
-                        *s = Some(*other)
+    #[pg_extern(immutable, parallel_safe, strict)]
+    pub fn vector_selector_serialize(state: Internal) -> bytea {
+        let state: &mut VectorSelector = unsafe {
+            // This is safe as long as this function is defined as `strict`, in
+            // which case PG knows that NULL -> NULL and so it will not call this
+            // function with NULL values
+            state.get_mut().unwrap()
+        };
+        crate::do_serialize!(state)
+    }
+
+    #[pg_extern(immutable, parallel_safe, strict)]
+    pub fn vector_selector_deserialize(bytes: bytea, _internal: Internal) -> Internal {
+        let v: VectorSelector = crate::do_deserialize!(bytes, VectorSelector);
+        Inner::from(v).internal()
+    }
+
+    #[pg_extern(immutable, parallel_safe)]
+    pub fn vector_selector_combine(
+        state1: Internal,
+        state2: Internal,
+        fcinfo: pg_sys::FunctionCallInfo,
+    ) -> Internal {
+        vector_selector_combine_inner(
+            unsafe { state1.to_inner() },
+            unsafe { state2.to_inner() },
+            fcinfo,
+        )
+        .internal()
+    }
+
+    fn vector_selector_combine_inner(
+        state1: Option<Inner<VectorSelector>>,
+        state2: Option<Inner<VectorSelector>>,
+        fcinfo: pg_sys::FunctionCallInfo,
+    ) -> Option<Inner<VectorSelector>> {
+        unsafe {
+            in_aggregate_context(fcinfo, || {
+                match (state1, state2) {
+                    (None, None) => None,
+                    (None, Some(state2)) => {
+                        let s = state2.clone();
+                        Some(s.into())
+                    }
+                    (Some(state1), None) => {
+                        let s = state1.clone();
+                        Some(s.into())
+                    } //should I make these return themselves?
+                    (Some(state1), Some(state2)) => {
+                        let mut s1 = state1.clone(); // is there a way to avoid if it doesn't need it
+                        s1.combine(&state2);
+                        Some(s1.into())
                     }
                 }
-            }
+            })
         }
     }
 
-    fn insert(&mut self, time: pg_sys::TimestampTz, val: f64) {
-        if time > self.end_time {
-            error!("input time greater than expected")
-        }
-        if time > self.last_bucket_max_time {
-            return;
-        }
+    extension_sql!(
+        r#"
+    CREATE OR REPLACE AGGREGATE _prom_ext.vector_selector(
+        start_time TIMESTAMPTZ,
+        end_time TIMESTAMPTZ,
+        bucket_width BIGINT,
+        lookback BIGINT,
+        sample_time TIMESTAMPTZ,
+        sample_value DOUBLE PRECISION)
+    (
+        sfunc = _prom_ext.vector_selector_transition,
+        stype = internal,
+        finalfunc = _prom_ext.vector_selector_final,
+        combinefunc = _prom_ext.vector_selector_combine,
+        serialfunc = _prom_ext.vector_selector_serialize,
+        deserialfunc = _prom_ext.vector_selector_deserialize,
+        parallel = safe
+    );
+    "#,
+        name = "create_vector_selector_aggregate",
+        requires = [
+            vector_selector_transition,
+            vector_selector_final,
+            vector_selector_combine,
+            vector_selector_serialize,
+            vector_selector_deserialize
+        ]
+    );
 
-        let bucket_idx = self.get_bucket(time);
-        let contents = self.elements[bucket_idx];
+    // The internal state consists of a vector non-overlapping sample buckets. Each bucket
+    // has a corresponding (virtual) timestamp corresponding to the ts series
+    // described above. The timestamp represents the maximum value stored in the
+    // bucket (inclusive). The minimum value is defined by the maximum value of
+    // the previous bucket (exclusive).
+    // the value stored inside the bucket is the last sample in the bucket (sample with highest timestamp)
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct VectorSelector {
+        first_bucket_max_time: pg_sys::TimestampTz,
+        last_bucket_max_time: pg_sys::TimestampTz,
+        end_time: pg_sys::TimestampTz,
+        //only used for error checking
+        bucket_width: Milliseconds,
+        lookback: Milliseconds,
+        elements: Vec<Option<(pg_sys::TimestampTz, f64)>>,
+    }
 
-        match contents {
-            Some(x) => {
-                let (exising_time, _) = x;
-                if exising_time < time {
-                    self.elements[bucket_idx] = Some((time, val))
+    impl VectorSelector {
+        pub fn new(
+            start_time: pg_sys::TimestampTz,
+            end_time: pg_sys::TimestampTz,
+            bucket_width: Milliseconds,
+            lookback: Milliseconds,
+        ) -> Self {
+            let (num_buckets, last_bucket_max_time) = {
+                if bucket_width == 0 {
+                    (1, end_time)
+                } else {
+                    let num_buckets = ((end_time - start_time) / (bucket_width * USECS_PER_MS)) + 1;
+                    let max_time =
+                        end_time - ((end_time - start_time) % (bucket_width * USECS_PER_MS));
+                    (num_buckets, max_time)
                 }
+            };
+
+            VectorSelector {
+                first_bucket_max_time: start_time,
+                last_bucket_max_time,
+                end_time,
+                bucket_width,
+                lookback,
+                elements: vec![None; num_buckets as usize],
             }
-            None => self.elements[bucket_idx] = Some((time, val)),
-        }
-    }
-
-    fn get_bucket(&self, time: pg_sys::TimestampTz) -> usize {
-        if time < self.first_bucket_max_time - (self.lookback * USECS_PER_MS) {
-            error!("input time less than expected")
         }
 
-        if time > self.last_bucket_max_time {
-            error!("input time greater than the last bucket's time")
-        }
+        fn combine(&mut self, other: &Inner<VectorSelector>) {
+            if self.first_bucket_max_time != other.first_bucket_max_time
+                || self.last_bucket_max_time != other.last_bucket_max_time
+                || self.end_time != other.end_time
+                || self.bucket_width != other.bucket_width
+                || self.lookback != other.lookback
+                || self.elements.len() != other.elements.len()
+            {
+                error!("trying to combine incompatible vector selectors")
+            }
 
-        if time <= self.first_bucket_max_time {
-            return 0;
-        }
-
-        let offset = time - self.first_bucket_max_time;
-        let mut bucket = (offset / (self.bucket_width * USECS_PER_MS)) + 1;
-        if offset % (self.bucket_width * USECS_PER_MS) == 0 {
-            bucket -= 1
-        }
-        bucket as usize
-    }
-
-    pub fn results(&self) -> Vec<Option<f64>> {
-        let mut vals: Vec<Option<f64>> = Vec::with_capacity(self.elements.capacity());
-
-        //last value found in any bucket
-        let mut last = None;
-
-        /* staleNaN check happens after the bucket/last item is retrieved.
-         * if the value is a staleNaN, then the result is a NULL
-         * see vectorSelectorSingle in engine.go
-         */
-
-        let mut ts = self.first_bucket_max_time;
-        for content in &self.elements {
-            let mut pushed = false;
-            match content {
-                /* if current bucket is empty, last value may still apply */
-                None => {
-                    if let Some(tuple) = last {
-                        let (t, v): (pg_sys::TimestampTz, f64) = tuple;
-                        if t >= ts - (self.lookback * USECS_PER_MS) && v.to_bits() != STALE_NAN {
-                            pushed = true;
-                            vals.push(Some(v));
+            for it in self.elements.iter_mut().zip(other.elements.iter()) {
+                let (s, o) = it;
+                match (*s, o) {
+                    (None, None) => (),
+                    (Some(_), None) => (),
+                    (None, Some(other)) => *s = Some(*other),
+                    (Some(mine), Some(other)) => {
+                        let (my_t, _): (pg_sys::TimestampTz, f64) = mine;
+                        let (other_t, _): (pg_sys::TimestampTz, f64) = *other;
+                        if other_t > my_t {
+                            *s = Some(*other)
                         }
                     }
                 }
-                Some(tuple) => {
-                    let (t, v2): &(pg_sys::TimestampTz, f64) = tuple;
-                    //if buckets > lookback, timestamp in bucket may still be out of lookback
-                    if *t >= ts - (self.lookback * USECS_PER_MS) && v2.to_bits() != STALE_NAN {
-                        pushed = true;
-                        vals.push(Some(*v2));
-                    }
-                    last = *content
-                }
             }
-            if !pushed {
-                //push a null
-                vals.push(None);
-            }
-            ts += self.bucket_width * USECS_PER_MS
         }
 
-        vals
-    }
+        fn insert(&mut self, time: pg_sys::TimestampTz, val: f64) {
+            if time > self.end_time {
+                error!("input time greater than expected")
+            }
+            if time > self.last_bucket_max_time {
+                return;
+            }
 
-    pub fn to_pg_array(&self) -> Vec<Option<f64>> {
-        self.results()
+            let bucket_idx = self.get_bucket(time);
+            let contents = self.elements[bucket_idx];
+
+            match contents {
+                Some(x) => {
+                    let (exising_time, _) = x;
+                    if exising_time < time {
+                        self.elements[bucket_idx] = Some((time, val))
+                    }
+                }
+                None => self.elements[bucket_idx] = Some((time, val)),
+            }
+        }
+
+        fn get_bucket(&self, time: pg_sys::TimestampTz) -> usize {
+            if time < self.first_bucket_max_time - (self.lookback * USECS_PER_MS) {
+                error!("input time less than expected")
+            }
+
+            if time > self.last_bucket_max_time {
+                error!("input time greater than the last bucket's time")
+            }
+
+            if time <= self.first_bucket_max_time {
+                return 0;
+            }
+
+            let offset = time - self.first_bucket_max_time;
+            let mut bucket = (offset / (self.bucket_width * USECS_PER_MS)) + 1;
+            if offset % (self.bucket_width * USECS_PER_MS) == 0 {
+                bucket -= 1
+            }
+            bucket as usize
+        }
+
+        pub fn results(&self) -> Vec<Option<f64>> {
+            let mut vals: Vec<Option<f64>> = Vec::with_capacity(self.elements.capacity());
+
+            //last value found in any bucket
+            let mut last = None;
+
+            /* staleNaN check happens after the bucket/last item is retrieved.
+             * if the value is a staleNaN, then the result is a NULL
+             * see vectorSelectorSingle in engine.go
+             */
+
+            let mut ts = self.first_bucket_max_time;
+            for content in &self.elements {
+                let mut pushed = false;
+                match content {
+                    /* if current bucket is empty, last value may still apply */
+                    None => {
+                        if let Some(tuple) = last {
+                            let (t, v): (pg_sys::TimestampTz, f64) = tuple;
+                            if t >= ts - (self.lookback * USECS_PER_MS) && v.to_bits() != STALE_NAN
+                            {
+                                pushed = true;
+                                vals.push(Some(v));
+                            }
+                        }
+                    }
+                    Some(tuple) => {
+                        let (t, v2): &(pg_sys::TimestampTz, f64) = tuple;
+                        //if buckets > lookback, timestamp in bucket may still be out of lookback
+                        if *t >= ts - (self.lookback * USECS_PER_MS) && v2.to_bits() != STALE_NAN {
+                            pushed = true;
+                            vals.push(Some(*v2));
+                        }
+                        last = *content
+                    }
+                }
+                if !pushed {
+                    //push a null
+                    vals.push(None);
+                }
+                ts += self.bucket_width * USECS_PER_MS
+            }
+
+            vals
+        }
+
+        pub fn to_pg_array(&self) -> Vec<Option<f64>> {
+            self.results()
+        }
     }
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,5 +1,7 @@
 use pgx_macros::extension_sql_file;
 
+extension_sql_file!("../bootstrap.sql", name = "bootstrap", bootstrap);
+
 extension_sql_file!(
     "../hand-written-migration.sql",
     name = "migration",

--- a/src/support.rs
+++ b/src/support.rs
@@ -1,115 +1,121 @@
-use crate::palloc::ToInternal;
 use pgx::*;
-use std::ptr;
 
-/// This [support function] optimizes calls to the supported function if it's
-/// called with constant-like arguments. Such calls are transformed into a
-/// subquery of the function call. This allows the planner to make this call an
-/// InitPlan which is evaluated once per query instead of multiple times
-/// (e.g. on every tuple when the function is used in a WHERE clause).
-///
-/// Assuming the presence of a supported function `supported_fn(text, text)`,
-/// a query such as the following:
-///
-/// ```sql
-/// SELECT * FROM some_table WHERE supported_fn('constant', 'parameters');
-/// ```
-///
-/// Will be transformed into the following by this support function:
-///
-/// ```sql
-/// SELECT * FROM some_table WHERE (SELECT supported_fn('constant', 'parameters'));
-/// ```
-///
-/// This should be used on any stable function that is often called with constant-like
-/// arguments.
-///
-/// [support function]: https://www.postgresql.org/docs/current/xfunc-optimization.html
-#[pg_extern(immutable, strict)]
-pub unsafe fn rewrite_fn_call_to_subquery(input: Internal) -> Internal {
-    let input: *mut pg_sys::Node = input.unwrap().unwrap() as _;
-    if !pgx::is_a(input, pg_sys::NodeTag_T_SupportRequestSimplify) {
-        return ptr::null_mut::<pg_sys::Node>().internal();
+#[pg_schema]
+mod _prom_ext {
+    use crate::palloc::ToInternal;
+    use pgx::*;
+    use std::ptr;
+
+    /// This [support function] optimizes calls to the supported function if it's
+    /// called with constant-like arguments. Such calls are transformed into a
+    /// subquery of the function call. This allows the planner to make this call an
+    /// InitPlan which is evaluated once per query instead of multiple times
+    /// (e.g. on every tuple when the function is used in a WHERE clause).
+    ///
+    /// Assuming the presence of a supported function `supported_fn(text, text)`,
+    /// a query such as the following:
+    ///
+    /// ```sql
+    /// SELECT * FROM some_table WHERE supported_fn('constant', 'parameters');
+    /// ```
+    ///
+    /// Will be transformed into the following by this support function:
+    ///
+    /// ```sql
+    /// SELECT * FROM some_table WHERE (SELECT supported_fn('constant', 'parameters'));
+    /// ```
+    ///
+    /// This should be used on any stable function that is often called with constant-like
+    /// arguments.
+    ///
+    /// [support function]: https://www.postgresql.org/docs/current/xfunc-optimization.html
+    #[pg_extern(immutable, strict)]
+    pub unsafe fn rewrite_fn_call_to_subquery(input: Internal) -> Internal {
+        let input: *mut pg_sys::Node = input.unwrap().unwrap() as _;
+        if !pgx::is_a(input, pg_sys::NodeTag_T_SupportRequestSimplify) {
+            return ptr::null_mut::<pg_sys::Node>().internal();
+        }
+
+        let req: *mut pg_sys::SupportRequestSimplify = input.cast();
+
+        let root = (*req).root;
+
+        if root.is_null() {
+            return (ptr::null_mut::<pg_sys::Node>()).internal();
+        }
+
+        // This prevents recursion of this optimization when the subselect is planned
+        if (*root).query_level > 1 {
+            return ptr::null_mut::<pg_sys::Node>().internal();
+        }
+
+        let expr = (*req).fcall;
+
+        let original_args = PgList::<pg_sys::Node>::from_pg((*expr).args);
+
+        // Check that these are expressions that don't reference any vars,
+        // i.e. they are constants or expressions of constants
+        let args_are_constants = original_args
+            .iter_ptr()
+            .all(|arg| arg_can_be_put_into_subquery(arg));
+        if !args_are_constants {
+            return ptr::null_mut::<pg_sys::Node>().internal();
+        }
+
+        (*(*root).parse).hasSubLinks = true;
+
+        let f2: *mut pg_sys::FuncExpr =
+            pg_sys::copyObjectImpl(expr as *const ::std::os::raw::c_void) as *mut pg_sys::FuncExpr;
+
+        let mut te = PgBox::<pg_sys::TargetEntry>::alloc_node(pg_sys::NodeTag_T_TargetEntry);
+        te.expr = f2 as *mut pg_sys::Expr;
+        te.resno = 1;
+
+        let mut query = PgBox::<pg_sys::Query>::alloc_node(pg_sys::NodeTag_T_Query);
+        query.commandType = pg_sys::CmdType_CMD_SELECT;
+        query.jointree =
+            PgBox::<pg_sys::FromExpr>::alloc_node(pg_sys::NodeTag_T_FromExpr).into_pg();
+        query.canSetTag = true;
+
+        let mut list = PgList::<pg_sys::TargetEntry>::new();
+        list.push(te.into_pg() as *mut pg_sys::TargetEntry);
+
+        query.targetList = list.into_pg();
+
+        let mut sublink = PgBox::<pg_sys::SubLink>::alloc_node(pg_sys::NodeTag_T_SubLink);
+        sublink.subLinkType = pg_sys::SubLinkType_EXPR_SUBLINK;
+        sublink.subLinkId = 0;
+        sublink.subselect = query.into_pg() as *mut pg_sys::Node;
+
+        (sublink.into_pg() as *mut pg_sys::Node).internal()
     }
 
-    let req: *mut pg_sys::SupportRequestSimplify = input.cast();
-
-    let root = (*req).root;
-
-    if root.is_null() {
-        return (ptr::null_mut::<pg_sys::Node>()).internal();
+    /// Backwards compatibility
+    #[no_mangle]
+    pub extern "C" fn pg_finfo_make_call_subquery_support() -> &'static pg_sys::Pg_finfo_record {
+        const V1_API: pg_sys::Pg_finfo_record = pg_sys::Pg_finfo_record { api_version: 1 };
+        &V1_API
     }
 
-    // This prevents recursion of this optimization when the subselect is planned
-    if (*root).query_level > 1 {
-        return ptr::null_mut::<pg_sys::Node>().internal();
+    #[no_mangle]
+    pub unsafe extern "C" fn make_call_subquery_support(
+        fcinfo: pg_sys::FunctionCallInfo,
+    ) -> pg_sys::Datum {
+        rewrite_fn_call_to_subquery_wrapper(fcinfo)
     }
 
-    let expr = (*req).fcall;
+    pub unsafe fn arg_can_be_put_into_subquery(arg: *mut pg_sys::Node) -> bool {
+        if pgx::is_a(arg, pg_sys::NodeTag_T_Const) {
+            return true;
+        }
 
-    let original_args = PgList::<pg_sys::Node>::from_pg((*expr).args);
+        if pgx::is_a(arg, pg_sys::NodeTag_T_CoerceToDomain) {
+            let domain = arg.cast::<pg_sys::CoerceToDomain>();
+            return arg_can_be_put_into_subquery((*domain).arg as *mut pg_sys::Node);
+        }
 
-    // Check that these are expressions that don't reference any vars,
-    // i.e. they are constants or expressions of constants
-    let args_are_constants = original_args
-        .iter_ptr()
-        .all(|arg| arg_can_be_put_into_subquery(arg));
-    if !args_are_constants {
-        return ptr::null_mut::<pg_sys::Node>().internal();
+        false
     }
-
-    (*(*root).parse).hasSubLinks = true;
-
-    let f2: *mut pg_sys::FuncExpr =
-        pg_sys::copyObjectImpl(expr as *const ::std::os::raw::c_void) as *mut pg_sys::FuncExpr;
-
-    let mut te = PgBox::<pg_sys::TargetEntry>::alloc_node(pg_sys::NodeTag_T_TargetEntry);
-    te.expr = f2 as *mut pg_sys::Expr;
-    te.resno = 1;
-
-    let mut query = PgBox::<pg_sys::Query>::alloc_node(pg_sys::NodeTag_T_Query);
-    query.commandType = pg_sys::CmdType_CMD_SELECT;
-    query.jointree = PgBox::<pg_sys::FromExpr>::alloc_node(pg_sys::NodeTag_T_FromExpr).into_pg();
-    query.canSetTag = true;
-
-    let mut list = PgList::<pg_sys::TargetEntry>::new();
-    list.push(te.into_pg() as *mut pg_sys::TargetEntry);
-
-    query.targetList = list.into_pg();
-
-    let mut sublink = PgBox::<pg_sys::SubLink>::alloc_node(pg_sys::NodeTag_T_SubLink);
-    sublink.subLinkType = pg_sys::SubLinkType_EXPR_SUBLINK;
-    sublink.subLinkId = 0;
-    sublink.subselect = query.into_pg() as *mut pg_sys::Node;
-
-    (sublink.into_pg() as *mut pg_sys::Node).internal()
-}
-
-/// Backwards compatibility
-#[no_mangle]
-pub extern "C" fn pg_finfo_make_call_subquery_support() -> &'static pg_sys::Pg_finfo_record {
-    const V1_API: pg_sys::Pg_finfo_record = pg_sys::Pg_finfo_record { api_version: 1 };
-    &V1_API
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn make_call_subquery_support(
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> pg_sys::Datum {
-    rewrite_fn_call_to_subquery_wrapper(fcinfo)
-}
-
-pub unsafe fn arg_can_be_put_into_subquery(arg: *mut pg_sys::Node) -> bool {
-    if pgx::is_a(arg, pg_sys::NodeTag_T_Const) {
-        return true;
-    }
-
-    if pgx::is_a(arg, pg_sys::NodeTag_T_CoerceToDomain) {
-        let domain = arg.cast::<pg_sys::CoerceToDomain>();
-        return arg_can_be_put_into_subquery((*domain).arg as *mut pg_sys::Node);
-    }
-
-    false
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,12 @@
-use num_cpus::get;
 use pgx::*;
 
-#[pg_extern(immutable, parallel_safe)]
-pub fn num_cpus() -> i32 {
-    get() as i32
+#[pg_schema]
+mod _prom_ext {
+    use num_cpus::get;
+    use pgx::*;
+
+    #[pg_extern(immutable, parallel_safe)]
+    pub fn num_cpus() -> i32 {
+        get() as i32
+    }
 }

--- a/templates/idempotent-wrapper.sql
+++ b/templates/idempotent-wrapper.sql
@@ -1,17 +1,11 @@
 
 -- {{filename}}
 DO $outer_idempotent_block$
-DECLARE
-    _old_search_path text;
 BEGIN
-    EXECUTE 'SHOW search_path' INTO STRICT _old_search_path;
-    SET search_path TO pg_catalog;
 
 -- Note: this weird indentation is important. We compare SQL across upgrade paths,
 -- and the comparison is indentation-sensitive.
 {{body}}
 
-    EXECUTE format('SET search_path TO %s', _old_search_path);
-    RAISE LOG 'Applied idempotent {{filename}}';
 END;
 $outer_idempotent_block$;

--- a/templates/promscale.control
+++ b/templates/promscale.control
@@ -3,7 +3,7 @@ comment = 'Promscale support functions'
 default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/promscale'
 relocatable = false
-schema = _prom_ext
+schema = public
 superuser = true
 {%if !is_pg_12 -%}
 trusted = true


### PR DESCRIPTION
Because the extension was declared as non-relocatable, and in the schema
`_prom_ext`, it was possible to have that schema (and objects in it)
created before the extension install script is run. This opened the
extension up to precreation attacks.

This change takes a number of measures to mitigate that.

- We configure the schema to `public`, which allows the extension to
  control the creation of the `_prom_ext` schema.
- We add a `bootstrap` migration script which is run before the pgx
  generated SQL, which creates the `_prom_ext` schema.
- We tell pgx to put all generated objects in the `_prom_ext` schema.