### PR TITLE
Add _prom_ext.re2_match(string, pattern) -> bool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "askama"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,9 +1577,11 @@ dependencies = [
  "pgx-macros",
  "pgx-tests",
  "proptest",
+ "regex",
  "serde",
  "serde_json",
  "sha2 0.10.2",
+ "uluru",
 ]
 
 [[package]]
@@ -1752,9 +1760,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1772,9 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "remove_dir_all"
@@ -2432,6 +2440,15 @@ name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
+name = "uluru"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794a32261a1f5eb6a4462c81b59cec87b5c27d5deea7dd1ac8fc781c41d226db"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "unescape"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,13 +29,15 @@ pg_test = ["serde_json", "proptest"]
 
 [dependencies]
 bincode = "1.3.1"
+num_cpus = "1.13.1"
 pgx = "0.3.1"
 pgx-macros = "0.3.1"
-num_cpus = "1.13.1"
+proptest  = { version = "1.0.0", optional = true }
+regex = "1.5.6"
 sha2 = "0.10.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.70", optional = true }
-proptest  = { version = "1.0.0", optional = true }
+uluru = "3.0.0"
 
 [build-dependencies]
 askama = "0.11.0"

--- a/docs/sql-api.md
+++ b/docs/sql-api.md
@@ -1026,6 +1026,11 @@ aggregate double precision[] **_prom_ext.prom_rate**(lowest_time timestamp with 
 ```
 function internal **_prom_ext.prom_rate_transition**(state internal, lowest_time timestamp with time zone, greatest_time timestamp with time zone, step_size bigint, range bigint, sample_time timestamp with time zone, sample_value double precision)
 ```
+### _prom_ext.re2_match
+
+```
+function boolean **_prom_ext.re2_match**(string text, pattern text)
+```
 ### _prom_ext.rewrite_fn_call_to_subquery
 
 ```

--- a/migration/idempotent/015-extension-function-permissions.sql
+++ b/migration/idempotent/015-extension-function-permissions.sql
@@ -1,0 +1,1 @@
+GRANT EXECUTE ON FUNCTION _prom_ext.re2_match(TEXT, TEXT) TO prom_reader;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod jsonb_digest;
 mod palloc;
 mod pg_imports;
 mod raw;
+mod regex;
 mod schema;
 mod support;
 mod type_builder;

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -1,0 +1,105 @@
+use pgx::*;
+
+#[pg_schema]
+mod _prom_ext {
+    use pgx::*;
+    use regex::Regex;
+    use std::cell::RefCell;
+    use uluru::LRUCache;
+
+    // On caching: Creating a new Regex instance is expensive, so we keep a
+    // global cache of Regex instances in an LRU cache.
+    // An alternative approach would be to create a new regex type, and provide
+    // match functions between our custom regex type and TEXT (see pgpcre [1]).
+    // This would work, but requires dealing with the fact that somebody might
+    // decide to _store_ the compiled regex, which we don't want to support.
+    // Interestingly, the Postgres' native regex engine is quite similar,
+    // storing compiled regex expressions in an LRU cache of 32 elements [2].
+    //
+    // [1]: https://github.com/petere/pgpcre/blob/c36de3d9b84f7740f24083b2e55fc6fcb33ec849/pgpcre.c
+    // [2]: https://github.com/postgres/postgres/blob/f5135d2aba87f59944bdab4f54129fc43a3f03d0/src/backend/utils/adt/regexp.c
+
+    // On memory contexts: This cache and function do not behave nicely with
+    // Postgres' memory models. Allocations are not in a MemoryContext, instead
+    // they are directly on the stack, or heap. This is safe because we do not
+    // ever pass these objects to Postgres.
+
+    // Caveats: We completely ignore collation, and character sets.
+
+    struct CompiledRegex {
+        pattern: String,
+        matcher: Regex,
+    }
+
+    // Note: The chosen size is the same as Postgres' internal regex cache
+    const CACHE_SIZE: usize = 32;
+
+    thread_local! {
+        static CACHE: RefCell<LRUCache<CompiledRegex, CACHE_SIZE>> = RefCell::default();
+    }
+
+    /// re2_match matches `string` against `pattern` using an [RE2-like][re2]
+    /// regular expression engine, returning a `BOOLEAN`.
+    /// [re2]: https://github.com/google/re2
+    #[pg_extern(immutable, parallel_safe)]
+    fn re2_match(string: &str, pattern: &str) -> bool {
+        CACHE.with(|cache| {
+            let mut cache = cache.borrow_mut();
+            match cache.find(|i| i.pattern == pattern) {
+                Some(compiled) => compiled.matcher.is_match(string),
+                None => match Regex::new(pattern) {
+                    Ok(matcher) => {
+                        cache.insert(CompiledRegex {
+                            pattern: String::from(pattern),
+                            matcher: matcher.clone(),
+                        });
+                        matcher.is_match(string)
+                    }
+                    Err(e) => {
+                        pgx::error!("unable to compile regular expression: {}", e)
+                    }
+                },
+            }
+        })
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use pgx::*;
+
+    #[pg_test]
+    fn test_trivial_regex() {
+        let result =
+            Spi::get_one::<bool>("SELECT re2_match('test', 'test');").expect("SQL query failed");
+        assert_eq!(result, true);
+        let result =
+            Spi::get_one::<bool>("SELECT re2_match('test', 'unnest');").expect("SQL query failed");
+        assert_eq!(result, false);
+    }
+
+    #[pg_test]
+    fn test_case_insensitive_regex() {
+        let result = Spi::get_one::<bool>(r#"SELECT re2_match('A123', '(?i)^a\d+');"#)
+            .expect("SQL query failed");
+        assert_eq!(result, true);
+    }
+
+    #[pg_test(
+        error = "unable to compile regular expression: Compiled regex exceeds size limit of 10485760 bytes."
+    )]
+    fn test_regex_too_large() {
+        Spi::get_one::<bool>(r#"SELECT re2_match('a', 'a'||repeat('.?', 10000));"#);
+    }
+
+    #[pg_test]
+    fn test_regex_too_large_does_not_kill_session() {
+        let _ = pg_try(|| {
+            Spi::run(r#"SELECT re2_match('a', 'a'||repeat('.?', 10000));"#);
+        });
+        let result =
+            Spi::get_one::<bool>(r#"SELECT re2_match('a', 'a');"#).expect("SQL query failed");
+        assert_eq!(result, true);
+    }
+}


### PR DESCRIPTION
## Description

Postgres' native regex engine is a POSIX-compatible regex.

The regex engine used in Prometheus for PromQL is an RE2-based engine
[1], which is more like PCRE.

The re2_match function allows us to use promQL-compatible regexes in the
database.

[1]: https://swtch.com/~rsc/regexp/regexp3.html

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation