### PR TITLE
gitignore the sql directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 /hand-written-migration.sql
 /promscale.control
 /bootstrap.sql
+/sql


### PR DESCRIPTION
The scripts in the /sql directory are automatically generated. These do not need to be committed until we cut a release. It's a bit annoying to have git call out changes to these files in the meantime, so ignore them.