### PR TITLE
Cast between trace_id and uuid 

### DIFF
--- a/migration/incremental/015-tracing-compression.sql
+++ b/migration/incremental/015-tracing-compression.sql
@@ -187,6 +187,9 @@ DEFAULT FOR TYPE ps_trace.trace_id USING hash AS
 
 GRANT USAGE ON TYPE ps_trace.trace_id TO prom_reader;
 
+-- ps_trace.trace_id and uuid are binary coercible
+CREATE CAST(ps_trace.trace_id as uuid) WITHOUT FUNCTION AS IMPLICIT;
+CREATE CAST(uuid AS ps_trace.trace_id) WITHOUT FUNCTION AS IMPLICIT;
 
 CREATE TABLE _ps_trace.span
 (


### PR DESCRIPTION
These two types are binary coercible and we can cast without a function.

This will enable:

`SELECT '00000000-0000-0000-1763-6d7b3258c7bf'::uuid::ps_trace.trace_id`
`SELECT '00000000-0000-0000-1763-6d7b3258c7bf'::ps_trace.trace_id::uuid`