### PR TITLE
Correct storage type for columns deriving from `tag_map` and `tag_v`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ We use the following categories for changes:
 
 ## [Unreleased]
 
+### Changed
+
+- Correct storage type for attributes deriving from `tag_map` and `tag_v` [#365]
+
 ## [0.5.1] - 2021-06-08
 
 ### Added

--- a/migration/incremental/027-tag-map-storage-views.sql
+++ b/migration/incremental/027-tag-map-storage-views.sql
@@ -1,0 +1,14 @@
+-- When we changed the storage type of `ps_trace.tag_map` and
+-- `_ps_trace.tag_v` from `PLAIN` to `EXTENDED`, we didn't update all
+-- `pg_attribute` entries. This meant that the definitions for our views
+-- (`ps_trace.{event,link,span}`) were incorrect.
+--
+-- While we noticed this specifically with our views, it could also cascade
+-- to relations which end users built on top of our types.
+UPDATE pg_catalog.pg_attribute AS a
+SET attstorage = 'x'
+WHERE a.atttypid = '_ps_trace.tag_v'::regtype::oid;
+
+UPDATE pg_catalog.pg_attribute AS a
+SET attstorage = 'x'
+WHERE a.atttypid = 'ps_trace.tag_map'::regtype::oid;


### PR DESCRIPTION
## Description

When we changed the storage type of `ps_trace.tag_map` and
`_ps_trace.tag_v` from `PLAIN` to `EXTENDED`, we didn't update all
`pg_attribute` entries. This meant that the definitions for our views
(`ps_trace.{event,link,span}`) were incorrect.

While we noticed this specifically with our views, it could also cascade
to tables or views which end users built on top of our types.

This change modifies the storage type for all `pg_attribute` entries of
type `ps_trace.tag_map` and `_ps_trace.tag_v`.

Note: should a user have purposefully set the storage type for a
specific column, this change will overwrite that. We deem this to be
very unlikely, and `EXTENDED` is almost certainly what you want.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] ~~Updated the relevant documentation~~