### PR TITLE
Remove `paths-ignore` for required CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,11 +1,6 @@
 name: ci
 on:
   pull_request:
-    paths-ignore:
-    - '.github/workflows/release.yaml'
-    - '*.md'
-    - 'dist/*'
-    - 'tools/package'
 
 jobs:
   test:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -2,9 +2,6 @@ name: docker
 on:
   pull_request:
     paths-ignore:
-    - '.github/workflows/release.yaml'
-    - 'dist/*'
-    - 'tools/*'
   push:
     branches:
       - develop

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,10 +2,6 @@ name: lint
 on:
   pull_request:
     paths-ignore:
-    - '.github/workflows/release.yaml'
-    - 'dist/*'
-    - 'tools/package'
-    - '*.md'
 
 jobs:
   fmt:


### PR DESCRIPTION
## Description

Our branch protection rules require that certain checks pass before
allowing a PR to be merged into the master branch.

Having `paths-ignore` set for these checks means that a PR which only
adds or touches a .md file will not have the required checks run, and so
is not able to be merged. This doesn't make sense.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~