### PR TITLE
Stop all background workers for the duration of the upgrade

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -102,9 +102,12 @@ fn render_bootstrap(manifest_dir: &str) -> String {
     ext_schema_path.push("migration/bootstrap/001-create-ext-schema.sql");
     let ext_schema_sql = wrap(ext_schema_path.as_path(), &Incremental);
 
+    let stop_bgw_sql = include_str!("migration/bootstrap/002-stop-bgw.sql").to_string();
+
     let mut result = String::from("");
     result.push_str(&migration_table_sql);
     result.push_str(&ext_schema_sql);
+    result.push_str(&stop_bgw_sql);
     result
 }
 

--- a/migration/bootstrap/002-stop-bgw.sql
+++ b/migration/bootstrap/002-stop-bgw.sql
@@ -1,0 +1,25 @@
+-- stop all background workers in the current db so they don't interfere
+-- with the upgrade (by e.g. holding locks).
+--
+-- Note: this stops the scheduler (and thus all jobs)
+-- and waits for the current txn (the one doing the upgrade) to finish
+-- before starting it up again. Thus, no jobs will be running during
+-- the upgrade.
+
+-- TimescaleDB itself does the same thing:
+-- https://github.com/timescale/timescaledb/blob/72d03e6f7d30cc4794c9263445f14199241e2eb5/sql/updates/pre-update.sql#L34
+DO
+$stop_bgw$
+DECLARE
+    _is_timescaledb_installed boolean = false;
+BEGIN
+    SELECT count(*) > 0
+    INTO STRICT _is_timescaledb_installed
+    FROM pg_extension
+    WHERE extname='timescaledb';
+
+    IF _is_timescaledb_installed THEN
+        PERFORM _timescaledb_internal.restart_background_workers();
+    END IF;
+END;
+$stop_bgw$;

--- a/sql/promscale--0.0.0.sql
+++ b/sql/promscale--0.0.0.sql
@@ -1,4 +1,22 @@
 SET LOCAL search_path = pg_catalog, pg_temp;
+
+--stop background workers; see note in bootstrap/002-stop-bgw.sql
+DO
+$stop_bgw$
+DECLARE
+    _is_timescaledb_installed boolean = false;
+BEGIN
+    SELECT count(*) > 0
+    INTO STRICT _is_timescaledb_installed
+    FROM pg_extension
+    WHERE extname='timescaledb';
+
+    IF _is_timescaledb_installed THEN
+        PERFORM _timescaledb_internal.restart_background_workers();
+    END IF;
+END;
+$stop_bgw$;
+
 DROP TABLE public.prom_schema_migrations;
 
 REVOKE EXECUTE ON FUNCTION ps_trace.delete_all_traces() FROM prom_writer;


### PR DESCRIPTION
This commit stops bgws while upgrading the Promscale extension.
This prevents lock contention between jobs and upgrades and thus
seems safer.