### PR TITLE
Fix install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ package: promscale.control ## Generate extension artifacts for packaging
 
 .PHONY: install
 install: ## Install the extension in the Postgres found via pg_config
-	cp -a ./target/release/promscale-pg${PG_BUILD_VERSION}/* /
+	cp --recursive ./target/release/promscale-pg${PG_BUILD_VERSION}/* /
 
 dist/$(RELEASE_FILE_NAME): release-builder
 	@container="$$(docker create $(RELEASE_IMAGE_NAME))"; \


### PR DESCRIPTION
## Description

Using `cp -a` messes with attributes of higher-level directories, which
is not what we want.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation