### PR TITLE
fix: Use `cluster` label to report about HA setup

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -63,7 +63,7 @@ jobs:
             "AWS_SECRET_ACCESS_KEY=${{ secrets.PROMSCALE_EXTENSION_SCCACHE_AWS_SECRET_ACCESS_KEY }}"
           context: .
           file: ${{matrix.base}}.Dockerfile
-          push: true
+          push: false
           tags: |
             ghcr.io/timescale/dev_promscale_extension:${{steps.metadata.outputs.image_branch_name}}-ts${{matrix.tsversion}}-pg${{matrix.pgversion}}${{steps.metadata.outputs.build_type_suffix}}
             ghcr.io/timescale/dev_promscale_extension:${{steps.metadata.outputs.image_branch_name}}-ts${{steps.metadata.outputs.tsmajor}}-pg${{matrix.pgversion}}${{steps.metadata.outputs.build_type_suffix}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use the following categories for changes:
 ### Fixed
 
 - Correctly identify and drop `prom_schema_migrations` [#372]
+- Use `cluster` label from `_prom_catalog.label` to report about HA setup [#393]
 
 ## [0.5.2] - 2021-06-20
 

--- a/migration/idempotent/010-telemetry.sql
+++ b/migration/idempotent/010-telemetry.sql
@@ -85,7 +85,7 @@ $$
         SELECT count(*)::TEXT INTO result FROM _prom_catalog.label WHERE key = '__tenant__';
         PERFORM _ps_catalog.apply_telemetry('metrics_multi_tenancy_tenant_count', result);
 
-        SELECT count(*)::TEXT INTO result FROM _prom_catalog.label_key WHERE key = '__cluster__';
+        SELECT count(*)::TEXT INTO result FROM _prom_catalog.label WHERE key = 'cluster';
         PERFORM _ps_catalog.apply_telemetry('metrics_ha_cluster_count', result);
 
         SELECT count(*)::TEXT INTO result FROM _prom_catalog.metric WHERE is_view IS true;


### PR DESCRIPTION
Prior to this we were using `__cluster__` to find out whether prometheus
is deployed as HA, it is incorrect according to [1]. We must be using
`cluster` instead.

[1] https://github.com/timescale/promscale/blob/master/docs/high-availability/prometheus-HA.md#prometheus-leader-election-via-external-labels

Signed-off-by: Arunprasad Rajkumar <ar.arunprasad@gmail.com>

## Description

<!--Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.-->

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation