### PR TITLE
Correctly determine package version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
           version="$(echo "${GITHUB_REF}" | sed -e 's|refs/tags/||')"; \
           tag="${version}"; \
         else \
-          tag="$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[0].version')"; \
+          tag="$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "promscale") | .version')"; \
           version="${tag}-snapshot"; \
         fi;
         # a dash indicates a pre-release version in semver

--- a/tools/package
+++ b/tools/package
@@ -127,7 +127,7 @@ if ! command -v fpm; then
 fi
 
 if [ -z "${version}" ]; then
-    if ! version="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')"; then
+    if ! version="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "promscale") | .version')"; then
         echo "${version}"
         echo "Failed to read extension version from Cargo metadata!"
         exit 1


### PR DESCRIPTION
The commands to parse `cargo metadata` didn't handle cargo workspaces
correctly, so were pulling out the version of the `e2e` package instead
of the `promscale` package.