### PR TITLE
Fix `safe_approximate_row_count` when timescaledb not present

### DIFF
--- a/migration/idempotent/001-base.sql
+++ b/migration/idempotent/001-base.sql
@@ -719,12 +719,13 @@ BEGIN
     IF _prom_catalog.get_timescale_major_version() >= 2 THEN
         RETURN (SELECT * FROM public.approximate_row_count(table_name_input));
     ELSE
-        IF _prom_catalog.is_timescaledb_installed()
-            AND (SELECT count(*) > 0
+        IF _prom_catalog.is_timescaledb_installed() THEN
+            IF (SELECT count(*) > 0
                 FROM _timescaledb_catalog.hypertable
                 WHERE format('%I.%I', schema_name, table_name)::regclass=table_name_input)
-        THEN
+            THEN
                 RETURN (SELECT row_estimate FROM hypertable_approximate_row_count(table_name_input));
+            END IF;
         END IF;
         RETURN (SELECT reltuples::BIGINT FROM pg_class WHERE oid=table_name_input);
     END IF;


### PR DESCRIPTION
Postgres doesn't short-circuit evaluate `IF cond_a AND cond_b` when
`cond_a` is false, so it to evaluates `cond_b`. In this case the
evaluation of `cond_b` will fail when `cond_a` is false.