### PR TITLE
Drop support for EOL distros

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,12 +27,10 @@ jobs:
           distro: debian
           version: 11
           pkg_cloud_tags:
-            - debian/stretch
             - debian/buster
             - debian/bullseye
             - ubuntu/bionic
             - ubuntu/focal
-            - ubuntu/hirsute
             - ubuntu/jammy
             - ubuntu/impish
           pkg_type: deb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ We use the following categories for changes:
 - Use `cluster` label from `_prom_catalog.label` to report about HA setup [#398]
 - Optimize `promscale_sql_telemetry()` by removing `metric_bytes_total` and `traces_spans_bytes_total` metrics [#388]
 
+### Changed
+
+- Drop support for Debian Stretch and Ubuntu Hirsute [#404]
+
 ## [0.5.2] - 2021-06-20
 
 ### Changed

--- a/dist/deb.dockerfile
+++ b/dist/deb.dockerfile
@@ -15,18 +15,12 @@ RUN <<EOF
 export OS_NAME="$(source /etc/os-release; echo "${ID}")"
 export OS_VERSION="$(source /etc/os-release; echo "${VERSION_ID}")"
 
-if [ "${OS_VERSION}" = "9" ]; then
-    echo "deb http://deb.debian.org/debian stretch-backports main" >> /etc/apt/sources.list.d/backports.list
-    echo "deb http://deb.debian.org/debian stretch-backports-sloppy main" >> /etc/apt/sources.list.d/backports.list
-    apt-get update -y
-    apt-get -t stretch-backports-sloppy install -y libarchive13
-    apt-get -t stretch-backports install -y cmake gcc make
-else
-    apt-get update -y
-    apt-get install -y cmake gcc make
-fi
+apt-get update -y
 
 apt-get install -y \
+    cmake \
+    gcc \
+    make \
     apt-transport-https \
     build-essential \
     software-properties-common \


### PR DESCRIPTION
## Description

Ubuntu Hirsute became EOL in January 2022.

Debian Stretch became EOL at the end of June 2022. A glibc
incompatibility began to break our tests at approximately the same time,
so we are forced to drop support.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] ~~Updated the relevant documentation~~