### PR TITLE
Minor cleanup and refactoring

### DIFF
--- a/docs/sql-api.md
+++ b/docs/sql-api.md
@@ -562,7 +562,7 @@ function bigint **_prom_catalog.delete_series_from_metric**(name text, series_id
 procedure void **_prom_catalog.do_decompress_chunks_after**(IN metric_table text, IN min_time timestamp with time zone, IN transactional boolean DEFAULT false)
 ```
 ### _prom_catalog.drop_metric_chunk_data
-
+drop chunks from schema_name.metric_name containing data older than older_than.
 ```
 function void **_prom_catalog.drop_metric_chunk_data**(schema_name text, metric_name text, older_than timestamp with time zone)
 ```
@@ -618,8 +618,13 @@ function record **_prom_catalog.get_cagg_info**(metric_schema text, metric_table
 ```
 ### _prom_catalog.get_confirmed_unused_series
 
+Given a `metric_schema`, `metric_table`, and `series_table`, this function
+returns all series ids in `potential_series_ids` which are not referenced by
+data newer than `newer_than` in any metric table.
+Note: See _prom_catalog.mark_series_to_be_dropped_as_unused for context.
+
 ```
-function bigint[] **_prom_catalog.get_confirmed_unused_series**(metric_schema text, metric_table text, series_table text, potential_series_ids bigint[], check_time timestamp with time zone)
+function bigint[] **_prom_catalog.get_confirmed_unused_series**(metric_schema text, metric_table text, series_table text, potential_series_ids bigint[], newer_than timestamp with time zone)
 ```
 ### _prom_catalog.get_default_chunk_interval
 
@@ -886,10 +891,18 @@ function boolean **_prom_catalog.lock_metric_for_maintenance**(metric_id integer
 ```
 function trigger **_prom_catalog.make_metric_table**()
 ```
-### _prom_catalog.mark_unused_series
+### _prom_catalog.mark_series_to_be_dropped_as_unused
+
+Marks series which we will drop soon as unused.
+A series is unused if there is no data newer than `drop_point` which
+references that series.
+Note: This function can only mark a series as unused if there is still
+data which references that series.
+This function is designed to be used in the context of dropping metric
+chunks, see `_prom_catalog.drop_metric_chunks`.
 
 ```
-function void **_prom_catalog.mark_unused_series**(metric_schema text, metric_table text, metric_series_table text, older_than timestamp with time zone, check_time timestamp with time zone)
+function void **_prom_catalog.mark_series_to_be_dropped_as_unused**(metric_schema text, metric_table text, metric_series_table text, drop_point timestamp with time zone)
 ```
 ### _prom_catalog.match_equals
 

--- a/migration/idempotent/011-maintenance.sql
+++ b/migration/idempotent/011-maintenance.sql
@@ -75,6 +75,8 @@ LANGUAGE PLPGSQL;
 --redundant given schema settings but extra caution for security definers
 REVOKE ALL ON FUNCTION _prom_catalog.drop_metric_chunk_data(text, text, timestamptz) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION _prom_catalog.drop_metric_chunk_data(text, text, timestamptz) TO prom_maintenance;
+COMMENT ON FUNCTION _prom_catalog.drop_metric_chunk_data(text, text, timestamptz)
+    IS 'drop chunks from schema_name.metric_name containing data older than older_than.';
 
 --drop chunks from metrics tables and delete the appropriate series.
 CREATE OR REPLACE PROCEDURE _prom_catalog.drop_metric_chunks(
@@ -87,7 +89,6 @@ DECLARE
     metric_table NAME;
     metric_series_table NAME;
     is_metric_view BOOLEAN;
-    check_time TIMESTAMPTZ;
     time_dimension_id INT;
     last_updated TIMESTAMPTZ;
     present_epoch BIGINT;
@@ -100,9 +101,6 @@ BEGIN
     SELECT id, table_schema, table_name, series_table, is_view
     INTO STRICT metric_id, metric_schema, metric_table, metric_series_table, is_metric_view
     FROM _prom_catalog.get_metric_table_name_if_exists(schema_name, metric_name);
-
-    SELECT older_than OPERATOR(pg_catalog.+) pg_catalog.interval '1 hour'
-    INTO check_time;
 
     startT := pg_catalog.clock_timestamp();
 
@@ -157,7 +155,7 @@ BEGIN
     -- transaction 2
         lastT := pg_catalog.clock_timestamp();
         PERFORM _prom_catalog.set_app_name(pg_catalog.format('promscale maintenance: data retention: metric %s: mark unused series', metric_name));
-        PERFORM _prom_catalog.mark_unused_series(metric_schema, metric_table, metric_series_table, older_than, check_time);
+        PERFORM _prom_catalog.mark_series_to_be_dropped_as_unused(metric_schema, metric_table, metric_series_table, older_than);
         IF log_verbose THEN
             RAISE LOG 'promscale maintenance: data retention: metric %: done marking unused series in %', metric_name, pg_catalog.clock_timestamp() OPERATOR(pg_catalog.-) lastT;
         END IF;

--- a/migration/incremental/028-refactor-mark-unused-series.sql
+++ b/migration/incremental/028-refactor-mark-unused-series.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS _prom_catalog.mark_unused_series(text, text, text, timestamptz, timestamptz);


### PR DESCRIPTION
## Description

- Remove checks for timescaledb >= 2 in maintenance functions
- Fix indentation and typos
- Add some comments
- Refactor marking of unused series in context of dropping chunks

  Rename `mark_unused_series` to `mark_series_to_be_dropped_as_unused`.
This clarifies that we're not finding series which are unused and
marking them for deletion. Instead, we are marking all of the series
which are only referenced by data in chunks which we will drop as
unused.

  Move the `check_time` parameter in `drop_metric_chunks` to
`mark_series_to_be_dropped_as_unused`. The parameter is local to the
logic in `mark_series_to_be_dropped_as_unused`. It is an optimization
used to exclude series which are not unused from the
`get_confirmed_unused_series` check.

  Note: As the calculation of `check_time` has been moved (and because
`drop_metric_chunks` modifies `older_than`), the value that we calculate
in `check_time` is now slightly different (based on the modified
`older_than`). Nonetheless, this should not make a difference in the
logic that we're executing.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~