### PR TITLE
Drop old versions of func/proc where signature changed

### DIFF
--- a/docs/sql-api.md
+++ b/docs/sql-api.md
@@ -734,22 +734,22 @@ function trigger **_prom_catalog.ha_leases_audit_fn**()
 ### _prom_catalog.hypertable_compression_stats_for_schema
 
 ```
-function TABLE(hypertable_name name, total_chunks bigint, number_compressed_chunks bigint, before_compression_total_bytes bigint, after_compression_total_bytes bigint) **_prom_catalog.hypertable_compression_stats_for_schema**(schema_name_in name)
+function TABLE(hypertable_name text, total_chunks bigint, number_compressed_chunks bigint, before_compression_total_bytes bigint, after_compression_total_bytes bigint) **_prom_catalog.hypertable_compression_stats_for_schema**(schema_name_in text)
 ```
 ### _prom_catalog.hypertable_local_size
 
 ```
-function TABLE(hypertable_name name, table_bytes bigint, index_bytes bigint, toast_bytes bigint, total_bytes bigint) **_prom_catalog.hypertable_local_size**(schema_name_in name)
+function TABLE(hypertable_name text, table_bytes bigint, index_bytes bigint, toast_bytes bigint, total_bytes bigint) **_prom_catalog.hypertable_local_size**(schema_name_in text)
 ```
 ### _prom_catalog.hypertable_node_up
 
 ```
-function TABLE(hypertable_name name, node_name name, node_up boolean) **_prom_catalog.hypertable_node_up**(schema_name_in name)
+function TABLE(hypertable_name text, node_name text, node_up boolean) **_prom_catalog.hypertable_node_up**(schema_name_in text)
 ```
 ### _prom_catalog.hypertable_remote_size
 
 ```
-function TABLE(hypertable_name name, table_bytes bigint, index_bytes bigint, toast_bytes bigint, total_bytes bigint) **_prom_catalog.hypertable_remote_size**(schema_name_in name)
+function TABLE(hypertable_name text, table_bytes bigint, index_bytes bigint, toast_bytes bigint, total_bytes bigint) **_prom_catalog.hypertable_remote_size**(schema_name_in text)
 ```
 ### _prom_catalog.insert_exemplar_row
 
@@ -874,7 +874,7 @@ function boolean **_prom_catalog.match_regexp_not_matches**(labels label_array, 
 ### _prom_catalog.metric_view
 
 ```
-function TABLE(id integer, metric_name text, table_name name, label_keys text[], retention_period interval, chunk_interval interval, compressed_interval interval, total_interval interval, before_compression_bytes bigint, after_compression_bytes bigint, total_size_bytes bigint, total_size text, compression_ratio numeric, total_chunks bigint, compressed_chunks bigint) **_prom_catalog.metric_view**()
+function TABLE(id integer, metric_name text, table_name text, label_keys text[], retention_period interval, chunk_interval interval, compressed_interval interval, total_interval interval, before_compression_bytes bigint, after_compression_bytes bigint, total_size_bytes bigint, total_size text, compression_ratio numeric, total_chunks bigint, compressed_chunks bigint) **_prom_catalog.metric_view**()
 ```
 ### _prom_catalog.pg_name_unique
 

--- a/migration/idempotent/001-base.sql
+++ b/migration/idempotent/001-base.sql
@@ -2559,8 +2559,8 @@ DO $block$
 BEGIN
     IF _prom_catalog.is_timescaledb_installed() AND _prom_catalog.get_timescale_major_version() >= 2 THEN
 
-        CREATE OR REPLACE FUNCTION _prom_catalog.hypertable_local_size(schema_name_in name)
-        RETURNS TABLE(hypertable_name name, table_bytes bigint, index_bytes bigint, toast_bytes bigint, total_bytes bigint)
+        CREATE OR REPLACE FUNCTION _prom_catalog.hypertable_local_size(schema_name_in text)
+        RETURNS TABLE(hypertable_name text, table_bytes bigint, index_bytes bigint, toast_bytes bigint, total_bytes bigint)
         SECURITY DEFINER
         SET search_path = pg_catalog, pg_temp
         AS $function$
@@ -2572,7 +2572,7 @@ BEGIN
                 -- we explicit aliases to deal with this
                 RETURN QUERY
                 SELECT
-                    ch.hypertable_name,
+                    ch.hypertable_name::text as hypertable_name,
                     (COALESCE(sum(ch.total_bytes), 0) - COALESCE(sum(ch.index_bytes), 0) - COALESCE(sum(ch.toast_bytes), 0) + COALESCE(sum(ch.compressed_heap_size), 0))::bigint + pg_relation_size(format('%I.%I', ch.hypertable_schema, ch.hypertable_name)::regclass)::bigint AS heap_bytes,
                     (COALESCE(sum(ch.index_bytes), 0) + COALESCE(sum(ch.compressed_index_size), 0))::bigint + pg_indexes_size(format('%I.%I', ch.hypertable_schema, ch.hypertable_name)::regclass)::bigint AS index_bytes,
                     (COALESCE(sum(ch.toast_bytes), 0) + COALESCE(sum(ch.compressed_toast_size), 0))::bigint AS toast_bytes,
@@ -2597,7 +2597,7 @@ BEGIN
             ELSE
                 RETURN QUERY
                 SELECT
-                    ch.hypertable_name,
+                    ch.hypertable_name::text as hypertable_name,
                     (COALESCE(sum(ch.total_bytes), 0) - COALESCE(sum(ch.index_bytes), 0) - COALESCE(sum(ch.toast_bytes), 0) + COALESCE(sum(ch.compressed_heap_size), 0))::bigint + pg_relation_size(format('%I.%I', ch.hypertable_schema, ch.hypertable_name)::regclass)::bigint AS heap_bytes,
                     (COALESCE(sum(ch.index_bytes), 0) + COALESCE(sum(ch.compressed_index_size), 0))::bigint + pg_indexes_size(format('%I.%I', ch.hypertable_schema, ch.hypertable_name)::regclass)::bigint AS index_bytes,
                     (COALESCE(sum(ch.toast_bytes), 0) + COALESCE(sum(ch.compressed_toast_size), 0))::bigint AS toast_bytes,
@@ -2624,11 +2624,11 @@ BEGIN
         END;
         $function$
         LANGUAGE plpgsql STRICT STABLE;
-        REVOKE ALL ON FUNCTION _prom_catalog.hypertable_local_size(name) FROM PUBLIC;
-        GRANT EXECUTE ON FUNCTION _prom_catalog.hypertable_local_size(name) to prom_reader;
+        REVOKE ALL ON FUNCTION _prom_catalog.hypertable_local_size(text) FROM PUBLIC;
+        GRANT EXECUTE ON FUNCTION _prom_catalog.hypertable_local_size(text) to prom_reader;
 
-        CREATE OR REPLACE FUNCTION _prom_catalog.hypertable_node_up(schema_name_in name)
-        RETURNS TABLE(hypertable_name name, node_name name, node_up boolean)
+        CREATE OR REPLACE FUNCTION _prom_catalog.hypertable_node_up(schema_name_in text)
+        RETURNS TABLE(hypertable_name text, node_name text, node_up boolean)
         SECURITY DEFINER
         SET search_path = pg_catalog, pg_temp
         AS $function$
@@ -2659,24 +2659,24 @@ BEGIN
                 ) x
             )
             SELECT
-                dht.table_name as hypertable_name,
-                dht.node_name,
+                dht.table_name::text as hypertable_name,
+                dht.node_name::text as node_name,
                 up.node_up
             FROM dht
             JOIN up ON (dht.node_name = up.node_name)
         $function$
         LANGUAGE sql
         STRICT STABLE;
-        REVOKE ALL ON FUNCTION _prom_catalog.hypertable_node_up(name) FROM PUBLIC;
-        GRANT EXECUTE ON FUNCTION _prom_catalog.hypertable_node_up(name) to prom_reader;
+        REVOKE ALL ON FUNCTION _prom_catalog.hypertable_node_up(text) FROM PUBLIC;
+        GRANT EXECUTE ON FUNCTION _prom_catalog.hypertable_node_up(text) to prom_reader;
 
-        CREATE OR REPLACE FUNCTION _prom_catalog.hypertable_remote_size(schema_name_in name)
-        RETURNS TABLE(hypertable_name name, table_bytes bigint, index_bytes bigint, toast_bytes bigint, total_bytes bigint)
+        CREATE OR REPLACE FUNCTION _prom_catalog.hypertable_remote_size(schema_name_in text)
+        RETURNS TABLE(hypertable_name text, table_bytes bigint, index_bytes bigint, toast_bytes bigint, total_bytes bigint)
         SECURITY DEFINER
         SET search_path = pg_catalog, pg_temp
         AS $function$
             SELECT
-                dht.hypertable_name,
+                dht.hypertable_name::text as hypertable_name,
                 sum(x.table_bytes)::bigint AS table_bytes,
                 sum(x.index_bytes)::bigint AS index_bytes,
                 sum(x.toast_bytes)::bigint AS toast_bytes,
@@ -2692,22 +2692,22 @@ BEGIN
         $function$
         LANGUAGE sql
         STRICT STABLE;
-        REVOKE ALL ON FUNCTION _prom_catalog.hypertable_remote_size(name) FROM PUBLIC;
-        GRANT EXECUTE ON FUNCTION _prom_catalog.hypertable_remote_size(name) to prom_reader;
+        REVOKE ALL ON FUNCTION _prom_catalog.hypertable_remote_size(text) FROM PUBLIC;
+        GRANT EXECUTE ON FUNCTION _prom_catalog.hypertable_remote_size(text) to prom_reader;
 
         -- two columns in _timescaledb_internal.compressed_chunk_stats were renamed in version 2.2
         -- schema_name -> hypertable_schema
         -- table_name -> hypertable_name
         -- we use explicit column aliases on _timescaledb_internal.compressed_chunk_stats to rename the
         -- `schema_name` and `table_name` in the older versions to the new names
-        CREATE OR REPLACE FUNCTION _prom_catalog.hypertable_compression_stats_for_schema(schema_name_in name)
-        RETURNS TABLE(hypertable_name name, total_chunks bigint, number_compressed_chunks bigint, before_compression_total_bytes bigint, after_compression_total_bytes bigint)
+        CREATE OR REPLACE FUNCTION _prom_catalog.hypertable_compression_stats_for_schema(schema_name_in text)
+        RETURNS TABLE(hypertable_name text, total_chunks bigint, number_compressed_chunks bigint, before_compression_total_bytes bigint, after_compression_total_bytes bigint)
         SECURITY DEFINER
 
         SET search_path = pg_catalog, pg_temp
         AS $function$
             SELECT
-                x.hypertable_name,
+                x.hypertable_name::text as hypertable_name,
                 count(*)::bigint AS total_chunks,
                 (count(*) FILTER (WHERE x.compression_status = 'Compressed'))::bigint AS number_compressed_chunks,
                 sum(x.before_compression_total_bytes)::bigint AS before_compression_total_bytes,
@@ -2759,8 +2759,8 @@ BEGIN
         $function$
         LANGUAGE sql
         STRICT STABLE;
-        REVOKE ALL ON FUNCTION _prom_catalog.hypertable_compression_stats_for_schema(name) FROM PUBLIC;
-        GRANT EXECUTE ON FUNCTION _prom_catalog.hypertable_compression_stats_for_schema(name) to prom_reader;
+        REVOKE ALL ON FUNCTION _prom_catalog.hypertable_compression_stats_for_schema(text) FROM PUBLIC;
+        GRANT EXECUTE ON FUNCTION _prom_catalog.hypertable_compression_stats_for_schema(text) to prom_reader;
 
     END IF;
 END;
@@ -2770,7 +2770,7 @@ $block$
 --------------------------------- Views --------------------------------
 
 CREATE OR REPLACE FUNCTION _prom_catalog.metric_view()
-    RETURNS TABLE(id int, metric_name text, table_name name, label_keys text[], retention_period interval,
+    RETURNS TABLE(id int, metric_name text, table_name text, label_keys text[], retention_period interval,
               chunk_interval interval, compressed_interval interval, total_interval interval,
               before_compression_bytes bigint, after_compression_bytes bigint,
               total_size_bytes bigint, total_size text, compression_ratio numeric,
@@ -2784,7 +2784,7 @@ BEGIN
                 SELECT
                    i.id,
                    i.metric_name,
-                   i.table_name,
+                   i.table_name::text as table_name,
                    i.label_keys,
                    i.retention_period,
                    i.chunk_interval,
@@ -2833,7 +2833,7 @@ BEGIN
             SELECT
                 m.id,
                 m.metric_name,
-                m.table_name,
+                m.table_name::text as table_name,
                 ARRAY(
                     SELECT key
                     FROM _prom_catalog.label_key_position lkp
@@ -2876,7 +2876,7 @@ BEGIN
                 SELECT
                     m.id,
                     m.metric_name,
-                    m.table_name,
+                    m.table_name::text as table_name,
                     ARRAY(
                         SELECT key
                             FROM _prom_catalog.label_key_position lkp

--- a/migration/incremental/026-remove-name-param.sql
+++ b/migration/incremental/026-remove-name-param.sql
@@ -1,0 +1,27 @@
+
+-- we changed the data types (name → text) used in these function signatures
+-- need to drop the old versions
+DROP FUNCTION IF EXISTS _prom_catalog.hypertable_local_size(name) CASCADE;
+DROP FUNCTION IF EXISTS _prom_catalog.hypertable_node_up(name) CASCADE;
+DROP FUNCTION IF EXISTS _prom_catalog.hypertable_compression_stats_for_schema(name) CASCADE;
+DROP FUNCTION IF EXISTS _prom_catalog.hypertable_remote_size(name) CASCADE;
+DROP FUNCTION IF EXISTS _prom_catalog.metric_view() CASCADE;
+DROP FUNCTION IF EXISTS _prom_catalog.get_new_pos_for_key(text, name, text[], boolean) CASCADE;
+DROP FUNCTION IF EXISTS _prom_catalog.delete_series_catalog_row(name, bigint[]) CASCADE;
+DROP FUNCTION IF EXISTS _prom_catalog.get_or_create_label_ids(TEXT, NAME, text[], text[]) CASCADE;
+DROP FUNCTION IF EXISTS _prom_catalog.get_or_create_label_ids(text, name, text[], text[]) CASCADE;
+DROP FUNCTION IF EXISTS _prom_catalog.create_series(int, NAME, prom_api.label_array, OUT BIGINT) CASCADE;
+DROP FUNCTION IF EXISTS _prom_catalog.resurrect_series_ids(name, bigint) CASCADE;
+DROP FUNCTION IF EXISTS _prom_catalog.get_or_create_series_id_for_label_array(INT, NAME, prom_api.label_array, OUT BIGINT) CASCADE;
+DROP FUNCTION IF EXISTS _prom_catalog.get_confirmed_unused_series(NAME, NAME, NAME, BIGINT[], TIMESTAMPTZ) CASCADE;
+DROP FUNCTION IF EXISTS prom_api.register_metric_view(name, name, BOOLEAN) CASCADE;
+DROP FUNCTION IF EXISTS prom_api.unregister_metric_view(name, name, BOOLEAN) CASCADE;
+DROP FUNCTION IF EXISTS _prom_catalog.delay_compression_job(name, timestamptz) CASCADE;
+DROP FUNCTION IF EXISTS _prom_catalog.decompress_chunk_for_metric(TEXT, name, name) CASCADE;
+DROP PROCEDURE IF EXISTS _prom_catalog.do_decompress_chunks_after(NAME, TIMESTAMPTZ, BOOLEAN) CASCADE;
+DROP PROCEDURE IF EXISTS _prom_catalog.decompress_chunks_after(NAME, TIMESTAMPTZ, BOOLEAN) CASCADE;
+DROP FUNCTION IF EXISTS _prom_catalog.compress_chunk_for_hypertable(name, name, name, name) CASCADE;
+DROP PROCEDURE IF EXISTS _prom_catalog.compress_old_chunks(NAME, NAME, TIMESTAMPTZ) CASCADE;
+DROP FUNCTION IF EXISTS _prom_catalog.insert_metric_row(name, timestamptz[], DOUBLE PRECISION[], bigint[]) CASCADE;
+DROP FUNCTION IF EXISTS _prom_catalog.insert_exemplar_row(NAME, TIMESTAMPTZ[], BIGINT[], prom_api.label_value_array[], DOUBLE PRECISION[]) CASCADE;
+DROP PROCEDURE IF EXISTS _ps_trace.execute_tracing_compression(name, BOOLEAN) CASCADE;


### PR DESCRIPTION
We changed the signatures of some functions and procedures. We changed the data types from `name` to `text`. We did so with `create or replace function`. Since the signature changed, postgres ran this as a `create` and we ended up with two versions of each function/procedure. This adds a migration that drops the old versions.