### PR TITLE
Create packages as `promscale-extension`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,11 +75,11 @@ jobs:
         fi;
         echo "::set-output name=version::${version}"
         echo "::set-output name=tag::${tag}"
-        echo "::set-output name=filename::promscale_extension-${tag}.pg${{ matrix.postgres.version }}.${{ matrix.os.distro }}${{ matrix.os.version }}.${{ matrix.arch.cpu }}.${{ matrix.os.pkg_type }}"
-        echo "::set-output name=outfile::promscale_extension-${version}.pg${{ matrix.postgres.version }}.${{ matrix.os.distro }}${{ matrix.os.version }}.${{ matrix.arch.cpu }}.${{ matrix.os.pkg_type }}"
+        echo "::set-output name=filename::promscale-extension-${tag}.pg${{ matrix.postgres.version }}.${{ matrix.os.distro }}${{ matrix.os.version }}.${{ matrix.arch.cpu }}.${{ matrix.os.pkg_type }}"
+        echo "::set-output name=outfile::promscale-extension-${version}.pg${{ matrix.postgres.version }}.${{ matrix.os.distro }}${{ matrix.os.version }}.${{ matrix.arch.cpu }}.${{ matrix.os.pkg_type }}"
         echo "::set-output name=repo::${repo}"
         echo "::set-output name=ghopts::${ghopts}"
-        echo "::set-output name=image::promscale_extension:${tag}.pg${{ matrix.postgres.version }}.${{ matrix.os.distro }}${{ matrix.os.version }}"
+        echo "::set-output name=image::promscale-extension:${tag}.pg${{ matrix.postgres.version }}.${{ matrix.os.distro }}${{ matrix.os.version }}"
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v1

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ ifeq ($(OS_NAME),fedora)
 	PKG_TYPE = rpm
 endif
 RELEASE_IMAGE_NAME = promscale-extension-pkg:$(EXT_VERSION)-$(OS_NAME)$(OS_VERSION)-pg$(PG_RELEASE_VERSION)
-RELEASE_FILE_NAME = promscale_extension-$(EXT_VERSION).pg$(PG_RELEASE_VERSION).$(OS_NAME)$(OS_VERSION).$(ARCH).$(PKG_TYPE)
+RELEASE_FILE_NAME = promscale-extension-$(EXT_VERSION).pg$(PG_RELEASE_VERSION).$(OS_NAME)$(OS_VERSION).$(ARCH).$(PKG_TYPE)
 
 .PHONY: help
 help:

--- a/tools/package
+++ b/tools/package
@@ -190,7 +190,7 @@ esac
 
 # Ensure a package filename is set
 if [ -z "${pkg_name}" ]; then
-    pkg_name="promscale_extension-${version}.pg${pg_version}.${os_name}${os_version}.${arch}.${pkg_type}"
+    pkg_name="promscale-extension-${version}.pg${pg_version}.${os_name}${os_version}.${arch}.${pkg_type}"
 fi
 
 # Select the appropriate package name for the Postgres dependency
@@ -267,7 +267,7 @@ fpm --log info -s dir -t "${pkg_type}" \
     --url 'https://github.com/timescale/promscale_extension' \
     --category database \
     --depends "${pg_package}" \
-    --name "promscale_extension-postgresql-${pg_version}" \
+    --name "promscale-extension-postgresql-${pg_version}" \
     --version "${version}" \
     --iteration 1 \
     -C "target/release/promscale-pg${pg_version}" \


### PR DESCRIPTION
Debian/Ubuntu has the convention that package names do not contain
underscores [1]. While Fedora allows underscores, it states that dashes
should be used in preference of underscores [2].

[1]: https://www.debian.org/doc/debian-policy/ch-controlfields.html#source
[2]: https://fedoraproject.org/wiki/Packaging:Naming?rd=Packaging:NamingGuidelines#General_Naming