### PR TITLE
Adds ability to configure epoch duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ We use the following categories for changes:
 
 ## [Unreleased]
 
+### Added
+
+- Configure `epoch_duration` for Promscale series cache via `_prom_catalog.default` [#396]
+
 ### Fixed
 
 - Correctly identify and drop `prom_schema_migrations` [#372]

--- a/sql-tests/testdata/defaults.sql
+++ b/sql-tests/testdata/defaults.sql
@@ -15,7 +15,8 @@ from
     ('metric_compression'       , (exists(select 1 from pg_catalog.pg_proc where proname = 'compress_chunk')::text)),
     ('trace_retention_period'   , (30 * INTERVAL '1 days')::text),
     ('ha_lease_timeout'         , '1m'),
-    ('ha_lease_refresh'         , '10s')
+    ('ha_lease_refresh'         , '10s'),
+    ('epoch_duration'           , (INTERVAL '12 hours')::text)
 ) x(key, value)
 ;
 

--- a/sql-tests/tests/snapshots/tests__testdata__defaults.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__defaults.sql.snap
@@ -19,7 +19,8 @@ from
     ('metric_compression'       , (exists(select 1 from pg_catalog.pg_proc where proname = 'compress_chunk')::text)),
     ('trace_retention_period'   , (30 * INTERVAL '1 days')::text),
     ('ha_lease_timeout'         , '1m'),
-    ('ha_lease_refresh'         , '10s')
+    ('ha_lease_refresh'         , '10s'),
+    ('epoch_duration'           , (INTERVAL '12 hours')::text)
 ) x(key, value)
 ;
  key | value 


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

Fixes: https://github.com/timescale/promscale/issues/1399

## Description

This PR does 2 things:
1. Makes the epoch duration (used in series cache on Promscale side) configurable
2. Increases the default duration to 12 hours. This will lead to fewer resets of cache and less transactional load, hence should help in improving metric ingest performance

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation