### PR TITLE
Pass prefix for temporary table used for ingest

### DIFF
--- a/docs/sql-api.md
+++ b/docs/sql-api.md
@@ -504,9 +504,12 @@ function boolean **_prom_catalog.create_exemplar_table_if_not_exists**(metric_na
 ### _prom_catalog.create_ingest_temp_table
 Creates a temporary table (if it doesn't exist) used for ingestion of metrics or traces.
 Temporary table is created using supplied table and schema as prototype.
-Suppresses corresponding DDL logging, otherwise PG log may get unnecessarily verbose.Returns temporary table name
+Suppresses corresponding DDL logging, otherwise PG log may get unnecessarily verbose.
+Api user has to make sure that table_prefix is unique per session/connection.
+This is to prevent different truncated table names having same temp table.
+Returns temporary table name
 ```
-function text **_prom_catalog.create_ingest_temp_table**(table_name text, schema_name text)
+function text **_prom_catalog.create_ingest_temp_table**(table_name text, schema_name text, table_prefix text)
 ```
 ### _prom_catalog.create_label_key
 

--- a/e2e/testdata/create_ingest_temp_table.sql
+++ b/e2e/testdata/create_ingest_temp_table.sql
@@ -4,16 +4,16 @@
 
 CREATE EXTENSION promscale;
 
-CREATE TEMP TABLE metric_names(name TEXT);
+CREATE TEMP TABLE test_data(metric_name TEXT, prefix TEXT);
 
-INSERT INTO metric_names VALUES
-  ('cpu_usage'),
-  ('aMultiCase"fun"Metric!'),
-  ('aVeryLongMultiCaseMetricWhich"might"BeTruncatedIfIt''sTOOOOOOOOOOOOOOOLONGZOMG!');
+INSERT INTO test_data VALUES
+  ('cpu_usage', 'exe_'),
+  ('aMultiCase"fun"Metric!', 'eXe_'),
+  ('aVeryLongMultiCaseMetricWhich"might"BeTruncatedIfIt''sTOOOOOOOOOOOOOOOLONGZOMG!','ThisIsLong_');
 
 -- Note: Metric creation must be outside of the test function below, to avoid
 -- 'invalid transaction termination'
-SELECT _prom_catalog.get_or_create_metric_table_name(name) FROM metric_names;
+SELECT _prom_catalog.get_or_create_metric_table_name(metric_name) FROM test_data;
 CALL _prom_catalog.finalize_metric_creation();
 
 CREATE OR REPLACE FUNCTION test_create_ingest_temp_table()
@@ -21,17 +21,17 @@ RETURNS SETOF TEXT LANGUAGE plpgsql AS $$
 DECLARE
     metric_table_name TEXT;
     temp_table_name TEXT;
-    metric_name TEXT;
     temp_schema TEXT;
+    test RECORD;
 BEGIN
-    FOR metric_name IN SELECT name FROM metric_names
+    FOR test IN SELECT t.metric_name, t.prefix FROM test_data t
     LOOP
-        SELECT table_name INTO metric_table_name FROM _prom_catalog.get_or_create_metric_table_name(metric_name);
+        SELECT table_name INTO metric_table_name FROM _prom_catalog.get_or_create_metric_table_name(test.metric_name);
 
         RETURN NEXT has_table('prom_data', metric_table_name, format('table %I.%I exists', 'prom_data', metric_table_name));
 
-        SELECT _prom_catalog.create_ingest_temp_table(metric_table_name, 'prom_data') INTO temp_table_name;
-        RETURN NEXT is(temp_table_name, metric_table_name, 'temp table name is well-formed');
+        SELECT _prom_catalog.create_ingest_temp_table(metric_table_name, 'prom_data', test.prefix) INTO temp_table_name;
+        RETURN NEXT is(temp_table_name, left(test.prefix || metric_table_name, 62) , 'temp table name is well-formed');
         SELECT nspname INTO temp_schema FROM pg_namespace WHERE oid = pg_my_temp_schema();
         RETURN NEXT has_table(temp_schema, temp_table_name, format('temp table %I exists', temp_table_name));
     END LOOP;

--- a/e2e/tests/snapshots/golden_tests__testdata__create_ingest_temp_table.sql.snap
+++ b/e2e/tests/snapshots/golden_tests__testdata__create_ingest_temp_table.sql.snap
@@ -14,13 +14,13 @@ expression: query_result
      # Subtest: public.test_create_ingest_temp_table()
      ok 1 - table prom_data.cpu_usage exists
      ok 2 - temp table name is well-formed
-     ok 3 - temp table cpu_usage exists
+     ok 3 - temp table exe_cpu_usage exists
      ok 4 - table prom_data."aMultiCase""fun""Metric!" exists
      ok 5 - temp table name is well-formed
-     ok 6 - temp table "aMultiCase""fun""Metric!" exists
+     ok 6 - temp table "eXe_aMultiCase""fun""Metric!" exists
      ok 7 - table prom_data."aVeryLongMultiCaseMetricWhich""might""BeTruncatedIfIt'sTOOOOOO_3" exists
      ok 8 - temp table name is well-formed
-     ok 9 - temp table "aVeryLongMultiCaseMetricWhich""might""BeTruncatedIfIt'sTOOOOOO_3" exists
+     ok 9 - temp table "ThisIsLong_aVeryLongMultiCaseMetricWhich""might""BeTruncatedIfIt" exists
      1..9
  ok 1 - public.test_create_ingest_temp_table
  1..1

--- a/migration/idempotent/001-base.sql
+++ b/migration/idempotent/001-base.sql
@@ -3375,26 +3375,31 @@ GRANT EXECUTE ON FUNCTION _prom_catalog.insert_metric_row(TEXT, TIMESTAMPTZ[], D
 -- Suppresses corresponding DDL logging, otherwise PG log may get unnecessarily verbose.
 -- Temporary table is created using supplied table and schema as prototype.
 -- Returns temporary table name
-CREATE OR REPLACE FUNCTION _prom_catalog.create_ingest_temp_table(table_name TEXT, schema_name TEXT)
+CREATE OR REPLACE FUNCTION _prom_catalog.create_ingest_temp_table(table_name TEXT, schema_name TEXT, table_prefix TEXT)
     RETURNS TEXT
     SECURITY DEFINER
     VOLATILE
     SET search_path = pg_catalog, pg_temp
-AS $func$             
+AS $func$
+DECLARE
+    temp_table TEXT;         
 BEGIN
     SET LOCAL log_statement = 'none';
-    EXECUTE format($sql$CREATE TEMPORARY TABLE IF NOT EXISTS %I (LIKE %I.%I) ON COMMIT DELETE ROWS$sql$,
-                 table_name, schema_name, table_name);
+    temp_table := left(CONCAT(table_prefix, table_name), 62);
+    EXECUTE format($sql$CREATE TEMPORARY TABLE IF NOT EXISTS %I (LIKE %I.%I) ON COMMIT DROP$sql$,
+                 temp_table, schema_name, table_name);
     EXECUTE format($sql$GRANT SELECT, INSERT ON TABLE %I TO prom_writer$sql$,
-                 table_name);
-    RETURN table_name;
+                 temp_table);
+    RETURN temp_table;
 END;
 $func$
 LANGUAGE plpgsql;
-REVOKE ALL ON FUNCTION _prom_catalog.create_ingest_temp_table(TEXT, TEXT) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION _prom_catalog.create_ingest_temp_table(TEXT, TEXT) TO prom_writer;
+REVOKE ALL ON FUNCTION _prom_catalog.create_ingest_temp_table(TEXT, TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION _prom_catalog.create_ingest_temp_table(TEXT, TEXT, TEXT) TO prom_writer;
 COMMENT ON FUNCTION _prom_catalog.create_ingest_temp_table
 IS 'Creates a temporary table (if it doesn''t exist) used for ingestion of metrics or traces.
 Temporary table is created using supplied table and schema as prototype.
-Suppresses corresponding DDL logging, otherwise PG log may get unnecessarily verbose.'
-'Returns temporary table name';
+Suppresses corresponding DDL logging, otherwise PG log may get unnecessarily verbose.
+Api user has to make sure that table_prefix is unique per session/connection.
+This is to prevent different truncated table names having same temp table.
+Returns temporary table name';

--- a/migration/incremental/029-remove-unused-ingest-func.sql
+++ b/migration/incremental/029-remove-unused-ingest-func.sql
@@ -1,0 +1,2 @@
+-- We've changed the function signature by adding new argument so dropping old one
+DROP FUNCTION IF EXISTS _prom_catalog.create_ingest_temp_table(TEXT, TEXT) CASCADE;


### PR DESCRIPTION
It can happen that we insert both samples and exemplars within the same
transaction. That means we need a separate temp table for these two 
so passing a prefix shoud help with that.
