### PR TITLE
Use text instead of name for function args

### DIFF
--- a/migration/idempotent/006-exemplar.sql
+++ b/migration/idempotent/006-exemplar.sql
@@ -73,7 +73,7 @@ REVOKE ALL ON FUNCTION _prom_catalog.create_exemplar_table_if_not_exists(TEXT) F
 GRANT EXECUTE ON FUNCTION _prom_catalog.create_exemplar_table_if_not_exists(TEXT) TO prom_writer;
 
 CREATE OR REPLACE FUNCTION _prom_catalog.insert_exemplar_row(
-    metric_table NAME,
+    metric_table TEXT,
     time_array TIMESTAMPTZ[],
     series_id_array BIGINT[],
     exemplar_label_values_array prom_api.label_value_array[],
@@ -96,4 +96,4 @@ BEGIN
 END;
 $$
 LANGUAGE PLPGSQL;
-GRANT EXECUTE ON FUNCTION _prom_catalog.insert_exemplar_row(NAME, TIMESTAMPTZ[], BIGINT[], prom_api.label_value_array[], DOUBLE PRECISION[]) TO prom_writer;
+GRANT EXECUTE ON FUNCTION _prom_catalog.insert_exemplar_row(TEXT, TIMESTAMPTZ[], BIGINT[], prom_api.label_value_array[], DOUBLE PRECISION[]) TO prom_writer;

--- a/migration/idempotent/013-tracing-maintenance.sql
+++ b/migration/idempotent/013-tracing-maintenance.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE PROCEDURE _ps_trace.execute_tracing_compression(hypertable_name name, log_verbose BOOLEAN = false)
+CREATE OR REPLACE PROCEDURE _ps_trace.execute_tracing_compression(hypertable_name text, log_verbose BOOLEAN = false)
 AS $$
 DECLARE
    startT TIMESTAMPTZ;
@@ -21,9 +21,9 @@ BEGIN
     END IF;
 END;
 $$ LANGUAGE PLPGSQL;
-COMMENT ON PROCEDURE _ps_trace.execute_tracing_compression(name, boolean)
+COMMENT ON PROCEDURE _ps_trace.execute_tracing_compression(text, boolean)
 IS 'Execute tracing compression compresses tracing tables';
-GRANT EXECUTE ON PROCEDURE _ps_trace.execute_tracing_compression(name, boolean) TO prom_maintenance;
+GRANT EXECUTE ON PROCEDURE _ps_trace.execute_tracing_compression(text, boolean) TO prom_maintenance;
 
 --job boilerplate
 CREATE OR REPLACE PROCEDURE _ps_trace.execute_tracing_compression_job(job_id int, config jsonb)


### PR DESCRIPTION
Since NAME type uses C collation it confuses PG planner and results in non
optimal query plans (not using indexes where it should).
We switch to use TEXT for function IN arguments and that results in picking
optimal query plans.
Switch shouldn't cause any harm
since internally both types are stored the same just
NAME is limited to 63-chars, but TEXT has no limits.

An example of non-optimal query plan:
```
Aggregate  (cost=298493.79..298494.05 rows=1 width=128) (actual time=2816.778..2816.780 rows=1 loops=1)
          CTE cte
            ->  Result  (cost=298490.80..298493.43 rows=10 width=72) (actual time=2816.760..2816.764 rows=13 loops=1)
                  ->  Sort  (cost=298490.80..298490.83 rows=10 width=72) (actual time=2816.759..2816.761 rows=13 loops=1)
                        Sort Key: kv.key COLLATE "C", kv.value COLLATE "C"
                        Sort Method: quicksort  Memory: 26kB
                        ->  Merge Left Join  (cost=298490.44..298490.63 rows=10 width=72) (actual time=2816.748..2816.755 rows=13 loops=1)
                              Merge Cond: (kv.key = lkp.key)
                              ->  Sort  (cost=298465.14..298465.16 rows=10 width=68) (actual time=2816.657..2816.659 rows=13 loops=1)
                                    Sort Key: kv.key COLLATE "C"
                                    Sort Method: quicksort  Memory: 25kB
                                    ->  Hash Right Join  (cost=0.26..298464.97 rows=10 width=68) (actual time=0.031..2816.648 rows=13 loops=1)
                                          Hash Cond: ((l.key = kv.key) AND (l.value = kv.value))
                                          ->  Seq Scan on label l  (cost=0.00..223462.26 rows=10000326 width=68) (actual time=0.006..969.334 rows=10000207 loops=1)
                                          ->  Hash  (cost=0.11..0.11 rows=10 width=64) (actual time=0.018..0.018 rows=13 loops=1)
                                                Buckets: 1024  Batches: 1  Memory Usage: 9kB
                                                ->  Function Scan on kv  (cost=0.01..0.11 rows=10 width=64) (actual time=0.010..0.012 rows=13 loops=1)
                              ->  Sort  (cost=25.30..25.34 rows=13 width=23) (actual time=0.087..0.088 rows=16 loops=1)
                                    Sort Key: lkp.key COLLATE "C"
                                    Sort Method: quicksort  Memory: 26kB
                                    ->  Seq Scan on label_key_position lkp  (cost=0.00..25.06 rows=13 width=23) (actual time=0.010..0.076 rows=16 loops=1)
                                          Filter: (metric_name = $1)
                                          Rows Removed by Filter: 975
          ->  CTE Scan on cte  (cost=0.00..0.20 rows=10 width=72) (actual time=2816.762..2816.767 rows=13 loops=1)
```

A better query plan when using TEXT:
```
 ->  Sort  (cost=28.88..28.91 rows=13 width=72) (actual time=0.107..0.108 rows=13 loops=1)
         Sort Key: kv.key, kv.value
         Sort Method: quicksort  Memory: 26kB
         ->  Hash Left Join  (cost=6.09..28.64 rows=13 width=72) (actual time=0.051..0.096 rows=13 loops=1)
               Hash Cond: (kv.key = lkp.key)
               ->  Nested Loop Left Join  (cost=0.57..23.08 rows=13 width=68) (actual time=0.030..0.071 rows=13 loops=1)
                     ->  Function Scan on kv  (cost=0.01..0.14 rows=13 width=64) (actual time=0.008..0.009 rows=13 loops=1)
                     ->  Index Only Scan using label_key_value_id_key on label l  (cost=0.56..1.76 rows=1 width=70) (actual time=0.004..0.004 rows=1 loops=13)
                           Index Cond: ((key = kv.key) AND (value = kv.value))
                           Heap Fetches: 13
               ->  Hash  (cost=5.48..5.48 rows=4 width=36) (actual time=0.016..0.016 rows=13 loops=1)
                     Buckets: 1024  Batches: 1  Memory Usage: 9kB
                     ->  Bitmap Heap Scan on label_key_position lkp  (cost=1.28..5.48 rows=4 width=36) (actual time=0.006..0.007 rows=13 loops=1)
                           Recheck Cond: (metric_name = 'avalanche_metric_mmmmm_0_0'::text)
                           Heap Blocks: exact=1
                           ->  Bitmap Index Scan on label_key_position_metric_name_key_pos_key  (cost=0.00..1.28 rows=4 width=0) (actual time=0.003..0.003 rows=13 loops=1)
                                 Index Cond: (metric_name = 'avalanche_metric_mmmmm_0_0'::text)
```

Since getting query plans from functions would require quite a bit of effort (basically it needs `auto_explain` extension which prints plans to a PG log....) I didn't provide any test as a poof.