### PR TITLE
Improve drop prom_schema_migration logic

### DIFF
--- a/sql/promscale--0.0.0.sql
+++ b/sql/promscale--0.0.0.sql
@@ -24,10 +24,11 @@ DECLARE
 BEGIN
     -- The prom_schema_migrations table was not schema-qualified on creation,
     -- so it could be in any schema. Find out the schema it's in and drop.
-    SELECT schemaname INTO STRICT schema FROM pg_catalog.pg_tables WHERE tablename = 'prom_schema_migrations';
-    IF schema IS NOT NULL THEN
-        EXECUTE format('DROP TABLE %I.prom_schema_migrations', schema);
+    SELECT schemaname INTO schema FROM pg_catalog.pg_tables WHERE tablename = 'prom_schema_migrations';
+    IF schema IS NULL THEN
+        RAISE EXCEPTION 'the prom_schema_migrations table was not found.';
     END IF;
+    EXECUTE format('DROP TABLE %I.prom_schema_migrations', schema);
 END;
 $drop_prom_schema_migrations$;
 


### PR DESCRIPTION


## Description

Follow-on change to https://github.com/timescale/promscale_extension/pull/372
The 0.0.0 script should only run if the prom_schema_migration table exists.
If we cannot find the table, raise an exception.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation