### PR TITLE
Switch to using docker image based on `master` branch

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -9,7 +9,7 @@ Run the tests with `cargo test -p e2e`. The tests are run against a docker image
 the `TS_DOCKER_IMAGE` env var to override the default docker image, e.g.:
 
 ```
-TS_DOCKER_IMAGE=ghcr.io/timescale/dev_promscale_extension:develop-ts2-pg13 cargo test -p e2e
+TS_DOCKER_IMAGE=ghcr.io/timescale/dev_promscale_extension:master-ts2-pg13 cargo test -p e2e
 ```
 
 ## Rust tests

--- a/e2e/tests/common/mod.rs
+++ b/e2e/tests/common/mod.rs
@@ -12,7 +12,7 @@ pub const PASSWORD: &str = "postgres-password-test";
 
 pub fn run_postgres(client: &Cli) -> Container<Cli, GenericImage> {
     let docker_image = env::var("TS_DOCKER_IMAGE").unwrap_or(String::from(
-        "ghcr.io/timescale/dev_promscale_extension:develop-ts2-pg14",
+        "ghcr.io/timescale/dev_promscale_extension:master-ts2-pg14",
     ));
 
     let src = concat!(env!("CARGO_MANIFEST_DIR"), "/testdata");

--- a/e2e/tests/dump-restore-test.rs
+++ b/e2e/tests/dump-restore-test.rs
@@ -18,7 +18,7 @@ type PostgresContainer<'d> = Container<'d, Cli, GenericImage>;
 /// Otherwise, it returns a default image.
 fn postgres_image() -> String {
     env::var("TS_DOCKER_IMAGE").unwrap_or_else(|_| {
-        String::from("ghcr.io/timescale/dev_promscale_extension:develop-ts2-pg14")
+        String::from("ghcr.io/timescale/dev_promscale_extension:master-ts2-pg14")
     })
 }
 

--- a/gendoc/src/main.rs
+++ b/gendoc/src/main.rs
@@ -135,7 +135,7 @@ fn output_operators(connection: &mut Client) {
 
 fn run_postgres(client: &Cli) -> Container<Cli, GenericImage> {
     let docker_image = env::var("TS_DOCKER_IMAGE").unwrap_or(String::from(
-        "ghcr.io/timescale/dev_promscale_extension:develop-ts2-pg14",
+        "ghcr.io/timescale/dev_promscale_extension:master-ts2-pg14",
     ));
 
     let src = concat!(env!("CARGO_MANIFEST_DIR"), "/testdata");

--- a/tools/smoke-test
+++ b/tools/smoke-test
@@ -6,7 +6,7 @@ set -euo pipefail
 # It leverages docker containers for both connector and extension.
 
 # It takes three positional arguments:
-EXTENSION_DOCKER_IMAGE=$1 # e.g. ghcr.io/timescale/promscale_dev_extension:develop-ts2-pg14
+EXTENSION_DOCKER_IMAGE=$1 # e.g. ghcr.io/timescale/promscale_dev_extension:master-ts2-pg14
 CONNECTOR_DOCKER_IMAGE=$2 # e.g. timescale/promscale:0.11.0
 DOCKER_PLATFORM=$3 # e.g. linux/amd64
 


### PR DESCRIPTION
We're switching our development workflow to be `master`-based, so the
default branch for all tests should be that branch.