### PR TITLE
Improve build caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,11 @@ jobs:
         - version: "14"
         - version: "13"
         - version: "12"
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_BUCKET: promscale-extension-sccache
+      AWS_ACCESS_KEY_ID: ${{ secrets.PROMSCALE_EXTENSION_SCCACHE_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.PROMSCALE_EXTENSION_SCCACHE_AWS_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v2
       - name: Install latest nightly
@@ -23,6 +28,13 @@ jobs:
         with:
             toolchain: stable
             override: true
+
+      - name: Setup sccache
+        run: |
+          curl -L "https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz" | tar zxf -
+          chmod +x sccache-*/sccache
+          sudo mv sccache-*/sccache /usr/local/bin/sccache
+          sccache --show-stats
 
       - uses: Swatinem/rust-cache@v1
 
@@ -51,4 +63,7 @@ jobs:
         with:
           command: pgx
           args: test pg${{ matrix.postgres.version }}
+
+      - name: Show sccache stats
+        run: sccache --show-stats
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -59,6 +59,9 @@ jobs:
             TIMESCALEDB_VERSION_FULL=${{ matrix.tsversion }}
             TIMESCALEDB_VERSION_MAJOR=${{ steps.metadata.outputs.tsmajor }}
             TIMESCALEDB_VERSION_MAJMIN=${{ steps.metadata.outputs.tsmajmin }}
+          secrets: |
+            "AWS_ACCESS_KEY_ID=${{ secrets.PROMSCALE_EXTENSION_SCCACHE_AWS_ACCESS_KEY_ID }}"
+            "AWS_SECRET_ACCESS_KEY=${{ secrets.PROMSCALE_EXTENSION_SCCACHE_AWS_SECRET_ACCESS_KEY }}"
           context: .
           file: ${{matrix.base}}.Dockerfile
           push: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,6 +27,11 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_BUCKET: promscale-extension-sccache
+      AWS_ACCESS_KEY_ID: ${{ secrets.PROMSCALE_EXTENSION_SCCACHE_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.PROMSCALE_EXTENSION_SCCACHE_AWS_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v2
       - name: Install latest nightly
@@ -35,6 +40,13 @@ jobs:
             toolchain: stable
             override: true
             components: rustfmt, clippy
+
+      - name: Setup sccache
+        run: |
+          curl -L "https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz" | tar zxf -
+          chmod +x sccache-*/sccache
+          sudo mv sccache-*/sccache /usr/local/bin/sccache
+          sccache --show-stats
 
       - uses: Swatinem/rust-cache@v1
 
@@ -58,6 +70,11 @@ jobs:
 
   pgspot:
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_BUCKET: promscale-extension-sccache
+      AWS_ACCESS_KEY_ID: ${{ secrets.PROMSCALE_EXTENSION_SCCACHE_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.PROMSCALE_EXTENSION_SCCACHE_AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Checkout extension code
         uses: actions/checkout@v2
@@ -76,6 +93,13 @@ jobs:
 
       - name: Install pgspot dependencies
         run: python -m pip install -r pgspot/requirements.txt
+
+      - name: Setup sccache
+        run: |
+          curl -L "https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz" | tar zxf -
+          chmod +x sccache-*/sccache
+          sudo mv sccache-*/sccache /usr/local/bin/sccache
+          sccache --show-stats
 
       - uses: Swatinem/rust-cache@v1
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,6 +92,9 @@ jobs:
           PG_VERSION=${{ matrix.postgres.version }}
           RUST_VERSION=${{ env.RUST_VERSION }}
           RELEASE_FILE_NAME=${{ steps.metadata.outputs.filename }}
+        secrets: |
+          "AWS_ACCESS_KEY_ID=${{ secrets.PROMSCALE_EXTENSION_SCCACHE_AWS_ACCESS_KEY_ID }}"
+          "AWS_SECRET_ACCESS_KEY=${{ secrets.PROMSCALE_EXTENSION_SCCACHE_AWS_SECRET_ACCESS_KEY }}"
         tags: ${{ steps.metadata.outputs.image }}
 
     - name: Extract Package
@@ -118,6 +121,9 @@ jobs:
           PG_VERSION=${{ matrix.postgres.version }}
           RUST_VERSION=${{ env.RUST_VERSION }}
           RELEASE_FILE_NAME=${{ steps.metadata.outputs.filename }}
+        secrets: |
+          "AWS_ACCESS_KEY_ID=${{ secrets.PROMSCALE_EXTENSION_SCCACHE_AWS_ACCESS_KEY_ID }}"
+          "AWS_SECRET_ACCESS_KEY=${{ secrets.PROMSCALE_EXTENSION_SCCACHE_AWS_SECRET_ACCESS_KEY }}"
         tags: ${{ steps.metadata.outputs.image }}-test
 
     - name: Test Package


### PR DESCRIPTION
This change integrates a number of improvements to caching in our build
pipelines. The results of different comparisons can be seen here: [1].

Overall, testing changes to caching is _hard_ because there are a lot of
different caching mechanisms in place. We already use caching in Docker
layers, and for "local" (not in Docker) Rust compilation. These existing
mechanisms can confound the result of a run.

The main change is integrating `sccache` into all aspects of the build.
We configure it to use an S3 bucket as the backing store for cached
artifacts, which allows the cache to be persisted over multiple CI runs.

The following is a breakdown of the major experiments and their results:

- ci.yaml

  This workflow consists primarily of Rust compilation directly on the
  github actions runner. Here can use the `swatinem/rust-cache`
  action to cache the intermediate compile outputs. We evaluated the
  build times of the following configurations:

  1. No caching at all                             14m23s [ci-1]
  2. Only `swatinem/rust-cache`                     5m46s [ci-2]
  3. Only `sccache`                                 9m16s [ci-3]
  4. Both `swatinem/rust-cache` and `sccache`       5m19s [ci-4]

- release.yaml

  This workflow consists primarily of Rust compilation inside a Docker
  container. This _can_ profit from Docker layering, but this is not
  always effective. Here we compared two configurations, where Docker
  layer caching was not in effect:

  1. No caching at all                             38m19s [r-1]
  2. `sccache` for Rust builds in Docker           22m50s [r-2]

We also ran both lint.yaml and docker.yaml in an "sccache" and
"no-sccache" setup to compare the differences. There the differences are
less pronounced, with `sccache` builds being _marginally_ slower.


[1]: https://github.com/timescale/promscale_extension/pull/216

[ci-1]: https://github.com/timescale/promscale_extension/actions/runs/2269259208
[ci-2]: https://github.com/timescale/promscale_extension/actions/runs/2269259211
[ci-3]: https://github.com/timescale/promscale_extension/actions/runs/2269259214
[ci-4]: https://github.com/timescale/promscale_extension/actions/runs/2269259212

[r-1]: https://github.com/timescale/promscale_extension/actions/runs/2269259218
[r-2]: https://github.com/timescale/promscale_extension/actions/runs/2269259202