### PR TITLE
Add pgspot lint check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,8 +2,6 @@ name: ci
 on:
   pull_request:
     paths-ignore:
-    - '.github/workflows/docker.yaml'
-    - '.github/workflows/lint.yaml'
     - '.github/workflows/release.yaml'
     - '*.md'
     - 'dist/*'

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -2,8 +2,6 @@ name: docker
 on:
   pull_request:
     paths-ignore:
-    - '.github/workflows/ci.yaml'
-    - '.github/workflows/lint.yaml'
     - '.github/workflows/release.yaml'
     - 'dist/*'
     - 'tools/*'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,8 +2,6 @@ name: lint
 on:
   pull_request:
     paths-ignore:
-    - '.github/workflows/ci.yaml'
-    - '.github/workflows/docker.yaml'
     - '.github/workflows/release.yaml'
     - 'dist/*'
     - 'tools/package'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -58,3 +58,49 @@ jobs:
           command: clippy
           args: --features pg14 -- -D warnings
 
+  pgspot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout extension code
+        uses: actions/checkout@v2
+
+      - name: Setup python 3.10
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+
+      - name: Checkout pgspot
+        uses: actions/checkout@v2
+        with:
+          repository: 'timescale/pgspot'
+          ref: '0.1.0'
+          path: 'pgspot'
+
+      - name: Install pgspot dependencies
+        run: python -m pip install -r pgspot/requirements.txt
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Install cargo-pgx
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-pgx --git https://github.com/timescale/pgx --branch promscale-staging
+
+      - name: Initialize pgx
+        uses: actions-rs/cargo@v1
+        with:
+          command: pgx
+          args: init --pg14 download
+
+      - name: Prepare control file
+        run: make promscale.control
+
+      - name: Generate schema
+        uses: actions-rs/cargo@v1
+        with:
+          command: pgx
+          args: schema pg14 --out /tmp/schema.sql
+
+      - name: Run pgspot
+        run: ./pgspot/pgspot --sql-accepting=execute_everywhere --sql-accepting=distributed_exec --ignore PS005 /tmp/schema.sql


### PR DESCRIPTION
The pgspot [1] tool is used to spot vulnerabilities in PostgreSQL
extension scripts.

[1]: github.com/timescale/pgspot