### PR TITLE
Support cargo 1.62.0 pkgid format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use the following categories for changes:
 ### Fixed
 
 - Correctly identify and drop `prom_schema_migrations` [#372]
+- Support cargo 1.62.0 pkgid format [#390]
 - Use `cluster` label from `_prom_catalog.label` to report about HA setup [#398]
 
 ## [0.5.2] - 2021-06-20

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ARCH ?= $(shell uname -m)
 H := \#
 # We want to be able to execute `sudo make install`, but cargo and rustc are probably both
 # not available for sudo, so we use `command -v` to only run them if they are available
-EXT_VERSION ?= $(shell command -v cargo >/dev/null && cargo pkgid | cut -d'$H' -f2 | cut -d':' -f2)
+EXT_VERSION ?= $(shell command -v cargo >/dev/null && ./extract-extension-version.sh | tr -d '\n')
 RUST_VERSION ?= $(shell command -v rustc >/dev/null && rustc --version | cut -d' ' -f2)
 IMAGE_NAME ?= timescaledev/promscale-extension
 OS_NAME ?= debian

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -78,7 +78,7 @@ RUN --mount=type=secret,uid=70,gid=70,id=AWS_ACCESS_KEY_ID --mount=type=secret,u
 
 # Build extension
 COPY --chown=postgres:postgres Cargo.* /build/promscale/
-COPY --chown=postgres:postgres Makefile build.rs create-upgrade-symlinks.sh /build/promscale/
+COPY --chown=postgres:postgres Makefile build.rs create-upgrade-symlinks.sh extract-extension-version.sh /build/promscale/
 COPY --chown=postgres:postgres .cargo/ /build/promscale/.cargo/
 COPY --chown=postgres:postgres e2e/ /build/promscale/e2e/
 COPY --chown=postgres:postgres src/ /build/promscale/src/

--- a/create-upgrade-symlinks.sh
+++ b/create-upgrade-symlinks.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 prev_versions=$(cat promscale.control | sed -n 's/# upgradeable_from = \(.*\)/\1/p' | sed "s/[[:space:]']//g" | tr ',' '\n')
-cur_version=$(cargo pkgid | cut -d'#' -f2 | cut -d':' -f2)
+cur_version=$(./extract-extension-version.sh | tr -d '\n')
 
 for prev_version in $prev_versions; do
   if [ -n "${prev_version}" ] && [ -n "${cur_version}" ]; then

--- a/extract-extension-version.sh
+++ b/extract-extension-version.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Note: we cut on both ':' and '@' here to support pre-1.62.0 and post 1.62.0 `cargo pkgid` output
+command -v cargo >/dev/null && cargo pkgid | cut -d'#' -f2 | cut -d':' -f2 | cut -d'@' -f2

--- a/ha.Dockerfile
+++ b/ha.Dockerfile
@@ -59,7 +59,7 @@ RUN chown -R postgres:postgres /build
 USER postgres
 
 COPY --chown=postgres:postgres Cargo.* /build/promscale/
-COPY --chown=postgres:postgres Makefile build.rs create-upgrade-symlinks.sh /build/promscale/
+COPY --chown=postgres:postgres Makefile build.rs create-upgrade-symlinks.sh extract-extension-version.sh /build/promscale/
 COPY --chown=postgres:postgres .cargo/ /build/promscale/.cargo/
 COPY --chown=postgres:postgres e2e/ /build/promscale/e2e/
 COPY --chown=postgres:postgres src/ /build/promscale/src/


### PR DESCRIPTION
## Description

We use `cargo pkgid`, plus some text transformation, to determine the
extension version.

In cargo 1.62.0 the output of `cargo pkgid` changed from:
`<...>#promscale:<ver>`
to:
`<...>#promscale@<ver>`

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation