### PR TITLE
Fix tag_v type missing some operators and opclass

### DIFF
--- a/e2e/tests/snapshots/golden_tests__testdata__tag_map.sql.snap
+++ b/e2e/tests/snapshots/golden_tests__testdata__tag_map.sql.snap
@@ -2,7 +2,6 @@
 source: e2e/tests/golden-tests.rs
 expression: query_result
 ---
-\set ON_ERROR_STOP 1
 CREATE EXTENSION promscale;
 CREATE EXTENSION
 SELECT put_tag_key('char', ps_trace.span_tag_type());      /* 1001 */
@@ -71,9 +70,9 @@ EXECUTE neq_test;
 (1 row)
 
 /* Not equals uses support function and produces correct plan */
-SELECT 
+SELECT
     x::text LIKE '%InitPlan%',
-    x::text LIKE '% @> ANY%' 
+    x::text LIKE '% @> ANY%'
 FROM explain_jsonb('EXECUTE neq_test') AS f(x);
  ?column? | ?column? 
 ----------+----------
@@ -89,9 +88,9 @@ SELECT trace_id
         AND resource_tags -> 'service.name' = '"generator"';
 PREPARE
 /* Equals uses support function and produces correct plan */
-SELECT 
+SELECT
     x::text LIKE '%InitPlan%',
-    x::text LIKE '% @> %' 
+    x::text LIKE '% @> %'
 FROM explain_jsonb('EXECUTE eq_test') AS f(x);
  ?column? | ?column? 
 ----------+----------
@@ -99,22 +98,34 @@ FROM explain_jsonb('EXECUTE eq_test') AS f(x);
 (1 row)
 
 /* Functions, underpinning tag_map operators handle NULL arguments correctly */
-SELECT ps_trace.tag_v_eq(NULL, NULL);
- tag_v_eq 
+SELECT ps_trace.tag_v_eq(NULL::_ps_trace.tag_v, NULL::pg_catalog.jsonb) IS NULL;
+ ?column? 
 ----------
- 
+ t
 (1 row)
 
-SELECT ps_trace.tag_v_ne(NULL, NULL);
- tag_v_ne 
+SELECT ps_trace.tag_v_eq(NULL::_ps_trace.tag_v, NULL::_ps_trace.tag_v) IS NULL;
+ ?column? 
 ----------
- 
+ t
 (1 row)
 
-SELECT ps_trace.tag_map_object_field(NULL, NULL);
- tag_map_object_field 
-----------------------
- 
+SELECT ps_trace.tag_v_ne(NULL::_ps_trace.tag_v, NULL::pg_catalog.jsonb) IS NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT ps_trace.tag_v_ne(NULL::_ps_trace.tag_v, NULL::_ps_trace.tag_v) IS NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT ps_trace.tag_map_object_field(NULL, NULL) IS NULL;
+ ?column? 
+----------
+ t
 (1 row)
 
 /* Test tags in the link view */
