### PR TITLE
ci: skip docker push when PR is from forked repos

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -63,7 +63,8 @@ jobs:
             "AWS_SECRET_ACCESS_KEY=${{ secrets.PROMSCALE_EXTENSION_SCCACHE_AWS_SECRET_ACCESS_KEY }}"
           context: .
           file: ${{matrix.base}}.Dockerfile
-          push: true
+          load: true
+          push: ${{ github.event.pull_request.head.repo.owner.login == 'timescale' }} # Don't run docker push when PR is from not timescale github repo
           tags: |
             ghcr.io/timescale/dev_promscale_extension:${{steps.metadata.outputs.image_branch_name}}-ts${{matrix.tsversion}}-pg${{matrix.pgversion}}${{steps.metadata.outputs.build_type_suffix}}
             ghcr.io/timescale/dev_promscale_extension:${{steps.metadata.outputs.image_branch_name}}-ts${{steps.metadata.outputs.tsmajor}}-pg${{matrix.pgversion}}${{steps.metadata.outputs.build_type_suffix}}


### PR DESCRIPTION
## Description

Root cause: GITHUB_TOKEN is authorized to push to ghcr only when it is run from the owner context.

Solution: Skip ghcr image push when CI is running on forked repo context.

Signed-off-by: Arunprasad Rajkumar <ar.arunprasad@gmail.com>

<!--Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.-->

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation