### PR TITLE
Revert "Temporarily use jg/autoupdate-timescaledb branch"

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -110,7 +110,7 @@ jobs:
           if [[ "$res" = "200" ]]; then
             echo "::set-output name=branch::${branch_name}"
           elif [[ "$res" == "404" ]]; then
-            echo "::set-output name=branch::jg/autoupdate-timescaledb"
+            echo "::set-output name=branch::master"
           else
             echo "Unexpected HTTP response: $res"
             exit 1


### PR DESCRIPTION
## Description

This reverts commit 1d6788b375834add73be4c1def2fd3f534c500fc.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation