### PR TITLE
Fix migration query speed

### DIFF
--- a/migration/incremental/020-series-partitions.sql
+++ b/migration/incremental/020-series-partitions.sql
@@ -93,20 +93,14 @@ BEGIN
     -- rename the indexes on any existing series partitions to match the new naming scheme
     FOR _cmd IN
     (
-        SELECT format('ALTER INDEX IF EXISTS prom_data_series.%I RENAME TO series_delete_epoch_id_%s', f.indexname, m.id)
-        FROM pg_catalog.pg_inherits i
-        INNER JOIN pg_catalog.pg_class AS k ON (i.inhrelid=k.oid)
-        INNER JOIN pg_catalog.pg_class as p ON (i.inhparent=p.oid)
-        INNER JOIN pg_catalog.pg_namespace pn ON pn.oid = p.relnamespace
-        INNER JOIN pg_catalog.pg_namespace kn ON kn.oid = k.relnamespace
-        INNER JOIN pg_catalog.pg_index x on (k.oid = x.indrelid)
-        INNER JOIN pg_catalog.pg_class d on (x.indexrelid = d.oid)
-        INNER JOIN pg_catalog.pg_indexes f on (kn.nspname = f.schemaname AND d.relname = f.indexname)
-        INNER JOIN _prom_catalog.metric m ON (format('%I', m.table_name) = k.relname)
-        WHERE pn.nspname = '_prom_catalog'
-        AND p.relname = 'series'
-        AND kn.nspname = 'prom_data_series'
-        AND f.indexdef like '% USING btree (delete_epoch, id) WHERE (delete_epoch IS NOT NULL)'
+        SELECT DISTINCT ON (indclass.oid) --continous aggs can share series tables
+            format('ALTER INDEX IF EXISTS prom_data_series.%I RENAME TO series_delete_epoch_id_%s', indclass.relname, m.id)
+        FROM  _prom_catalog.metric m
+        INNER JOIN pg_catalog.pg_class AS series_table ON (m.series_table = series_table.relname)
+        INNER JOIN pg_catalog.pg_index indref on (series_table.oid = indref.indrelid)
+        INNER JOIN pg_catalog.pg_class indclass on (indref.indexrelid = indclass.oid)
+        WHERE series_table.relnamespace = (SELECT oid FROM pg_catalog.pg_namespace n WHERE n.nspname = 'prom_data_series')
+        AND pg_get_indexdef(indclass.oid) like '% USING btree (delete_epoch, id) WHERE (delete_epoch IS NOT NULL)'
     )
     LOOP
         EXECUTE _cmd;
@@ -115,20 +109,14 @@ BEGIN
     -- rename the indexes on any existing series partitions to match the new naming scheme
     FOR _cmd IN
     (
-        SELECT format('ALTER INDEX IF EXISTS prom_data_series.%I RENAME TO series_labels_%s', f.indexname, m.id)
-        FROM pg_catalog.pg_inherits i
-        INNER JOIN pg_catalog.pg_class AS k ON (i.inhrelid=k.oid)
-        INNER JOIN pg_catalog.pg_class as p ON (i.inhparent=p.oid)
-        INNER JOIN pg_catalog.pg_namespace pn ON pn.oid = p.relnamespace
-        INNER JOIN pg_catalog.pg_namespace kn ON kn.oid = k.relnamespace
-        INNER JOIN pg_catalog.pg_index x on (k.oid = x.indrelid)
-        INNER JOIN pg_catalog.pg_class d on (x.indexrelid = d.oid)
-        INNER JOIN pg_catalog.pg_indexes f on (kn.nspname = f.schemaname AND d.relname = f.indexname)
-        INNER JOIN _prom_catalog.metric m ON (format('%I', m.table_name) = k.relname)
-        WHERE pn.nspname = '_prom_catalog'
-        AND p.relname = 'series'
-        AND kn.nspname = 'prom_data_series'
-        AND f.indexdef like '% USING gin (labels)'
+        SELECT DISTINCT ON (indclass.oid) --continous aggs can share series tables
+            format('ALTER INDEX IF EXISTS prom_data_series.%I RENAME TO series_labels_%s', indclass.relname, m.id)
+        FROM  _prom_catalog.metric m
+        INNER JOIN pg_catalog.pg_class AS series_table ON (m.series_table = series_table.relname)
+        INNER JOIN pg_catalog.pg_index indref on (series_table.oid = indref.indrelid)
+        INNER JOIN pg_catalog.pg_class indclass on (indref.indexrelid = indclass.oid)
+        WHERE series_table.relnamespace = (SELECT oid FROM pg_catalog.pg_namespace n WHERE n.nspname = 'prom_data_series')
+        AND pg_get_indexdef(indclass.oid) like '% USING gin (labels)'
     )
     LOOP
         EXECUTE _cmd;


### PR DESCRIPTION
The old query took a long time on a DB with lots of data. The
renaming itself is and was quick. It's just the query to get
the list of indexes used to be slow.