### PR TITLE
Rename tracing enums

### DIFF
--- a/e2e/scripts/post-snapshot.sql
+++ b/e2e/scripts/post-snapshot.sql
@@ -44,7 +44,7 @@ select ps_trace.put_tag_key('test-tag-3', ps_trace.span_tag_type());
 select ps_trace.put_tag('test-tag-2', to_jsonb(2), ps_trace.span_tag_type());
 select ps_trace.put_tag('test-tag-3', to_jsonb(3), ps_trace.span_tag_type());
 select ps_trace.put_instrumentation_lib('test-inst-lib-1', '9.9.9', ps_trace.put_schema_url('buz.bam.bip'));
-select ps_trace.put_operation('test-service-1', 'endpoint-1', 'SPAN_KIND_SERVER'::ps_trace.span_kind);
+select ps_trace.put_operation('test-service-1', 'endpoint-1', 'server'::ps_trace.span_kind);
 
 insert into _ps_trace.span
 ( trace_id
@@ -80,7 +80,7 @@ insert into _ps_trace.span
 , tstzrange('2030-01-06 01:02'::timestamptz, '2030-01-06 01:03'::timestamptz, '[)')
 , 2
 , 3
-, 'STATUS_CODE_OK'::ps_trace.status_code
+, 'ok'::ps_trace.status_code
 , 'OK'
 , 1
 , ps_trace.get_tag_map(jsonb_build_object('test-tag-1', to_jsonb(1)))
@@ -100,7 +100,7 @@ insert into _ps_trace.span
 , tstzrange('2030-01-06 01:02'::timestamptz, '2030-01-06 01:03'::timestamptz, '[)')
 , 2
 , 3
-, 'STATUS_CODE_OK'::ps_trace.status_code
+, 'ok'::ps_trace.status_code
 , 'OK'
 , 1
 , ps_trace.get_tag_map(jsonb_build_object('test-tag-1', to_jsonb(1)))

--- a/e2e/scripts/pre-dump.sql
+++ b/e2e/scripts/pre-dump.sql
@@ -46,7 +46,7 @@ select ps_trace.put_tag_key('test-tag-1', ps_trace.span_tag_type());
 select ps_trace.put_tag('test-tag-0', to_jsonb(0), ps_trace.span_tag_type());
 select ps_trace.put_tag('test-tag-1', to_jsonb(1), ps_trace.span_tag_type());
 select ps_trace.put_instrumentation_lib('test-inst-lib-0', '9.9.9', ps_trace.put_schema_url('foo.bar.baz'));
-select ps_trace.put_operation('test-service-0', 'endpoint-0', 'SPAN_KIND_SERVER'::ps_trace.span_kind);
+select ps_trace.put_operation('test-service-0', 'endpoint-0', 'server'::ps_trace.span_kind);
 
 insert into _ps_trace.span
 ( trace_id
@@ -82,7 +82,7 @@ insert into _ps_trace.span
 , tstzrange('2030-01-06 01:02'::timestamptz, '2030-01-06 01:03'::timestamptz, '[)')
 , 2
 , 3
-, 'STATUS_CODE_OK'::ps_trace.status_code
+, 'ok'::ps_trace.status_code
 , 'OK'
 , 1
 , ps_trace.get_tag_map(jsonb_build_object('test-tag-1', to_jsonb(1)))
@@ -102,7 +102,7 @@ insert into _ps_trace.span
 , tstzrange('2030-01-06 01:02'::timestamptz, '2030-01-06 01:03'::timestamptz, '[)')
 , 2
 , 3
-, 'STATUS_CODE_OK'::ps_trace.status_code
+, 'ok'::ps_trace.status_code
 , 'OK'
 , 1
 , ps_trace.get_tag_map(jsonb_build_object('test-tag-1', to_jsonb(1)))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ mod tests {
         let (res_id, res_val) = Spi::get_two_with_args::<i64, String>(
             r#"
                 SELECT id, value::text
-                FROM _ps_trace.tag 
+                FROM _ps_trace.tag
                 WHERE id = $1
                 "#,
             vec![(PgBuiltInOids::INT8OID.oid(), tag_id.into_datum())],
@@ -95,10 +95,9 @@ mod tests {
 
     #[pg_test]
     fn test_tag_funs() {
-        let op_tag_id = Spi::get_one::<i64>(
-            r#"SELECT put_operation('myservice', 'test', 'SPAN_KIND_UNSPECIFIED');"#,
-        )
-        .expect("SQL query failed");
+        let op_tag_id =
+            Spi::get_one::<i64>(r#"SELECT put_operation('myservice', 'test', 'unspecified');"#)
+                .expect("SQL query failed");
 
         let srvc_tag_id = Spi::get_one::<i64>(
             r#"SELECT put_tag('service.name', '"myservice"'::jsonb, resource_tag_type())"#,
@@ -110,8 +109,8 @@ mod tests {
             SELECT id
             FROM _ps_trace.operation
             WHERE service_name_id = $1
-            AND span_kind = 'SPAN_KIND_UNSPECIFIED'
-            AND span_name = 'test'; 
+            AND span_kind = 'unspecified'
+            AND span_name = 'test';
             "#,
             vec![(PgBuiltInOids::INT8OID.oid(), srvc_tag_id.into_datum())],
         )


### PR DESCRIPTION
This makes the enum names much more user-friendly on the SQL level.
We made them lowercase and removed the prefix.

```
SELECT
  *
FROM ps_trace.span
WHERE start_time > NOW() - INTERVAL '30m'
AND status_code = 'STATUS_CODE_ERROR'
```

Now becomes

```
SELECT
  *
FROM ps_trace.span
WHERE start_time > NOW() - INTERVAL '30m'
AND status_code = 'error'
```