### PR TITLE
Add steps to build on MacOS 

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -121,7 +121,7 @@ For bare-metal installations, the full instructions for setting up PostgreSQL, T
     LATEST_VERSION=$(curl -s https://api.github.com/repos/timescale/promscale/releases/latest | grep "tag_name" | cut -d'"' -f4)
     curl -L -o promscale "https://github.com/timescale/promscale/releases/download/${LATEST_VERSION}/promscale_${LATEST_VERSION}_Linux_x86_64"
     chmod +x promscale
-    ./promscale --db.name promscale --db.password promscale --db.user promscale --db.ssl-mode allow --startup.install-extensions --startup.upgrade-prerelease-extensions
+    ./promscale --db.name promscale --db.password promscale --db.user promscale --db.ssl-mode allow --startup.install-extensions
     ```
 ## Compile From Source on MacOS(Darwin, ARM64)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -155,7 +155,7 @@ For bare-metal installations, the full instructions for setting up PostgreSQL, T
 1) Compile and install
     ```bash
     make package
-    sudo cp -r ./target/release/promscale-pg14/* /
+    sudo make install
     ```
 1) Create a PostgreSQL user and database for promscale (use an appropriate password!)
     ```bash

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -104,7 +104,7 @@ For bare-metal installations, the full instructions for setting up PostgreSQL, T
     sudo apt-get install -y git
     git clone https://github.com/timescale/promscale_extension
     cd promscale_extension
-    git checkout master
+    git checkout 0.5.0
     ```
 1) Compile and install
     ```bash
@@ -144,13 +144,13 @@ For bare-metal installations, the full instructions for setting up PostgreSQL, T
     ```
 1) Initialize the PGX framework using the PostgreSQL 14 installation
     ```bash
-    cargo pgx init --pg14=$(which pg_config)
+    cargo pgx init --pg14=/opt/homebrew/bin/pg_config
     ```
 1) Download this repo and change directory into it
     ```bash
     git clone https://github.com/timescale/promscale_extension
     cd promscale_extension
-    git checkout master
+    git checkout 0.5.0
     ```
 1) Compile and install
     ```bash
@@ -167,7 +167,7 @@ For bare-metal installations, the full instructions for setting up PostgreSQL, T
     LATEST_VERSION=$(curl -s https://api.github.com/repos/timescale/promscale/releases/latest | grep "tag_name" | cut -d'"' -f4)
     curl -L -o promscale "https://github.com/timescale/promscale/releases/download/${LATEST_VERSION}/promscale_${LATEST_VERSION}_Darwin_arm64"
     chmod +x promscale
-    ./promscale --db.name promscale --db.password promscale --db.user promscale --db.ssl-mode allow --startup.install-extensions --startup.upgrade-prerelease-extensions
+    ./promscale --db.name promscale --db.password promscale --db.user promscale --db.ssl-mode allow --startup.install-extensions
     ```
 
 This extension will be created via `CREATE EXTENSION` automatically by the Promscale connector and should not be created manually.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -127,10 +127,8 @@ For bare-metal installations, the full instructions for setting up PostgreSQL, T
 
 For bare-metal installations, the full instructions for setting up PostgreSQL, TimescaleDB, and the Promscale Extension are:
 
-1) Follow [this doc]([url](https://docs.timescale.com/install/latest/self-hosted/installation-macos/#install-self-hosted-timescaledb-using-homebrew)) and install Timescale(which also install Postgres)
-    ```bash
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-    ```
+1) Follow [this doc](https://docs.timescale.com/install/latest/self-hosted/installation-macos/#install-self-hosted-timescaledb-using-homebrew) and install TimescaleDB(which also install Postgres)
+
 1) Restart Postgres after executing `timescaledb-tune` script
     ```bash
     pg_ctl -D /opt/homebrew/var/postgres restart

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ package: promscale.control ## Generate extension artifacts for packaging
 
 .PHONY: install
 install: ## Install the extension in the Postgres found via pg_config
-	cp --recursive ./target/release/promscale-pg${PG_BUILD_VERSION}/* /
+	cp -R ./target/release/promscale-pg${PG_BUILD_VERSION}/* /
 
 dist/$(RELEASE_FILE_NAME): release-builder
 	@container="$$(docker create $(RELEASE_IMAGE_NAME))"; \


### PR DESCRIPTION
## Description

This commit adds steps to build and install promscale extension on MacOS.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation