### PR TITLE
Correctly identify and drop `prom_schema_migrations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ We use the following categories for changes:
 
 ## [Unreleased]
 
+### Fixed
+
+- Correctly identify and drop `prom_schema_migrations` [#372]
+
 ## [0.5.2] - 2021-06-20
 
 ### Changed

--- a/sql/promscale--0.0.0.sql
+++ b/sql/promscale--0.0.0.sql
@@ -17,7 +17,19 @@ BEGIN
 END;
 $stop_bgw$;
 
-DROP TABLE public.prom_schema_migrations;
+DO
+$drop_prom_schema_migrations$
+DECLARE
+    schema TEXT;
+BEGIN
+    -- The prom_schema_migrations table was not schema-qualified on creation,
+    -- so it could be in any schema. Find out the schema it's in and drop.
+    SELECT schemaname INTO STRICT schema FROM pg_catalog.pg_tables WHERE tablename = 'prom_schema_migrations';
+    IF schema IS NOT NULL THEN
+        EXECUTE format('DROP TABLE %I.prom_schema_migrations', schema);
+    END IF;
+END;
+$drop_prom_schema_migrations$;
 
 REVOKE EXECUTE ON FUNCTION ps_trace.delete_all_traces() FROM prom_writer;
 REVOKE EXECUTE ON PROCEDURE prom_api.add_prom_node(TEXT, BOOLEAN) FROM prom_writer;


### PR DESCRIPTION
## Description

The `prom_schema_migrations` table was not schema-qualified on creation,
so it could be in any schema. Find out the schema it's in and drop.

Part of: #371

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] ~~Updated the relevant documentation~~