### PR TITLE
Remove `bytes_total` calculation from telemetry.

### DIFF
--- a/migration/idempotent/010-telemetry.sql
+++ b/migration/idempotent/010-telemetry.sql
@@ -76,9 +76,6 @@ $$
         SELECT count(*)::TEXT INTO result FROM _prom_catalog.metric;
         PERFORM _ps_catalog.apply_telemetry('metrics_total', result);
 
-        SELECT sum(public.hypertable_size(format('prom_data.%I', table_name)))::TEXT INTO result FROM _prom_catalog.metric;
-        PERFORM _ps_catalog.apply_telemetry('metrics_bytes_total', result);
-
         SELECT public.approximate_row_count('_prom_catalog.series')::TEXT INTO result;
         PERFORM _ps_catalog.apply_telemetry('metrics_series_total_approx', result);
 
@@ -118,9 +115,6 @@ $$
 
         SELECT public.approximate_row_count('_ps_trace.span')::TEXT INTO result;
         PERFORM _ps_catalog.apply_telemetry('traces_spans_total_approx', result);
-
-        SELECT public.hypertable_size('_ps_trace.span')::TEXT INTO result;
-        PERFORM _ps_catalog.apply_telemetry('traces_spans_bytes_total', result);
 
         -- Others.
         -- The -1 is to ignore the row summing deleted rows i.e., the counter reset row. 


### PR DESCRIPTION
## Description

Fixes: https://github.com/timescale/promscale/issues/1455

This PR optimises the `_ps_catalog.promscale_sql_telemetry()` by removing the `_bytes_total` metrics that were taking 95% of the time, sometimes even blocking for several minutes.

### With this PR

```postgres
tsdb=> select _ps_catalog.promscale_sql_telemetry_without_sizes(); -- This is the one proposed in the PR.
promscale_sql_telemetry_without_sizes 
---------------------------------------------
 
(1 row)

Time: 341.549 ms

tsdb=> select _ps_catalog.promscale_sql_telemetry(); // Previous function, taking forever.
```

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation