### PR TITLE
Set database-wide default search_path

### DIFF
--- a/e2e/testdata/support.sql
+++ b/e2e/testdata/support.sql
@@ -22,4 +22,4 @@ FROM generate_series(1,10) g;
 --this should use a subquery with the Promscale extension but not without
 --this is thanks to the support function make_call_subquery_support
 ANALYZE;
-EXPLAIN (costs off) SELECT time, value, prom_api.jsonb(labels), prom_api.val(namespace_id) FROM prom_metric.cpu_usage WHERE labels OPERATOR(_prom_catalog.?) ('namespace' OPERATOR(ps_tag.!==) 'dev' ) ORDER BY time, series_id LIMIT 5;
+EXPLAIN (costs off) SELECT time, value, prom_api.jsonb(labels), prom_api.val(namespace_id) FROM prom_metric.cpu_usage WHERE labels OPERATOR(prom_api.?) ('namespace' OPERATOR(ps_tag.!==) 'dev' ) ORDER BY time, series_id LIMIT 5;

--- a/e2e/tests/snapshots/golden_tests__golden_test_testdata_support_sql.snap
+++ b/e2e/tests/snapshots/golden_tests__golden_test_testdata_support_sql.snap
@@ -39,7 +39,7 @@ INSERT 0 10
 --this is thanks to the support function make_call_subquery_support
 ANALYZE;
 ANALYZE
-EXPLAIN (costs off) SELECT time, value, prom_api.jsonb(labels), prom_api.val(namespace_id) FROM prom_metric.cpu_usage WHERE labels OPERATOR(_prom_catalog.?) ('namespace' OPERATOR(ps_tag.!==) 'dev' ) ORDER BY time, series_id LIMIT 5;
+EXPLAIN (costs off) SELECT time, value, prom_api.jsonb(labels), prom_api.val(namespace_id) FROM prom_metric.cpu_usage WHERE labels OPERATOR(prom_api.?) ('namespace' OPERATOR(ps_tag.!==) 'dev' ) ORDER BY time, series_id LIMIT 5;
                                        QUERY PLAN                                       
 ----------------------------------------------------------------------------------------
  Limit

--- a/migration/migration/004-schemas.sql
+++ b/migration/migration/004-schemas.sql
@@ -43,16 +43,3 @@ GRANT USAGE ON SCHEMA ps_trace TO prom_reader;
 
 -- _ps_catalog is created before
 GRANT USAGE ON SCHEMA _ps_catalog TO prom_reader;
-
--- the promscale extension contains optimized version of some
--- of our functions and operators. To ensure the correct version of the are
--- used, _prom_ext must be before all of our other schemas in the search path
-DO $$
-DECLARE
-   new_path text;
-BEGIN
-   new_path := format('%L,%L,%L,%L,%L,%L,%L,%L', '$user','public', 'ps_tag', '_prom_ext', 'prom_api', 'prom_metric', '_prom_catalog', 'ps_trace');
-   execute format('ALTER DATABASE %I SET search_path = %s', current_database(), new_path);
-   execute format('SET search_path = %s', new_path);
-END
-$$;

--- a/migration/migration/017-set-search-path.sql
+++ b/migration/migration/017-set-search-path.sql
@@ -1,0 +1,34 @@
+-- We had these operators in the private _prom_catalog schema instead of the
+-- public prom_api schema. With the new (restricted) search path, we need to
+-- move these.
+ALTER OPERATOR _prom_catalog.? (prom_api.label_array, ps_tag.tag_op_equals) SET SCHEMA prom_api;
+ALTER OPERATOR _prom_catalog.? (prom_api.label_array, ps_tag.tag_op_not_equals) SET SCHEMA prom_api;
+ALTER OPERATOR _prom_catalog.? (prom_api.label_array, ps_tag.tag_op_regexp_matches) SET SCHEMA prom_api;
+ALTER OPERATOR _prom_catalog.? (prom_api.label_array, ps_tag.tag_op_regexp_not_matches) SET SCHEMA prom_api;
+
+-- Setup the database-wide search path, so that users who want to interact with
+-- the promscale extension's SQL objects are able to do so without much fuss.
+DO $$
+    DECLARE
+        base_components TEXT[];
+        new_components TEXT[];
+        final_components TEXT[];
+        new_path TEXT;
+    BEGIN
+        -- we use the `reset_val` for `search_path` as the "clean" base of our search path
+        SELECT regexp_split_to_array(reset_val, ',\s*') FROM pg_settings WHERE name = 'search_path' INTO base_components;
+        -- we only want to add our components to the search path if they're not already in there
+        WITH only_new_components AS (
+            SELECT UNNEST(ARRAY ['ps_tag', 'prom_api', 'prom_metric', 'ps_trace']) as v
+            EXCEPT
+            SELECT UNNEST(base_components) as v
+        )
+        SELECT array_agg(v) FROM only_new_components INTO new_components;
+
+        final_components := base_components || new_components;
+
+        SELECT array_to_string(final_components, ', ') INTO new_path;
+        EXECUTE format('ALTER DATABASE %I SET search_path = %s', current_database(), new_path);
+        EXECUTE format('SET search_path = %s', new_path);
+    END
+$$;


### PR DESCRIPTION
We assume that most users are going to be installing promscale into a
database which has been setup specifically for promscale. Further, we
assume that without having these search paths available by default,
users will run into trouble with not being able to find the tables,
functions, and operators which promscale provides.

Hence, we set the database-wide default search_path to contain all of
our "public" schemas (private schemas are prefixed with an underscore).
