### PR TITLE
JIT off by default

### DIFF
--- a/migration/incremental/019-jit-off.sql
+++ b/migration/incremental/019-jit-off.sql
@@ -1,0 +1,8 @@
+-- PG JIT compilation doesn't play nicely with TimescaleDB planner and can cause a huge 
+-- slowdown for specific queries so we are turning it off.
+-- We might revisit this once JIT issues are fixed in TimescaleDB */
+DO $$
+    BEGIN
+        EXECUTE format('ALTER DATABASE %I SET jit = off', current_database());
+    END
+$$;


### PR DESCRIPTION
PG JIT compilation doesn't play nicely with TimescaleDB planner
and can cause a huge slowdown for specific queries so we are turning it off.
We might revisit this once JIT issues are fixed in TimescaleDB. (it might not be all TimescaleDB fault as PG itself can perform poorly when JIT is on for specific queries)

Setting JIT on database level will also disable it for 3rd party apps connecting to database (which is a good thing imho)

Related TimescaleDB issue https://github.com/timescale/timescaledb/issues/4222