### PR TITLE
Internal documentation for tracing-related API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,4 @@ To compile the extension (see instructions below):
 ## Development
 
 To understand more about how to write SQL migration files for this extension, consult [this](migration/README.md) guide.
-To get a better understanding of our CI pipeline see [this document](.github/README.md).
+To get a better understanding of our CI pipeline see [this document](.github/workflows/README.md).

--- a/docs/sql-api.md
+++ b/docs/sql-api.md
@@ -277,13 +277,13 @@ the specified span_id.
 function TABLE(trace_id trace_id, parent_span_id bigint, span_id bigint, dist integer, path bigint[]) **ps_trace.downstream_spans**(_trace_id trace_id, _span_id bigint, _max_dist integer DEFAULT NULL::integer)
 ```
 ### ps_trace.event_tag_type
-This function returns tag_type with the event tag bit.
+This function returns tag_type with the event tag bit set.
 ```
 function tag_type **ps_trace.event_tag_type**()
 ```
 ### ps_trace.get_tag_map
-For a given jsonb object cosisting of key-value pairs, representing tags and their values,
-this funciton returns a jsonb object of corresponding ids -- the primary keys in
+For a given jsonb object consisting of key-value pairs, representing tags and their values,
+this function returns a jsonb object of corresponding ids -- the primary keys in
 _ps_trace.tag_key and _ps_trace.tag tables.
 ```
 function tag_map **ps_trace.get_tag_map**(_tags jsonb)
@@ -314,7 +314,7 @@ This function checks whether a tag_type value has the span tag bit set.
 function boolean **ps_trace.is_span_tag_type**(_tag_type tag_type)
 ```
 ### ps_trace.link_tag_type
-This function returns tag_type with the link tag bit.
+This function returns tag_type with the link tag bit set.
 ```
 function tag_type **ps_trace.link_tag_type**()
 ```
@@ -356,7 +356,7 @@ its id (a key in _ps_trace.tag_key table)
 function bigint **ps_trace.put_tag_key**(_key tag_k, _tag_type tag_type)
 ```
 ### ps_trace.resource_tag_type
-This function returns tag_type with the resource tag bit.
+This function returns tag_type with the resource tag bit set.
 ```
 function tag_type **ps_trace.resource_tag_type**()
 ```
@@ -371,7 +371,7 @@ For a given trace_id and span_id this function returns spans sharing the same pa
 function TABLE(trace_id trace_id, parent_span_id bigint, span_id bigint) **ps_trace.sibling_spans**(_trace_id trace_id, _span_id bigint)
 ```
 ### ps_trace.span_tag_type
-This function returns tag_type with the span tag bit.
+This function returns tag_type with the span tag bit set.
 ```
 function tag_type **ps_trace.span_tag_type**()
 ```

--- a/docs/sql-api.md
+++ b/docs/sql-api.md
@@ -262,22 +262,29 @@ This function supports the !=~ operator.
 function tag_op_regexp_not_matches **ps_tag.tag_op_regexp_not_matches**(_tag_key text, _value text)
 ```
 ### ps_trace.delete_all_traces
-WARNING: this function deletes all spans and related tracing data in the system and restores it to a "just installed" state.
+WARNING: this function deletes all spans and related tracing data in the system and restores
+it to a "just installed" state.
 ```
 function void **ps_trace.delete_all_traces**()
 ```
 ### ps_trace.downstream_spans
-
+For a given trace_id and span_id this function returns a set that consists of the all spans starting
+from the specified span and down to the leaves of the trace. Each span is annotated with parent_span_id,
+a distance from the specified span (the span itself has the distance of 0) and a path from the specified span 
+towards the root. Optional third argument allows to limit the span tree traversal to a certain distance from 
+the specified span_id.
 ```
 function TABLE(trace_id trace_id, parent_span_id bigint, span_id bigint, dist integer, path bigint[]) **ps_trace.downstream_spans**(_trace_id trace_id, _span_id bigint, _max_dist integer DEFAULT NULL::integer)
 ```
 ### ps_trace.event_tag_type
-
+This function returns tag_type with the event tag bit.
 ```
 function tag_type **ps_trace.event_tag_type**()
 ```
 ### ps_trace.get_tag_map
-
+For a given jsonb object cosisting of key-value pairs, representing tags and their values,
+this funciton returns a jsonb object of corresponding ids -- the primary keys in
+_ps_trace.tag_key and _ps_trace.tag tables.
 ```
 function tag_map **ps_trace.get_tag_map**(_tags jsonb)
 ```
@@ -287,62 +294,69 @@ get the retention period for trace data
 function interval **ps_trace.get_trace_retention_period**()
 ```
 ### ps_trace.is_event_tag_type
-
+This function checks whether a tag_type value has the event tag bit set.
 ```
 function boolean **ps_trace.is_event_tag_type**(_tag_type tag_type)
 ```
 ### ps_trace.is_link_tag_type
-
+This function checks whether a tag_type value has the link tag bit set.
 ```
 function boolean **ps_trace.is_link_tag_type**(_tag_type tag_type)
 ```
 ### ps_trace.is_resource_tag_type
-
+This function checks whether a tag_type value has the resource tag bit set.
 ```
 function boolean **ps_trace.is_resource_tag_type**(_tag_type tag_type)
 ```
 ### ps_trace.is_span_tag_type
-
+This function checks whether a tag_type value has the span tag bit set.
 ```
 function boolean **ps_trace.is_span_tag_type**(_tag_type tag_type)
 ```
 ### ps_trace.link_tag_type
-
+This function returns tag_type with the link tag bit.
 ```
 function tag_type **ps_trace.link_tag_type**()
 ```
 ### ps_trace.operation_calls
-
+This function counts the number of parent -> child pairs (aka calls) within a specified
+time window and their operation ids.
 ```
 function TABLE(parent_operation_id bigint, child_operation_id bigint, cnt bigint) **ps_trace.operation_calls**(_start_time_min timestamp with time zone, _start_time_max timestamp with time zone)
 ```
 ### ps_trace.put_instrumentation_lib
-
+This function creates an entry in the _ps_trace.instrumentation_lib table if it doesn't exit and returns its id.
+It is meant to be used during span creation, to obtain a valid value for mandatory instrumentation_lib_id attribute.
 ```
 function bigint **ps_trace.put_instrumentation_lib**(_name text, _version text, _schema_url_id bigint)
 ```
 ### ps_trace.put_operation
-
+This function creates an operation record and a necessary service.name tag, if either doesn't exist 
+and returns the operation's id (a key in the _ps_tag.opertaions table). It is meant to be used during
+span creation, to obtain a valid value for mandatory operation_id attribute.
 ```
 function bigint **ps_trace.put_operation**(_service_name text, _span_name text, _span_kind span_kind)
 ```
 ### ps_trace.put_schema_url
-
+This function creates an entry in the _ps_trace.schema_url table if it doesn't exit and returns its id.
+It is meant to be used during span creation, to obtain a valid value for mandatory resource_schema_url_id attribute.
 ```
 function bigint **ps_trace.put_schema_url**(_schema_url text)
 ```
 ### ps_trace.put_tag
-
+This function inserts a new tag with the specified value and returns its id (a key in _ps_trace.tag table).
+The specified tag key must exist for the specified resource type.
 ```
 function bigint **ps_trace.put_tag**(_key tag_k, _value _ps_trace.tag_v, _tag_type tag_type)
 ```
 ### ps_trace.put_tag_key
-
+This function creates a new tag key and associates it with the specified tag type and returns
+its id (a key in _ps_trace.tag_key table)
 ```
 function bigint **ps_trace.put_tag_key**(_key tag_k, _tag_type tag_type)
 ```
 ### ps_trace.resource_tag_type
-
+This function returns tag_type with the resource tag bit.
 ```
 function tag_type **ps_trace.resource_tag_type**()
 ```
@@ -352,97 +366,108 @@ set the retention period for trace data
 function boolean **ps_trace.set_trace_retention_period**(_trace_retention_period interval)
 ```
 ### ps_trace.sibling_spans
-
+For a given trace_id and span_id this function returns spans sharing the same parent_span_id.
 ```
 function TABLE(trace_id trace_id, parent_span_id bigint, span_id bigint) **ps_trace.sibling_spans**(_trace_id trace_id, _span_id bigint)
 ```
 ### ps_trace.span_tag_type
-
+This function returns tag_type with the span tag bit.
 ```
 function tag_type **ps_trace.span_tag_type**()
 ```
 ### ps_trace.span_tree
-
+For a given pair of trace_id and span_id, this function returns a union of
+downstream_spans and upstream_spans.
 ```
 function TABLE(trace_id trace_id, parent_span_id bigint, span_id bigint, dist integer, is_upstream boolean, is_downstream boolean, path bigint[]) **ps_trace.span_tree**(_trace_id trace_id, _span_id bigint, _max_dist integer DEFAULT NULL::integer)
 ```
 ### ps_trace.tag_map_in
-
+This function is a part of custom ps_trace.tag_map type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.
 ```
 function tag_map **ps_trace.tag_map_in**(cstring)
 ```
 ### ps_trace.tag_map_object_field
-
+This function is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but returns _ps_trace.tag_v.
 ```
 function _ps_trace.tag_v **ps_trace.tag_map_object_field**(tag_map, text)
 ```
 ### ps_trace.tag_map_out
-
+This function is a part of custom ps_trace.tag_map type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.
 ```
 function cstring **ps_trace.tag_map_out**(tag_map)
 ```
 ### ps_trace.tag_map_recv
-
+This function is a part of custom ps_trace.tag_map type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.
 ```
 function tag_map **ps_trace.tag_map_recv**(internal)
 ```
 ### ps_trace.tag_map_send
-
+This function is a part of custom ps_trace.tag_map type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.
 ```
 function bytea **ps_trace.tag_map_send**(tag_map)
 ```
 ### ps_trace.tag_map_subscript_handler
-
+This function is a part of custom ps_trace.tag_map type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.
 ```
 function internal **ps_trace.tag_map_subscript_handler**(internal)
 ```
 ### ps_trace.tag_v_eq
-
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but has a support function attached.
 ```
 function boolean **ps_trace.tag_v_eq**(_ps_trace.tag_v, _ps_trace.tag_v)
 ```
 ### ps_trace.tag_v_eq
-
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but has a support function attached.
 ```
 function boolean **ps_trace.tag_v_eq**(_ps_trace.tag_v, jsonb)
 ```
 ### ps_trace.tag_v_ge
-
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.
 ```
 function boolean **ps_trace.tag_v_ge**(_ps_trace.tag_v, _ps_trace.tag_v)
 ```
 ### ps_trace.tag_v_gt
-
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.
 ```
 function boolean **ps_trace.tag_v_gt**(_ps_trace.tag_v, _ps_trace.tag_v)
 ```
 ### ps_trace.tag_v_le
-
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.
 ```
 function boolean **ps_trace.tag_v_le**(_ps_trace.tag_v, _ps_trace.tag_v)
 ```
 ### ps_trace.tag_v_lt
-
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.
 ```
 function boolean **ps_trace.tag_v_lt**(_ps_trace.tag_v, _ps_trace.tag_v)
 ```
 ### ps_trace.tag_v_ne
-
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but has a support function attached.
 ```
 function boolean **ps_trace.tag_v_ne**(_ps_trace.tag_v, _ps_trace.tag_v)
 ```
 ### ps_trace.tag_v_ne
-
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but has a support function attached.
 ```
 function boolean **ps_trace.tag_v_ne**(_ps_trace.tag_v, jsonb)
 ```
 ### ps_trace.trace_tree
-
+This function returns a set of all spans for a given trace_id. Additionally, parent span,
+nesting level and a path (as an array of span_id) are supplied for each span in the set.
 ```
 function TABLE(trace_id trace_id, parent_span_id bigint, span_id bigint, lvl integer, path bigint[]) **ps_trace.trace_tree**(_trace_id trace_id)
 ```
 ### ps_trace.upstream_spans
-
+For a given trace_id and span_id this function returns a set that consists of the all spans starting
+from the specified span and up to the root of the trace. Each span is annotated with parent_span_id,
+a distance from the specified span (the span itself has the distance of 0) and a path from the specified span 
+towards the root. Optional third argument allows to limit the span tree traversal to a certain distance from 
+the specified span_id.
 ```
 function TABLE(trace_id trace_id, parent_span_id bigint, span_id bigint, dist integer, path bigint[]) **ps_trace.upstream_spans**(_trace_id trace_id, _span_id bigint, _max_dist integer DEFAULT NULL::integer)
 ```
@@ -1062,22 +1087,23 @@ function void **_ps_catalog.promscale_sql_telemetry**()
 function boolean **_ps_catalog.promscale_telemetry_housekeeping**(telemetry_sync_duration interval DEFAULT '01:00:00'::interval)
 ```
 ### _ps_trace.drop_event_chunks
-
+This procedure drops chunks of _ps_trace.event hypertable that are older than a specified timestamp.
 ```
 procedure void **_ps_trace.drop_event_chunks**(IN _older_than timestamp with time zone)
 ```
 ### _ps_trace.drop_link_chunks
-
+This procedure drops chunks of _ps_trace.link hypertable that are older than a specified timestamp.
 ```
 procedure void **_ps_trace.drop_link_chunks**(IN _older_than timestamp with time zone)
 ```
 ### _ps_trace.drop_span_chunks
-
+This procedure drops chunks of _ps_trace.span hypertable that are older than a specified timestamp.
 ```
 procedure void **_ps_trace.drop_span_chunks**(IN _older_than timestamp with time zone)
 ```
 ### _ps_trace.ensure_trace_ingest_temp_table
-
+Creates a temporary table (if it doesn't exist), suitable for tracing data ingestion. 
+Supresses corresponding DDL logging, otherwise PG log may get unnecessarily verbose.
 ```
 function void **_ps_trace.ensure_trace_ingest_temp_table**(_temp_table_name text, _proto_table_name text)
 ```
@@ -1097,107 +1123,113 @@ procedure void **_ps_trace.execute_tracing_compression**(IN hypertable_name text
 procedure void **_ps_trace.execute_tracing_compression_job**(IN job_id integer, IN config jsonb)
 ```
 ### _ps_trace.tag_map_denormalize
-
+Given a json object of (ps_trace.tag_key.id, ps_trace.tag.id) this function
+performs necessary lookups and returns a reconstructed set of open telemetry tags
+as a tag_map.
 ```
 function tag_map **_ps_trace.tag_map_denormalize**(_map tag_map)
 ```
 ### _ps_trace.tag_v_cmp
-
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.
 ```
 function integer **_ps_trace.tag_v_cmp**(_ps_trace.tag_v, _ps_trace.tag_v)
 ```
 ### _ps_trace.tag_v_eq_matching_tags
-
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for 
+the built-in jsonb. The tag_map_rewrite support function, attached to tag_v_eq,
+will use this function instead, if it can.
 ```
 function jsonb **_ps_trace.tag_v_eq_matching_tags**(_tag_key text, _value jsonb)
 ```
 ### _ps_trace.tag_v_in
-
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.
 ```
 function _ps_trace.tag_v **_ps_trace.tag_v_in**(cstring)
 ```
 ### _ps_trace.tag_v_ne_matching_tags
-
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for 
+the built-in jsonb. The tag_map_rewrite support function, attached to tag_v_ne,
+will use this function instead, if it can.
 ```
 function jsonb[] **_ps_trace.tag_v_ne_matching_tags**(_tag_key text, _value jsonb)
 ```
 ### _ps_trace.tag_v_out
-
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.
 ```
 function cstring **_ps_trace.tag_v_out**(_ps_trace.tag_v)
 ```
 ### _ps_trace.tag_v_recv
-
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.
 ```
 function _ps_trace.tag_v **_ps_trace.tag_v_recv**(internal)
 ```
 ### _ps_trace.tag_v_send
-
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.
 ```
 function bytea **_ps_trace.tag_v_send**(_ps_trace.tag_v)
 ```
 ### _ps_trace.tag_v_subscript_handler
-
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.
 ```
 function internal **_ps_trace.tag_v_subscript_handler**(internal)
 ```
 ### _ps_trace.trace_id_cmp
-
+This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.
 ```
 function integer **_ps_trace.trace_id_cmp**(trace_id, trace_id)
 ```
 ### _ps_trace.trace_id_eq
-
+This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.
 ```
 function boolean **_ps_trace.trace_id_eq**(trace_id, trace_id)
 ```
 ### _ps_trace.trace_id_ge
-
+This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.
 ```
 function boolean **_ps_trace.trace_id_ge**(trace_id, trace_id)
 ```
 ### _ps_trace.trace_id_gt
-
+This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.
 ```
 function boolean **_ps_trace.trace_id_gt**(trace_id, trace_id)
 ```
 ### _ps_trace.trace_id_hash
-
+This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.
 ```
 function integer **_ps_trace.trace_id_hash**(trace_id)
 ```
 ### _ps_trace.trace_id_in
-
+This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.
 ```
 function trace_id **_ps_trace.trace_id_in**(cstring)
 ```
 ### _ps_trace.trace_id_le
-
+This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.
 ```
 function boolean **_ps_trace.trace_id_le**(trace_id, trace_id)
 ```
 ### _ps_trace.trace_id_lt
-
+This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.
 ```
 function boolean **_ps_trace.trace_id_lt**(trace_id, trace_id)
 ```
 ### _ps_trace.trace_id_ne
-
+This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.
 ```
 function boolean **_ps_trace.trace_id_ne**(trace_id, trace_id)
 ```
 ### _ps_trace.trace_id_out
-
+This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.
 ```
 function cstring **_ps_trace.trace_id_out**(trace_id)
 ```
 ### _ps_trace.trace_id_recv
-
+This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.
 ```
 function trace_id **_ps_trace.trace_id_recv**(internal)
 ```
 ### _ps_trace.trace_id_send
-
+This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.
 ```
 function bytea **_ps_trace.trace_id_send**(trace_id)
 ```
@@ -1341,91 +1373,99 @@ __Function:__ tag_op_jsonb_path_exists
 
 __Schema:__ ps_tag
 ### tag_map -> text → _ps_trace.tag_v
-
+This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but returns _ps_trace.tag_v.
 
 __Function:__ tag_map_object_field
 
 __Schema:__ ps_trace
 ### _ps_trace.tag_v < _ps_trace.tag_v → boolean
-
+This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
 
 __Function:__ tag_v_lt
 
 __Schema:__ ps_trace
 ### trace_id < trace_id → boolean
-
+This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.
 
 __Function:__ _ps_trace.trace_id_lt
 
 __Schema:__ ps_trace
 ### _ps_trace.tag_v <= _ps_trace.tag_v → boolean
-
+This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
 
 __Function:__ tag_v_le
 
 __Schema:__ ps_trace
 ### trace_id <= trace_id → boolean
-
+This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.
 
 __Function:__ _ps_trace.trace_id_le
 
 __Schema:__ ps_trace
 ### _ps_trace.tag_v <> _ps_trace.tag_v → boolean
-
+This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
 
 __Function:__ ps_trace.tag_v_ne
 
 __Schema:__ ps_trace
 ### _ps_trace.tag_v <> jsonb → boolean
-
+This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
 
 __Function:__ ps_trace.tag_v_ne
 
 __Schema:__ ps_trace
 ### trace_id <> trace_id → boolean
-
+This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.
 
 __Function:__ _ps_trace.trace_id_ne
 
 __Schema:__ ps_trace
 ### _ps_trace.tag_v = _ps_trace.tag_v → boolean
-
+This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
 
 __Function:__ ps_trace.tag_v_eq
 
 __Schema:__ ps_trace
 ### _ps_trace.tag_v = jsonb → boolean
-
+This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
 
 __Function:__ ps_trace.tag_v_eq
 
 __Schema:__ ps_trace
 ### trace_id = trace_id → boolean
-
+This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.
 
 __Function:__ _ps_trace.trace_id_eq
 
 __Schema:__ ps_trace
 ### _ps_trace.tag_v > _ps_trace.tag_v → boolean
-
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.
 
 __Function:__ tag_v_gt
 
 __Schema:__ ps_trace
 ### trace_id > trace_id → boolean
-
+This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.
 
 __Function:__ _ps_trace.trace_id_gt
 
 __Schema:__ ps_trace
 ### _ps_trace.tag_v >= _ps_trace.tag_v → boolean
-
+This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
 
 __Function:__ tag_v_ge
 
 __Schema:__ ps_trace
 ### trace_id >= trace_id → boolean
-
+This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.
 
 __Function:__ _ps_trace.trace_id_ge
 

--- a/migration/idempotent/007-tracing-tags.sql
+++ b/migration/idempotent/007-tracing-tags.sql
@@ -19,6 +19,11 @@ $fnc$;
 
 GRANT EXECUTE ON FUNCTION _ps_trace.tag_map_denormalize(ps_trace.tag_map) TO prom_reader;
 
+COMMENT ON FUNCTION _ps_trace.tag_map_denormalize
+IS 'Given a json object of (ps_trace.tag_key.id, ps_trace.tag.id) this function
+performs necessary lookups and returns a reconstructed set of open telemetry tags
+as a tag_map.';
+
 -------------------------------------------------------------------------------
 -- the -> operator
 -------------------------------------------------------------------------------
@@ -27,6 +32,9 @@ CREATE OR REPLACE FUNCTION ps_trace.tag_map_object_field(ps_trace.tag_map, pg_ca
     STRICT
     LANGUAGE internal AS 'jsonb_object_field';
 GRANT EXECUTE ON FUNCTION ps_trace.tag_map_object_field(ps_trace.tag_map, pg_catalog.text) TO prom_reader;
+COMMENT ON FUNCTION ps_trace.tag_map_object_field
+IS 'This function is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but returns _ps_trace.tag_v.';
 
 DO $do$
 BEGIN
@@ -40,6 +48,9 @@ EXCEPTION
         EXECUTE format($q$ALTER OPERATOR ps_trace.->(ps_trace.tag_map, pg_catalog.text) OWNER TO %I$q$, current_user);
 END;
 $do$;
+COMMENT ON OPERATOR ps_trace.-> (ps_trace.tag_map, pg_catalog.text)
+IS 'This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but returns _ps_trace.tag_v.';
 
 -------------------------------------------------------------------------------
 -- equals
@@ -53,6 +64,9 @@ CREATE OR REPLACE FUNCTION ps_trace.tag_v_eq(_ps_trace.tag_v, pg_catalog.jsonb)
         SUPPORT _prom_ext.tag_map_rewrite
     AS 'jsonb_eq';
 GRANT EXECUTE ON FUNCTION ps_trace.tag_v_eq(_ps_trace.tag_v, pg_catalog.jsonb) TO prom_reader;
+COMMENT ON FUNCTION ps_trace.tag_v_eq(_ps_trace.tag_v, pg_catalog.jsonb)
+IS 'This function is a part of custom _ps_trace.tag_v type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but has a support function attached.';
 
 CREATE OR REPLACE FUNCTION ps_trace.tag_v_eq(_ps_trace.tag_v, _ps_trace.tag_v)
     RETURNS pg_catalog.bool
@@ -62,6 +76,10 @@ CREATE OR REPLACE FUNCTION ps_trace.tag_v_eq(_ps_trace.tag_v, _ps_trace.tag_v)
         PARALLEL SAFE
     AS 'jsonb_eq';
 GRANT EXECUTE ON FUNCTION ps_trace.tag_v_eq(_ps_trace.tag_v, _ps_trace.tag_v) TO prom_reader;
+
+COMMENT ON FUNCTION ps_trace.tag_v_eq(_ps_trace.tag_v, _ps_trace.tag_v)
+IS 'This function is a part of custom _ps_trace.tag_v type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but has a support function attached.';
 
 CREATE OR REPLACE FUNCTION _ps_trace.tag_v_eq_matching_tags(_tag_key pg_catalog.text, _value pg_catalog.jsonb)
     RETURNS pg_catalog.jsonb
@@ -77,6 +95,10 @@ $fnc$
     LIMIT 1
 $fnc$;
 GRANT EXECUTE ON FUNCTION _ps_trace.tag_v_eq_matching_tags(_tag_key pg_catalog.text, _value pg_catalog.jsonb) TO prom_reader;
+COMMENT ON FUNCTION _ps_trace.tag_v_eq_matching_tags
+IS 'This function is a part of custom _ps_trace.tag_v type which is a wrapper for 
+the built-in jsonb. The tag_map_rewrite support function, attached to tag_v_eq,
+will use this function instead, if it can.';
 
 DO $do$
 BEGIN
@@ -94,6 +116,9 @@ EXCEPTION
         EXECUTE format($q$ALTER OPERATOR ps_trace.=(_ps_trace.tag_v, pg_catalog.jsonb) OWNER TO %I$q$, current_user);
 END;
 $do$;
+COMMENT ON OPERATOR ps_trace.= (_ps_trace.tag_v, pg_catalog.jsonb)
+IS 'This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.';
 
 
 DO $do$
@@ -112,6 +137,10 @@ EXCEPTION
         EXECUTE format($q$ALTER OPERATOR ps_trace.=(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
 END;
 $do$;
+COMMENT ON OPERATOR ps_trace.= (_ps_trace.tag_v, _ps_trace.tag_v)
+IS 'This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.';
+
 -------------------------------------------------------------------------------
 -- not equals
 -------------------------------------------------------------------------------
@@ -124,6 +153,9 @@ CREATE OR REPLACE FUNCTION ps_trace.tag_v_ne(_ps_trace.tag_v, pg_catalog.jsonb)
         SUPPORT _prom_ext.tag_map_rewrite
     AS 'jsonb_ne';
 GRANT EXECUTE ON FUNCTION ps_trace.tag_v_ne(_ps_trace.tag_v, pg_catalog.jsonb) TO prom_reader;
+COMMENT ON FUNCTION ps_trace.tag_v_ne(_ps_trace.tag_v, pg_catalog.jsonb)
+IS 'This function is a part of custom _ps_trace.tag_v type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but has a support function attached.';
 
 CREATE OR REPLACE FUNCTION ps_trace.tag_v_ne(_ps_trace.tag_v, _ps_trace.tag_v)
     RETURNS pg_catalog.bool
@@ -131,9 +163,12 @@ CREATE OR REPLACE FUNCTION ps_trace.tag_v_ne(_ps_trace.tag_v, _ps_trace.tag_v)
         IMMUTABLE
         STRICT
         PARALLEL SAFE
+        SUPPORT _prom_ext.tag_map_rewrite
     AS 'jsonb_ne';
 GRANT EXECUTE ON FUNCTION ps_trace.tag_v_ne(_ps_trace.tag_v, _ps_trace.tag_v) TO prom_reader;
-
+COMMENT ON FUNCTION ps_trace.tag_v_ne(_ps_trace.tag_v, _ps_trace.tag_v)
+IS 'This function is a part of custom _ps_trace.tag_v type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but has a support function attached.';
 
 CREATE OR REPLACE FUNCTION _ps_trace.tag_v_ne_matching_tags(_tag_key pg_catalog.text, _value pg_catalog.jsonb)
     RETURNS pg_catalog.jsonb[]
@@ -147,6 +182,10 @@ $fnc$
     AND a.value OPERATOR(pg_catalog.<>) _value
 $fnc$;
 GRANT EXECUTE ON FUNCTION _ps_trace.tag_v_ne_matching_tags(_tag_key pg_catalog.text, _value pg_catalog.jsonb) TO prom_reader;
+COMMENT ON FUNCTION _ps_trace.tag_v_ne_matching_tags
+IS 'This function is a part of custom _ps_trace.tag_v type which is a wrapper for 
+the built-in jsonb. The tag_map_rewrite support function, attached to tag_v_ne,
+will use this function instead, if it can.';
 
 
 DO $do$
@@ -164,6 +203,9 @@ EXCEPTION
         EXECUTE format($q$ALTER OPERATOR ps_trace.<>(_ps_trace.tag_v, pg_catalog.jsonb) OWNER TO %I$q$, current_user);
 END;
 $do$;
+COMMENT ON OPERATOR ps_trace.<> (_ps_trace.tag_v, pg_catalog.jsonb)
+IS 'This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.';
 
 DO $do$
 BEGIN
@@ -180,6 +222,9 @@ EXCEPTION
         EXECUTE format($q$ALTER OPERATOR ps_trace.<>(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
 END;
 $do$;
+COMMENT ON OPERATOR ps_trace.<> (_ps_trace.tag_v, _ps_trace.tag_v)
+IS 'This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.';
 
 -------------------------------------------------------------------------------
 -- comparison
@@ -193,6 +238,8 @@ CREATE OR REPLACE FUNCTION _ps_trace.tag_v_cmp(_ps_trace.tag_v, _ps_trace.tag_v)
         PARALLEL SAFE
     AS 'jsonb_cmp';
 GRANT EXECUTE ON FUNCTION _ps_trace.tag_v_cmp(_ps_trace.tag_v, _ps_trace.tag_v) TO prom_reader;
+COMMENT ON FUNCTION _ps_trace.tag_v_cmp
+IS 'This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.';
 
 CREATE OR REPLACE FUNCTION ps_trace.tag_v_gt(_ps_trace.tag_v, _ps_trace.tag_v)
     RETURNS pg_catalog.bool
@@ -202,6 +249,8 @@ CREATE OR REPLACE FUNCTION ps_trace.tag_v_gt(_ps_trace.tag_v, _ps_trace.tag_v)
         PARALLEL SAFE
     AS 'jsonb_gt';
 GRANT EXECUTE ON FUNCTION ps_trace.tag_v_gt(_ps_trace.tag_v, _ps_trace.tag_v) TO prom_reader;
+COMMENT ON FUNCTION ps_trace.tag_v_gt
+IS 'This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.';
 
 CREATE OR REPLACE FUNCTION ps_trace.tag_v_ge(_ps_trace.tag_v, _ps_trace.tag_v)
     RETURNS pg_catalog.bool
@@ -211,6 +260,8 @@ CREATE OR REPLACE FUNCTION ps_trace.tag_v_ge(_ps_trace.tag_v, _ps_trace.tag_v)
         PARALLEL SAFE
     AS 'jsonb_ge';
 GRANT EXECUTE ON FUNCTION ps_trace.tag_v_ge(_ps_trace.tag_v, _ps_trace.tag_v) TO prom_reader;
+COMMENT ON FUNCTION ps_trace.tag_v_ge
+IS 'This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.';
 
 CREATE OR REPLACE FUNCTION ps_trace.tag_v_lt(_ps_trace.tag_v, _ps_trace.tag_v)
     RETURNS pg_catalog.bool
@@ -220,6 +271,8 @@ CREATE OR REPLACE FUNCTION ps_trace.tag_v_lt(_ps_trace.tag_v, _ps_trace.tag_v)
         PARALLEL SAFE
     AS 'jsonb_lt';
 GRANT EXECUTE ON FUNCTION ps_trace.tag_v_lt(_ps_trace.tag_v, _ps_trace.tag_v) TO prom_reader;
+COMMENT ON FUNCTION ps_trace.tag_v_lt
+IS 'This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.';
 
 CREATE OR REPLACE FUNCTION ps_trace.tag_v_le(_ps_trace.tag_v, _ps_trace.tag_v)
     RETURNS pg_catalog.bool
@@ -229,6 +282,8 @@ CREATE OR REPLACE FUNCTION ps_trace.tag_v_le(_ps_trace.tag_v, _ps_trace.tag_v)
         PARALLEL SAFE
     AS 'jsonb_le';
 GRANT EXECUTE ON FUNCTION ps_trace.tag_v_le(_ps_trace.tag_v, _ps_trace.tag_v) TO prom_reader;
+COMMENT ON FUNCTION ps_trace.tag_v_le
+IS 'This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.';
 
 DO $do$
 BEGIN
@@ -262,6 +317,9 @@ EXCEPTION
         EXECUTE format($q$ALTER OPERATOR ps_trace.>=(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
 END;
 $do$;
+COMMENT ON OPERATOR ps_trace.>= (_ps_trace.tag_v, _ps_trace.tag_v)
+IS 'This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.';
 
 DO $do$
 BEGIN
@@ -278,7 +336,9 @@ EXCEPTION
         EXECUTE format($q$ALTER OPERATOR ps_trace.<(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
 END;
 $do$;
-
+COMMENT ON OPERATOR ps_trace.< (_ps_trace.tag_v, _ps_trace.tag_v)
+IS 'This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.';
 
 DO $do$
 BEGIN
@@ -295,7 +355,9 @@ EXCEPTION
         EXECUTE format($q$ALTER OPERATOR ps_trace.<=(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
 END;
 $do$;
-
+COMMENT ON OPERATOR ps_trace.<= (_ps_trace.tag_v, _ps_trace.tag_v)
+IS 'This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.';
 
 
 /* Create opclass for tag_v for distinct/group by type of queries */

--- a/migration/idempotent/008-tracing-functions.sql
+++ b/migration/idempotent/008-tracing-functions.sql
@@ -11,7 +11,7 @@ $sql$
 LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 GRANT EXECUTE ON FUNCTION ps_trace.span_tag_type() TO prom_reader;
 COMMENT ON FUNCTION ps_trace.span_tag_type
-IS 'This function returns tag_type with the span tag bit.';
+IS 'This function returns tag_type with the span tag bit set.';
 
 CREATE OR REPLACE FUNCTION ps_trace.resource_tag_type()
 RETURNS ps_trace.tag_type
@@ -22,7 +22,7 @@ $sql$
 LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 GRANT EXECUTE ON FUNCTION ps_trace.resource_tag_type() TO prom_reader;
 COMMENT ON FUNCTION ps_trace.resource_tag_type
-IS 'This function returns tag_type with the resource tag bit.';
+IS 'This function returns tag_type with the resource tag bit set.';
 
 CREATE OR REPLACE FUNCTION ps_trace.event_tag_type()
 RETURNS ps_trace.tag_type
@@ -33,7 +33,7 @@ $sql$
 LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 GRANT EXECUTE ON FUNCTION ps_trace.event_tag_type() TO prom_reader;
 COMMENT ON FUNCTION ps_trace.event_tag_type 
-IS 'This function returns tag_type with the event tag bit.';
+IS 'This function returns tag_type with the event tag bit set.';
 
 CREATE OR REPLACE FUNCTION ps_trace.link_tag_type()
 RETURNS ps_trace.tag_type
@@ -44,7 +44,7 @@ $sql$
 LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 GRANT EXECUTE ON FUNCTION ps_trace.link_tag_type() TO prom_reader;
 COMMENT ON FUNCTION ps_trace.link_tag_type
-IS 'This function returns tag_type with the link tag bit.';
+IS 'This function returns tag_type with the link tag bit set.';
 
 CREATE OR REPLACE FUNCTION ps_trace.is_span_tag_type(_tag_type ps_trace.tag_type)
 RETURNS BOOLEAN
@@ -467,8 +467,8 @@ $func$
 LANGUAGE SQL STABLE PARALLEL SAFE STRICT;
 GRANT EXECUTE ON FUNCTION ps_trace.get_tag_map(jsonb) TO prom_reader;
 COMMENT ON FUNCTION ps_trace.get_tag_map
-IS 'For a given jsonb object cosisting of key-value pairs, representing tags and their values,
-this funciton returns a jsonb object of corresponding ids -- the primary keys in
+IS 'For a given jsonb object consisting of key-value pairs, representing tags and their values,
+this function returns a jsonb object of corresponding ids -- the primary keys in
 _ps_trace.tag_key and _ps_trace.tag tables.';
 
 CREATE OR REPLACE FUNCTION ps_trace.put_operation(_service_name text, _span_name text, _span_kind ps_trace.span_kind)

--- a/migration/idempotent/008-tracing-functions.sql
+++ b/migration/idempotent/008-tracing-functions.sql
@@ -10,6 +10,8 @@ AS $sql$
 $sql$
 LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 GRANT EXECUTE ON FUNCTION ps_trace.span_tag_type() TO prom_reader;
+COMMENT ON FUNCTION ps_trace.span_tag_type
+IS 'This function returns tag_type with the span tag bit.';
 
 CREATE OR REPLACE FUNCTION ps_trace.resource_tag_type()
 RETURNS ps_trace.tag_type
@@ -19,6 +21,8 @@ AS $sql$
 $sql$
 LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 GRANT EXECUTE ON FUNCTION ps_trace.resource_tag_type() TO prom_reader;
+COMMENT ON FUNCTION ps_trace.resource_tag_type
+IS 'This function returns tag_type with the resource tag bit.';
 
 CREATE OR REPLACE FUNCTION ps_trace.event_tag_type()
 RETURNS ps_trace.tag_type
@@ -28,6 +32,8 @@ AS $sql$
 $sql$
 LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 GRANT EXECUTE ON FUNCTION ps_trace.event_tag_type() TO prom_reader;
+COMMENT ON FUNCTION ps_trace.event_tag_type 
+IS 'This function returns tag_type with the event tag bit.';
 
 CREATE OR REPLACE FUNCTION ps_trace.link_tag_type()
 RETURNS ps_trace.tag_type
@@ -37,6 +43,8 @@ AS $sql$
 $sql$
 LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 GRANT EXECUTE ON FUNCTION ps_trace.link_tag_type() TO prom_reader;
+COMMENT ON FUNCTION ps_trace.link_tag_type
+IS 'This function returns tag_type with the link tag bit.';
 
 CREATE OR REPLACE FUNCTION ps_trace.is_span_tag_type(_tag_type ps_trace.tag_type)
 RETURNS BOOLEAN
@@ -46,6 +54,8 @@ AS $sql$
 $sql$
 LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
 GRANT EXECUTE ON FUNCTION ps_trace.is_span_tag_type(ps_trace.tag_type) TO prom_reader;
+COMMENT ON FUNCTION ps_trace.is_span_tag_type
+IS 'This function checks whether a tag_type value has the span tag bit set.';
 
 CREATE OR REPLACE FUNCTION ps_trace.is_resource_tag_type(_tag_type ps_trace.tag_type)
 RETURNS BOOLEAN
@@ -55,6 +65,8 @@ AS $sql$
 $sql$
 LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
 GRANT EXECUTE ON FUNCTION ps_trace.is_resource_tag_type(ps_trace.tag_type) TO prom_reader;
+COMMENT ON FUNCTION ps_trace.is_resource_tag_type
+IS 'This function checks whether a tag_type value has the resource tag bit set.';
 
 CREATE OR REPLACE FUNCTION ps_trace.is_event_tag_type(_tag_type ps_trace.tag_type)
 RETURNS BOOLEAN
@@ -64,6 +76,8 @@ AS $sql$
 $sql$
 LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
 GRANT EXECUTE ON FUNCTION ps_trace.is_event_tag_type(ps_trace.tag_type) TO prom_reader;
+COMMENT ON FUNCTION ps_trace.is_event_tag_type
+IS 'This function checks whether a tag_type value has the event tag bit set.';
 
 CREATE OR REPLACE FUNCTION ps_trace.is_link_tag_type(_tag_type ps_trace.tag_type)
 RETURNS BOOLEAN
@@ -73,6 +87,8 @@ AS $sql$
 $sql$
 LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
 GRANT EXECUTE ON FUNCTION ps_trace.is_link_tag_type(ps_trace.tag_type) TO prom_reader;
+COMMENT ON FUNCTION ps_trace.is_link_tag_type
+IS 'This function checks whether a tag_type value has the link tag bit set.';
 
 -------------------------------------------------------------------------------
 -- trace tree functions
@@ -124,6 +140,9 @@ AS $func$
     FROM x
 $func$ LANGUAGE sql STABLE STRICT PARALLEL SAFE;
 GRANT EXECUTE ON FUNCTION ps_trace.trace_tree(ps_trace.trace_id) TO prom_reader;
+COMMENT ON FUNCTION ps_trace.trace_tree
+IS 'This function returns a set of all spans for a given trace_id. Additionally, parent span,
+nesting level and a path (as an array of span_id) are supplied for each span in the set.';
 
 CREATE OR REPLACE FUNCTION ps_trace.upstream_spans(_trace_id ps_trace.trace_id, _span_id bigint, _max_dist int default null)
 RETURNS TABLE
@@ -173,6 +192,12 @@ AS $func$
     FROM x
 $func$ LANGUAGE sql STABLE PARALLEL SAFE;
 GRANT EXECUTE ON FUNCTION ps_trace.upstream_spans(ps_trace.trace_id, bigint, int) TO prom_reader;
+COMMENT ON FUNCTION ps_trace.upstream_spans
+IS 'For a given trace_id and span_id this function returns a set that consists of the all spans starting
+from the specified span and up to the root of the trace. Each span is annotated with parent_span_id,
+a distance from the specified span (the span itself has the distance of 0) and a path from the specified span 
+towards the root. Optional third argument allows to limit the span tree traversal to a certain distance from 
+the specified span_id.';
 
 CREATE OR REPLACE FUNCTION ps_trace.downstream_spans(_trace_id ps_trace.trace_id, _span_id bigint, _max_dist int default null)
 RETURNS TABLE
@@ -220,6 +245,12 @@ AS $func$
     FROM x
 $func$ LANGUAGE sql STABLE PARALLEL SAFE;
 GRANT EXECUTE ON FUNCTION ps_trace.downstream_spans(ps_trace.trace_id, bigint, int) TO prom_reader;
+COMMENT ON FUNCTION ps_trace.downstream_spans
+IS 'For a given trace_id and span_id this function returns a set that consists of the all spans starting
+from the specified span and down to the leaves of the trace. Each span is annotated with parent_span_id,
+a distance from the specified span (the span itself has the distance of 0) and a path from the specified span 
+towards the root. Optional third argument allows to limit the span tree traversal to a certain distance from 
+the specified span_id.';
 
 CREATE OR REPLACE FUNCTION ps_trace.sibling_spans(_trace_id ps_trace.trace_id, _span_id bigint)
 RETURNS TABLE
@@ -245,6 +276,8 @@ AS $func$
     )
 $func$ LANGUAGE sql STABLE PARALLEL SAFE;
 GRANT EXECUTE ON FUNCTION ps_trace.sibling_spans(ps_trace.trace_id, bigint) TO prom_reader;
+COMMENT ON FUNCTION ps_trace.sibling_spans
+IS 'For a given trace_id and span_id this function returns spans sharing the same parent_span_id.';
 
 CREATE OR REPLACE FUNCTION ps_trace.operation_calls(_start_time_min timestamptz, _start_time_max timestamptz)
 RETURNS TABLE
@@ -275,6 +308,9 @@ $func$ LANGUAGE sql
 SET  enable_nestloop = off
 STABLE PARALLEL SAFE;
 GRANT EXECUTE ON FUNCTION ps_trace.operation_calls(timestamptz, timestamptz) TO prom_reader;
+COMMENT ON FUNCTION ps_trace.operation_calls
+IS 'This function counts the number of parent -> child pairs (aka calls) within a specified
+time window and their operation ids.';
 
 CREATE OR REPLACE FUNCTION ps_trace.span_tree(_trace_id ps_trace.trace_id, _span_id bigint, _max_dist int default null)
 RETURNS TABLE
@@ -311,6 +347,9 @@ AS $func$
     FROM ps_trace.downstream_spans(_trace_id, _span_id, _max_dist) d
 $func$ LANGUAGE sql STABLE PARALLEL SAFE;
 GRANT EXECUTE ON FUNCTION ps_trace.span_tree(ps_trace.trace_id, bigint, int) TO prom_reader;
+COMMENT ON FUNCTION ps_trace.span_tree
+IS 'For a given pair of trace_id and span_id, this function returns a union of
+downstream_spans and upstream_spans.';
 
 -------------------------------------------------------------------------------
 -- get / put functions
@@ -349,6 +388,9 @@ END;
 $func$
 LANGUAGE plpgsql;
 GRANT EXECUTE ON FUNCTION ps_trace.put_tag_key(ps_trace.tag_k, ps_trace.tag_type) TO prom_writer;
+COMMENT ON FUNCTION ps_trace.put_tag_key
+IS 'This function creates a new tag key and associates it with the specified tag type and returns
+its id (a key in _ps_trace.tag_key table)';
 
 CREATE OR REPLACE FUNCTION ps_trace.put_tag(_key ps_trace.tag_k, _value _ps_trace.tag_v, _tag_type ps_trace.tag_type)
     RETURNS BIGINT
@@ -402,6 +444,9 @@ END;
 $func$
 LANGUAGE plpgsql;
 GRANT EXECUTE ON FUNCTION ps_trace.put_tag(ps_trace.tag_k, _ps_trace.tag_v, ps_trace.tag_type) TO prom_writer;
+COMMENT ON FUNCTION ps_trace.put_tag
+IS 'This function inserts a new tag with the specified value and returns its id (a key in _ps_trace.tag table).
+The specified tag key must exist for the specified resource type.';
 
 CREATE OR REPLACE FUNCTION ps_trace.get_tag_map(_tags jsonb)
 RETURNS ps_trace.tag_map
@@ -421,6 +466,10 @@ AS $func$
 $func$
 LANGUAGE SQL STABLE PARALLEL SAFE STRICT;
 GRANT EXECUTE ON FUNCTION ps_trace.get_tag_map(jsonb) TO prom_reader;
+COMMENT ON FUNCTION ps_trace.get_tag_map
+IS 'For a given jsonb object cosisting of key-value pairs, representing tags and their values,
+this funciton returns a jsonb object of corresponding ids -- the primary keys in
+_ps_trace.tag_key and _ps_trace.tag tables.';
 
 CREATE OR REPLACE FUNCTION ps_trace.put_operation(_service_name text, _span_name text, _span_kind ps_trace.span_kind)
     RETURNS bigint
@@ -497,6 +546,10 @@ END;
 $func$
 LANGUAGE plpgsql;
 GRANT EXECUTE ON FUNCTION ps_trace.put_operation(text, text, ps_trace.span_kind) TO prom_writer;
+COMMENT ON FUNCTION ps_trace.put_operation
+IS 'This function creates an operation record and a necessary service.name tag, if either doesn''t exist 
+and returns the operation''s id (a key in the _ps_tag.opertaions table). It is meant to be used during
+span creation, to obtain a valid value for mandatory operation_id attribute.';
 
 CREATE OR REPLACE FUNCTION ps_trace.put_schema_url(_schema_url text)
     RETURNS bigint
@@ -528,6 +581,9 @@ END;
 $func$
 LANGUAGE plpgsql;
 GRANT EXECUTE ON FUNCTION ps_trace.put_schema_url(text) TO prom_writer;
+COMMENT ON FUNCTION ps_trace.put_schema_url
+IS 'This function creates an entry in the _ps_trace.schema_url table if it doesn''t exit and returns its id.
+It is meant to be used during span creation, to obtain a valid value for mandatory resource_schema_url_id attribute.';
 
 CREATE OR REPLACE FUNCTION ps_trace.put_instrumentation_lib(_name text, _version text, _schema_url_id bigint)
     RETURNS bigint
@@ -568,6 +624,9 @@ END;
 $func$
 LANGUAGE plpgsql;
 GRANT EXECUTE ON FUNCTION ps_trace.put_instrumentation_lib(text, text, bigint) TO prom_writer;
+COMMENT ON FUNCTION ps_trace.put_instrumentation_lib
+IS 'This function creates an entry in the _ps_trace.instrumentation_lib table if it doesn''t exit and returns its id.
+It is meant to be used during span creation, to obtain a valid value for mandatory instrumentation_lib_id attribute.';
 
 -- Creates a temporary table (if it doesn't exist), suitable for tracing data ingestion.
 -- Supresses corresponding DDL logging, otherwise PG log may get unnecessarily verbose.
@@ -593,6 +652,9 @@ $func$
 LANGUAGE plpgsql;
 REVOKE ALL ON FUNCTION _ps_trace.ensure_trace_ingest_temp_table(text, text) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION _ps_trace.ensure_trace_ingest_temp_table(text, text) TO prom_writer;
+COMMENT ON FUNCTION _ps_trace.ensure_trace_ingest_temp_table
+IS 'Creates a temporary table (if it doesn''t exist), suitable for tracing data ingestion. 
+Supresses corresponding DDL logging, otherwise PG log may get unnecessarily verbose.';
 
 CREATE OR REPLACE FUNCTION ps_trace.delete_all_traces()
     RETURNS void
@@ -612,8 +674,9 @@ AS $func$
 $func$
 LANGUAGE sql;
 GRANT EXECUTE ON FUNCTION ps_trace.delete_all_traces() TO prom_admin;
-COMMENT ON FUNCTION ps_trace.delete_all_traces IS
-$$WARNING: this function deletes all spans and related tracing data in the system and restores it to a "just installed" state.$$;
+COMMENT ON FUNCTION ps_trace.delete_all_traces
+IS 'WARNING: this function deletes all spans and related tracing data in the system and restores
+it to a "just installed" state.';
 
 CREATE OR REPLACE FUNCTION ps_trace.tag_map_in(cstring)
 RETURNS ps_trace.tag_map
@@ -621,6 +684,8 @@ LANGUAGE internal
 IMMUTABLE PARALLEL SAFE STRICT
 AS $function$jsonb_in$function$
 ;
+COMMENT ON FUNCTION ps_trace.tag_map_in
+IS 'This function is a part of custom ps_trace.tag_map type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.';
 
 CREATE OR REPLACE FUNCTION ps_trace.tag_map_out(ps_trace.tag_map)
 RETURNS cstring
@@ -628,6 +693,8 @@ LANGUAGE internal
 IMMUTABLE PARALLEL SAFE STRICT
 AS $function$jsonb_out$function$
 ;
+COMMENT ON FUNCTION ps_trace.tag_map_out
+IS 'This function is a part of custom ps_trace.tag_map type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.';
 
 CREATE OR REPLACE FUNCTION ps_trace.tag_map_send(ps_trace.tag_map)
 RETURNS bytea
@@ -635,6 +702,8 @@ LANGUAGE internal
 IMMUTABLE PARALLEL SAFE STRICT
 AS $function$jsonb_send$function$
 ;
+COMMENT ON FUNCTION ps_trace.tag_map_send
+IS 'This function is a part of custom ps_trace.tag_map type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.';
 
 CREATE OR REPLACE FUNCTION ps_trace.tag_map_recv(internal)
 RETURNS ps_trace.tag_map
@@ -642,6 +711,8 @@ LANGUAGE internal
 IMMUTABLE PARALLEL SAFE STRICT
 AS $function$jsonb_recv$function$
 ;
+COMMENT ON FUNCTION ps_trace.tag_map_recv
+IS 'This function is a part of custom ps_trace.tag_map type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.';
 
 DO
 $do$
@@ -660,6 +731,8 @@ BEGIN
                 IMMUTABLE PARALLEL SAFE STRICT
                 AS $f$jsonb_subscript_handler$f$;
 
+        COMMENT ON FUNCTION ps_trace.tag_map_subscript_handler
+        IS 'This function is a part of custom ps_trace.tag_map type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.';
         /* Add subscript handler in case of a prior PG13 -> PG14 upgrade that
          * didn't take care of this
          */
@@ -680,6 +753,8 @@ LANGUAGE internal
 IMMUTABLE PARALLEL SAFE STRICT
 AS $function$jsonb_in$function$
 ;
+COMMENT ON FUNCTION _ps_trace.tag_v_in
+IS 'This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.';
 
 CREATE OR REPLACE FUNCTION _ps_trace.tag_v_out(_ps_trace.tag_v)
 RETURNS cstring
@@ -687,6 +762,8 @@ LANGUAGE internal
 IMMUTABLE PARALLEL SAFE STRICT
 AS $function$jsonb_out$function$
 ;
+COMMENT ON FUNCTION _ps_trace.tag_v_out
+IS 'This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.';
 
 CREATE OR REPLACE FUNCTION _ps_trace.tag_v_send(_ps_trace.tag_v)
 RETURNS bytea
@@ -694,6 +771,8 @@ LANGUAGE internal
 IMMUTABLE PARALLEL SAFE STRICT
 AS $function$jsonb_send$function$
 ;
+COMMENT ON FUNCTION _ps_trace.tag_v_send
+IS 'This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.';
 
 CREATE OR REPLACE FUNCTION _ps_trace.tag_v_recv(internal)
 RETURNS _ps_trace.tag_v
@@ -701,6 +780,8 @@ LANGUAGE internal
 IMMUTABLE PARALLEL SAFE STRICT
 AS $function$jsonb_recv$function$
 ;
+COMMENT ON FUNCTION _ps_trace.tag_v_recv
+IS 'This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.';
 
 DO
 $do$
@@ -718,6 +799,8 @@ BEGIN
                 LANGUAGE internal
                 IMMUTABLE PARALLEL SAFE STRICT
                 AS $f$jsonb_subscript_handler$f$;
+        COMMENT ON FUNCTION _ps_trace.tag_v_subscript_handler
+        IS 'This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.';
         /* Add subscript handler in case of a prior PG13 -> PG14 upgrade that
          * didn't take care of this
          */

--- a/migration/idempotent/011-maintenance.sql
+++ b/migration/idempotent/011-maintenance.sql
@@ -231,6 +231,8 @@ LANGUAGE PLPGSQL;
 --redundant given schema settings but extra caution for security definers
 REVOKE ALL ON PROCEDURE _ps_trace.drop_span_chunks(timestamptz) FROM PUBLIC;
 GRANT EXECUTE ON PROCEDURE _ps_trace.drop_span_chunks(timestamptz) TO prom_maintenance;
+COMMENT ON PROCEDURE _ps_trace.drop_span_chunks
+IS 'This procedure drops chunks of _ps_trace.span hypertable that are older than a specified timestamp.';
 
 CREATE OR REPLACE PROCEDURE _ps_trace.drop_link_chunks(_older_than timestamptz)
 --security definer to add jobs as the logged-in user
@@ -261,6 +263,8 @@ LANGUAGE PLPGSQL;
 --redundant given schema settings but extra caution for security definers
 REVOKE ALL ON PROCEDURE _ps_trace.drop_link_chunks(timestamptz) FROM PUBLIC;
 GRANT EXECUTE ON PROCEDURE _ps_trace.drop_link_chunks(timestamptz) TO prom_maintenance;
+COMMENT ON PROCEDURE _ps_trace.drop_link_chunks
+IS 'This procedure drops chunks of _ps_trace.link hypertable that are older than a specified timestamp.';
 
 CREATE OR REPLACE PROCEDURE _ps_trace.drop_event_chunks(_older_than timestamptz)
 --security definer to add jobs as the logged-in user
@@ -291,6 +295,8 @@ LANGUAGE PLPGSQL;
 --redundant given schema settings but extra caution for security definers
 REVOKE ALL ON PROCEDURE _ps_trace.drop_event_chunks(timestamptz) FROM PUBLIC;
 GRANT EXECUTE ON PROCEDURE _ps_trace.drop_event_chunks(timestamptz) TO prom_maintenance;
+COMMENT ON PROCEDURE _ps_trace.drop_event_chunks
+IS 'This procedure drops chunks of _ps_trace.event hypertable that are older than a specified timestamp.';
 
 CREATE OR REPLACE FUNCTION ps_trace.set_trace_retention_period(_trace_retention_period INTERVAL)
     RETURNS BOOLEAN

--- a/migration/idempotent/012-trace-id-functions.sql
+++ b/migration/idempotent/012-trace-id-functions.sql
@@ -5,6 +5,8 @@ LANGUAGE internal
 IMMUTABLE PARALLEL SAFE STRICT
 AS $function$uuid_in$function$;
 GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_in(cstring) TO prom_reader;
+COMMENT ON FUNCTION _ps_trace.trace_id_in
+IS 'This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.';
 
 CREATE OR REPLACE FUNCTION _ps_trace.trace_id_out(ps_trace.trace_id)
 RETURNS cstring
@@ -12,6 +14,8 @@ LANGUAGE internal
 IMMUTABLE PARALLEL SAFE STRICT
 AS $function$uuid_out$function$;
 GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_out(ps_trace.trace_id) TO prom_reader;
+COMMENT ON FUNCTION _ps_trace.trace_id_out
+IS 'This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.';
 
 CREATE OR REPLACE FUNCTION _ps_trace.trace_id_send(ps_trace.trace_id)
 RETURNS bytea
@@ -19,6 +23,8 @@ LANGUAGE internal
 IMMUTABLE PARALLEL SAFE STRICT
 AS $function$uuid_send$function$;
 GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_send(ps_trace.trace_id) TO prom_reader;
+COMMENT ON FUNCTION _ps_trace.trace_id_send
+IS 'This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.';
 
 CREATE OR REPLACE FUNCTION _ps_trace.trace_id_recv(internal)
 RETURNS ps_trace.trace_id
@@ -26,6 +32,8 @@ LANGUAGE internal
 IMMUTABLE PARALLEL SAFE STRICT
 AS $function$uuid_recv$function$;
 GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_recv(internal) TO prom_reader;
+COMMENT ON FUNCTION _ps_trace.trace_id_recv
+IS 'This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.';
 
 CREATE OR REPLACE FUNCTION _ps_trace.trace_id_ne(ps_trace.trace_id, ps_trace.trace_id)
 RETURNS bool
@@ -33,6 +41,8 @@ LANGUAGE internal
 IMMUTABLE PARALLEL SAFE STRICT
 AS $function$uuid_ne$function$;
 GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_ne(ps_trace.trace_id, ps_trace.trace_id) TO prom_reader;
+COMMENT ON FUNCTION _ps_trace.trace_id_ne
+IS 'This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.';
 
 CREATE OR REPLACE FUNCTION _ps_trace.trace_id_eq(ps_trace.trace_id, ps_trace.trace_id)
 RETURNS bool
@@ -40,6 +50,8 @@ LANGUAGE internal
 IMMUTABLE PARALLEL SAFE STRICT
 AS $function$uuid_eq$function$;
 GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_eq(ps_trace.trace_id, ps_trace.trace_id) TO prom_reader;
+COMMENT ON FUNCTION _ps_trace.trace_id_eq
+IS 'This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.';
 
 CREATE OR REPLACE FUNCTION _ps_trace.trace_id_ge(ps_trace.trace_id, ps_trace.trace_id)
 RETURNS bool
@@ -47,6 +59,8 @@ LANGUAGE internal
 IMMUTABLE PARALLEL SAFE STRICT
 AS $function$uuid_ge$function$;
 GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_ge(ps_trace.trace_id, ps_trace.trace_id) TO prom_reader;
+COMMENT ON FUNCTION _ps_trace.trace_id_ge
+IS 'This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.';
 
 CREATE OR REPLACE FUNCTION _ps_trace.trace_id_le(ps_trace.trace_id, ps_trace.trace_id)
 RETURNS bool
@@ -54,6 +68,8 @@ LANGUAGE internal
 IMMUTABLE PARALLEL SAFE STRICT
 AS $function$uuid_le$function$;
 GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_le(ps_trace.trace_id, ps_trace.trace_id) TO prom_reader;
+COMMENT ON FUNCTION _ps_trace.trace_id_le
+IS 'This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.';
 
 CREATE OR REPLACE FUNCTION _ps_trace.trace_id_gt(ps_trace.trace_id, ps_trace.trace_id)
 RETURNS bool
@@ -61,6 +77,8 @@ LANGUAGE internal
 IMMUTABLE PARALLEL SAFE STRICT
 AS $function$uuid_gt$function$;
 GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_gt(ps_trace.trace_id, ps_trace.trace_id) TO prom_reader;
+COMMENT ON FUNCTION _ps_trace.trace_id_gt
+IS 'This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.';
 
 CREATE OR REPLACE FUNCTION _ps_trace.trace_id_lt(ps_trace.trace_id, ps_trace.trace_id)
 RETURNS bool
@@ -68,6 +86,8 @@ LANGUAGE internal
 IMMUTABLE PARALLEL SAFE STRICT
 AS $function$uuid_lt$function$;
 GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_lt(ps_trace.trace_id, ps_trace.trace_id) TO prom_reader;
+COMMENT ON FUNCTION _ps_trace.trace_id_lt
+IS 'This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.';
 
 CREATE OR REPLACE FUNCTION _ps_trace.trace_id_cmp(ps_trace.trace_id, ps_trace.trace_id)
 RETURNS int
@@ -75,6 +95,8 @@ LANGUAGE internal
 IMMUTABLE PARALLEL SAFE STRICT
 AS $function$uuid_cmp$function$;
 GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_cmp(ps_trace.trace_id, ps_trace.trace_id) TO prom_reader;
+COMMENT ON FUNCTION _ps_trace.trace_id_cmp
+IS 'This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.';
 
 CREATE OR REPLACE FUNCTION _ps_trace.trace_id_hash(ps_trace.trace_id)
 RETURNS int
@@ -82,3 +104,5 @@ LANGUAGE internal
 IMMUTABLE PARALLEL SAFE STRICT
 AS $function$uuid_hash$function$;
 GRANT EXECUTE ON FUNCTION _ps_trace.trace_id_hash(ps_trace.trace_id) TO prom_reader;
+COMMENT ON FUNCTION _ps_trace.trace_id_hash
+IS 'This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.';


### PR DESCRIPTION
## Description

- This PR partially addresses #159 by adding SQL comments to functions and procedures that comprise Tracing API.
- Additionally, I've noticed that `(tag_v,tag_v)` eq and neq functions lacked the support function annotation, so I've added it.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~CHANGELOG entry for user-facing changes~
- [x] Updated the relevant documentation