### PR TITLE
Support for reuse temp table for trace ingest 

### DIFF
--- a/migration/idempotent/008-tracing-functions.sql
+++ b/migration/idempotent/008-tracing-functions.sql
@@ -584,7 +584,7 @@ BEGIN
 
     SET LOCAL log_statement = 'none';
 
-    EXECUTE format($sql$CREATE TEMPORARY TABLE IF NOT EXISTS %I ON COMMIT DELETE ROWS AS TABLE _ps_trace.%I WITH NO DATA$sql$,
+    EXECUTE format($sql$CREATE TEMPORARY TABLE IF NOT EXISTS %I (LIKE _ps_trace.%I) ON COMMIT DELETE ROWS$sql$,
                     _temp_table_name, _proto_table_name);
     EXECUTE format($sql$GRANT SELECT, INSERT ON TABLE %I TO prom_writer$sql$,
                     _temp_table_name);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ mod util;
 pg_module_magic!();
 
 /// A helper function for building [`pgx::PgList`] out of
-/// iterable collection of binary, C-compatible strings.
+/// iterable collection of `str`.
 ///
 /// For safety reasons it p-allocates and copies its arguemnts
 /// every time. Which is OK for our current once-per-query usage,


### PR DESCRIPTION
Creates a temporary table (if it doesn't exist), suitable for tracing data ingestion.
Suppresses corresponding DDL logging, otherwise, the PG log may get unnecessarily verbose.

Addresses https://github.com/timescale/promscale/pull/1333