@@ -122,7 +133,6 @@ INSERT INTO _ps_trace.link(trace_id, span_id, linked_trace_id, linked_span_id, t
     VALUES
         (E'78dd078e-8c69-e10a-d2fe-9e9f47de7728',-2771219554170079234, E'05a8be0f-bb79-c052-223e-48608580efce',2625299614982951051, E'{"1": 114, "5": 94, "6": 93, "7": 95}', E'2022-04-26 11:44:55.185139+00');
 INSERT 0 1
-	
 SELECT span_tags, resource_tags, linked_span_tags, linked_resource_tags, link_tags FROM link;
    span_tags   |                                                               resource_tags                                                                | linked_span_tags |                                                            linked_resource_tags                                                            |                                                                 link_tags                                                                  
 ---------------+--------------------------------------------------------------------------------------------------------------------------------------------+------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------
@@ -138,5 +148,20 @@ SELECT event_tags, span_tags, resource_tags FROM event;
 ------------------------------------------------------------------------+---------------+--------------------------------------------------------------------------------------------------------------------------------------------
  {"telemetry.sdk.version": "1.8.0", "telemetry.sdk.language": "python"} | {"pwlen": 25} | {"service.name": "generator", "telemetry.sdk.name": "opentelemetry", "telemetry.sdk.version": "1.8.0", "telemetry.sdk.language": "python"}
 (1 row)
+
+/* Distinct/group by for tag_v type */
+SELECT DISTINCT span_tags -> 'pwlen' FROM span ;
+ ?column? 
+----------
+ 18
+ 25
+(2 rows)
+
+SELECT span_tags -> 'pwlen' AS tagv FROM span  GROUP BY tagv;
+ tagv 
+------
+ 18
+ 25
+(2 rows)
 
 

--- a/migration/idempotent/007-tracing-tags.sql
+++ b/migration/idempotent/007-tracing-tags.sql
@@ -2,7 +2,7 @@
 -- Tag_map related functions and operators
 -------------------------------------------------------------------------------
 
-CREATE FUNCTION _ps_trace.tag_map_denormalize(_map ps_trace.tag_map)
+CREATE OR REPLACE FUNCTION _ps_trace.tag_map_denormalize(_map ps_trace.tag_map)
     RETURNS ps_trace.tag_map
     LANGUAGE sql STABLE
     PARALLEL SAFE AS
@@ -54,6 +54,15 @@ CREATE OR REPLACE FUNCTION ps_trace.tag_v_eq(_ps_trace.tag_v, pg_catalog.jsonb)
     AS 'jsonb_eq';
 GRANT EXECUTE ON FUNCTION ps_trace.tag_v_eq(_ps_trace.tag_v, pg_catalog.jsonb) TO prom_reader;
 
+CREATE OR REPLACE FUNCTION ps_trace.tag_v_eq(_ps_trace.tag_v, _ps_trace.tag_v)
+    RETURNS pg_catalog.bool
+    LANGUAGE internal
+        IMMUTABLE
+        STRICT
+        PARALLEL SAFE
+    AS 'jsonb_eq';
+GRANT EXECUTE ON FUNCTION ps_trace.tag_v_eq(_ps_trace.tag_v, _ps_trace.tag_v) TO prom_reader;
+
 CREATE OR REPLACE FUNCTION _ps_trace.tag_v_eq_matching_tags(_tag_key pg_catalog.text, _value pg_catalog.jsonb)
     RETURNS pg_catalog.jsonb
     LANGUAGE sql STABLE
@@ -86,6 +95,23 @@ EXCEPTION
 END;
 $do$;
 
+
+DO $do$
+BEGIN
+	CREATE OPERATOR ps_trace.= (
+	    FUNCTION       = ps_trace.tag_v_eq,
+	    LEFTARG        = _ps_trace.tag_v,
+	    RIGHTARG       = _ps_trace.tag_v,
+        NEGATOR        = OPERATOR(ps_trace.<>),
+	    RESTRICT       = eqsel,
+	    JOIN           = eqjoinsel,
+	    HASHES, MERGES
+	);
+EXCEPTION
+    WHEN SQLSTATE '42723' THEN -- operator already exists
+        EXECUTE format($q$ALTER OPERATOR ps_trace.=(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
+END;
+$do$;
 -------------------------------------------------------------------------------
 -- not equals
 -------------------------------------------------------------------------------
@@ -98,6 +124,16 @@ CREATE OR REPLACE FUNCTION ps_trace.tag_v_ne(_ps_trace.tag_v, pg_catalog.jsonb)
         SUPPORT _prom_ext.tag_map_rewrite
     AS 'jsonb_ne';
 GRANT EXECUTE ON FUNCTION ps_trace.tag_v_ne(_ps_trace.tag_v, pg_catalog.jsonb) TO prom_reader;
+
+CREATE OR REPLACE FUNCTION ps_trace.tag_v_ne(_ps_trace.tag_v, _ps_trace.tag_v)
+    RETURNS pg_catalog.bool
+    LANGUAGE internal
+        IMMUTABLE
+        STRICT
+        PARALLEL SAFE
+    AS 'jsonb_ne';
+GRANT EXECUTE ON FUNCTION ps_trace.tag_v_ne(_ps_trace.tag_v, _ps_trace.tag_v) TO prom_reader;
+
 
 CREATE OR REPLACE FUNCTION _ps_trace.tag_v_ne_matching_tags(_tag_key pg_catalog.text, _value pg_catalog.jsonb)
     RETURNS pg_catalog.jsonb[]
@@ -125,6 +161,158 @@ BEGIN
 	);
 EXCEPTION
     WHEN SQLSTATE '42723' THEN -- operator already exists
-        EXECUTE format($q$ALTER OPERATOR ps_trace.=(_ps_trace.tag_v, pg_catalog.jsonb) OWNER TO %I$q$, current_user);
+        EXECUTE format($q$ALTER OPERATOR ps_trace.<>(_ps_trace.tag_v, pg_catalog.jsonb) OWNER TO %I$q$, current_user);
+END;
+$do$;
+
+DO $do$
+BEGIN
+	CREATE OPERATOR ps_trace.<> (
+	    FUNCTION       = ps_trace.tag_v_ne,
+	    LEFTARG        = _ps_trace.tag_v,
+	    RIGHTARG       = _ps_trace.tag_v,
+	    NEGATOR        = OPERATOR(ps_trace.=),
+	    RESTRICT       = neqsel,
+	    JOIN           = neqjoinsel
+	);
+EXCEPTION
+    WHEN SQLSTATE '42723' THEN -- operator already exists
+        EXECUTE format($q$ALTER OPERATOR ps_trace.<>(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
+END;
+$do$;
+
+-------------------------------------------------------------------------------
+-- comparison
+-------------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION _ps_trace.tag_v_cmp(_ps_trace.tag_v, _ps_trace.tag_v)
+    RETURNS pg_catalog.int4
+    LANGUAGE internal
+        IMMUTABLE
+        STRICT
+        PARALLEL SAFE
+    AS 'jsonb_cmp';
+GRANT EXECUTE ON FUNCTION _ps_trace.tag_v_cmp(_ps_trace.tag_v, _ps_trace.tag_v) TO prom_reader;
+
+CREATE OR REPLACE FUNCTION ps_trace.tag_v_gt(_ps_trace.tag_v, _ps_trace.tag_v)
+    RETURNS pg_catalog.bool
+    LANGUAGE internal
+        IMMUTABLE
+        STRICT
+        PARALLEL SAFE
+    AS 'jsonb_gt';
+GRANT EXECUTE ON FUNCTION ps_trace.tag_v_gt(_ps_trace.tag_v, _ps_trace.tag_v) TO prom_reader;
+
+CREATE OR REPLACE FUNCTION ps_trace.tag_v_ge(_ps_trace.tag_v, _ps_trace.tag_v)
+    RETURNS pg_catalog.bool
+    LANGUAGE internal
+        IMMUTABLE
+        STRICT
+        PARALLEL SAFE
+    AS 'jsonb_ge';
+GRANT EXECUTE ON FUNCTION ps_trace.tag_v_ge(_ps_trace.tag_v, _ps_trace.tag_v) TO prom_reader;
+
+CREATE OR REPLACE FUNCTION ps_trace.tag_v_lt(_ps_trace.tag_v, _ps_trace.tag_v)
+    RETURNS pg_catalog.bool
+    LANGUAGE internal
+        IMMUTABLE
+        STRICT
+        PARALLEL SAFE
+    AS 'jsonb_lt';
+GRANT EXECUTE ON FUNCTION ps_trace.tag_v_lt(_ps_trace.tag_v, _ps_trace.tag_v) TO prom_reader;
+
+CREATE OR REPLACE FUNCTION ps_trace.tag_v_le(_ps_trace.tag_v, _ps_trace.tag_v)
+    RETURNS pg_catalog.bool
+    LANGUAGE internal
+        IMMUTABLE
+        STRICT
+        PARALLEL SAFE
+    AS 'jsonb_le';
+GRANT EXECUTE ON FUNCTION ps_trace.tag_v_le(_ps_trace.tag_v, _ps_trace.tag_v) TO prom_reader;
+
+DO $do$
+BEGIN
+	CREATE OPERATOR ps_trace.> (
+	    FUNCTION       = ps_trace.tag_v_gt,
+	    LEFTARG        = _ps_trace.tag_v,
+	    RIGHTARG       = _ps_trace.tag_v,
+	    NEGATOR        = OPERATOR(ps_trace.<=),
+	    RESTRICT       = scalargtsel,
+	    JOIN           = scalargtjoinsel
+	);
+EXCEPTION
+    WHEN SQLSTATE '42723' THEN -- operator already exists
+        EXECUTE format($q$ALTER OPERATOR ps_trace.>(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
+END;
+$do$;
+
+
+DO $do$
+BEGIN
+	CREATE OPERATOR ps_trace.>= (
+	    FUNCTION       = ps_trace.tag_v_ge,
+	    LEFTARG        = _ps_trace.tag_v,
+	    RIGHTARG       = _ps_trace.tag_v,
+	    NEGATOR        = OPERATOR(ps_trace.<),
+	    RESTRICT       = scalargesel,
+	    JOIN           = scalargejoinsel
+	);
+EXCEPTION
+    WHEN SQLSTATE '42723' THEN -- operator already exists
+        EXECUTE format($q$ALTER OPERATOR ps_trace.>=(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
+END;
+$do$;
+
+DO $do$
+BEGIN
+	CREATE OPERATOR ps_trace.< (
+	    FUNCTION       = ps_trace.tag_v_lt,
+	    LEFTARG        = _ps_trace.tag_v,
+	    RIGHTARG       = _ps_trace.tag_v,
+	    NEGATOR        = OPERATOR(ps_trace.>=),
+	    RESTRICT       = scalarltsel,
+	    JOIN           = scalarltjoinsel
+	);
+EXCEPTION
+    WHEN SQLSTATE '42723' THEN -- operator already exists
+        EXECUTE format($q$ALTER OPERATOR ps_trace.<(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
+END;
+$do$;
+
+
+DO $do$
+BEGIN
+	CREATE OPERATOR ps_trace.<= (
+	    FUNCTION       = ps_trace.tag_v_le,
+	    LEFTARG        = _ps_trace.tag_v,
+	    RIGHTARG       = _ps_trace.tag_v,
+	    NEGATOR        = OPERATOR(ps_trace.>),
+	    RESTRICT       = scalarlesel,
+	    JOIN           = scalarlejoinsel
+	);
+EXCEPTION
+    WHEN SQLSTATE '42723' THEN -- operator already exists
+        EXECUTE format($q$ALTER OPERATOR ps_trace.<=(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
+END;
+$do$;
+
+
+
+/* Create opclass for tag_v for distinct/group by type of queries */
+
+DO $do$
+BEGIN
+    CREATE OPERATOR CLASS btree_tag_v_ops
+    DEFAULT FOR TYPE _ps_trace.tag_v USING btree
+    AS
+            OPERATOR        1       <  ,
+            OPERATOR        2       <= ,
+            OPERATOR        3       =  ,
+            OPERATOR        4       >= ,
+            OPERATOR        5       >  ,
+            FUNCTION        1       _ps_trace.tag_v_cmp(_ps_trace.tag_v, _ps_trace.tag_v);
+EXCEPTION
+    WHEN SQLSTATE '42723' THEN -- operator already exists
+        EXECUTE format($q$ALTER OPERATOR CLASS btree_tag_v_ops OWNER TO %I$q$, current_user);
 END;
 $do$;


### PR DESCRIPTION
- Add missing operators
- Add opclass so pg can correctly find `=` operator for the type thus enabling `group by` and `distinct` queries
- Fix/adjust tests
- Some minor fixes in tests
- Bug fixes in idempotent scripts (*please review thoroughly*)