### PR TITLE
Unset docker image labels

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -68,6 +68,10 @@ jobs:
             ghcr.io/timescale/dev_promscale_extension:${{steps.metadata.outputs.branch_name}}-ts${{matrix.tsversion}}-pg${{matrix.pgversion}}${{steps.metadata.outputs.build_type_suffix}}
             ghcr.io/timescale/dev_promscale_extension:${{steps.metadata.outputs.branch_name}}-ts${{steps.metadata.outputs.tsmajor}}-pg${{matrix.pgversion}}${{steps.metadata.outputs.build_type_suffix}}
             ghcr.io/timescale/dev_promscale_extension:${{steps.metadata.outputs.branch_name}}-ts${{steps.metadata.outputs.tsmajmin}}-pg${{matrix.pgversion}}${{steps.metadata.outputs.build_type_suffix}}
+          labels: |
+            org.opencontainers.image.source=
+            org.opencontainers.image.revision=
+            org.opencontainers.image.created=
           # Note: it's necessary to use a different cache scope to achieve caching for both Ubuntu and Alpine images
           cache-from: type=gha,scope=${{matrix.base}}-${{matrix.pgversion}}-${{matrix.tsversion}}
           cache-to: type=gha,mode=max,scope=${{matrix.base}}-${{matrix.pgversion}}-${{matrix.tsversion}}


### PR DESCRIPTION
## Description

These labels are inherited from the timescaledb-ha base docker image,
and establish a link between the package registry and the source
repository. Currently it is linking the timescaledb-docker-ha repo to
our ghcr.io/timescale/dev_promscale_extension package. We don't really
want the dev_promscale_extension image to be publicly available, so
unlinking this completely would be the best option.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~