### PR TITLE
Grant prom roles to session user

### DIFF
--- a/migration/incremental/018-grant-prom-roles.sql
+++ b/migration/incremental/018-grant-prom-roles.sql
@@ -1,0 +1,6 @@
+-- Grant roles to the session user (the one that is installing the extension)
+GRANT prom_reader TO SESSION_USER WITH ADMIN OPTION;
+GRANT prom_writer TO SESSION_USER WITH ADMIN OPTION;
+GRANT prom_maintenance TO SESSION_USER WITH ADMIN OPTION;
+GRANT prom_modifier TO SESSION_USER WITH ADMIN OPTION;
+GRANT prom_admin TO SESSION_USER WITH ADMIN OPTION;


### PR DESCRIPTION
It seems that when using pgextwlist extension the current_user is set to
postgres meaning that roles would not be granted to the user trying to
install the extension.