### PR TITLE
A port of TestSQLDropMetricChunk from promscale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We use the following categories for changes:
 - Support cargo 1.62.0 pkgid format [#390]
 - Use `cluster` label from `_prom_catalog.label` to report about HA setup [#398]
 - Optimize `promscale_sql_telemetry()` by removing `metric_bytes_total` and `traces_spans_bytes_total` metrics [#388]
+- A minor bug in epoch_abort that caused a confusing message in RAISE [#417].
 
 ### Changed
 

--- a/migration/idempotent/001-base.sql
+++ b/migration/idempotent/001-base.sql
@@ -1907,7 +1907,7 @@ CREATE OR REPLACE FUNCTION _prom_catalog.epoch_abort(user_epoch BIGINT)
 AS $func$
 DECLARE db_epoch BIGINT;
 BEGIN
-    SELECT current_epoch FROM ids_epoch LIMIT 1
+    SELECT current_epoch FROM _prom_catalog.ids_epoch LIMIT 1
         INTO db_epoch;
     RAISE EXCEPTION 'epoch % to old to continue INSERT, current: %',
         user_epoch, db_epoch

--- a/sql-tests/testdata/drop_metric.sql
+++ b/sql-tests/testdata/drop_metric.sql
@@ -1,0 +1,133 @@
+\unset ECHO
+\set QUIET 1
+\i '/testdata/scripts/pgtap-1.2.0.sql'
+
+SELECT * FROM plan(49);
+CREATE EXTENSION promscale;
+
+--
+-- Moved from TestSQLDropMetricChunk
+--
+
+DO $$
+DECLARE
+ s1_series_id BIGINT;
+ s2_series_id BIGINT;
+ s3_series_id BIGINT;
+BEGIN
+ -- Avoid randomness in chunk interval size by setting explicitly.
+ PERFORM _prom_catalog.get_or_create_metric_table_name('test');
+ PERFORM public.set_chunk_time_interval('prom_data.test', interval '8 hours');
+ -- Set 1h epoch duration to prevent changing defaults from affecting this test's outcome.
+ PERFORM _prom_catalog.set_default_value('epoch_duration', (interval '1 hour')::text);
+
+
+ -- this series (s1) will be deleted along with it's label
+ SELECT f.series_id 
+  FROM _prom_catalog.get_or_create_series_id_for_kv_array('test', ARRAY['__name__', 'name1'], ARRAY['test', 'value1']) f
+  INTO STRICT s1_series_id;
+ SELECT f.series_id
+  FROM _prom_catalog.get_or_create_series_id_for_kv_array('test', ARRAY['__name__', 'name1'], ARRAY['test', 'value2']) f
+  INTO STRICT s2_series_id;
+ SELECT f.series_id
+  FROM _prom_catalog.get_or_create_series_id_for_kv_array('test', ARRAY['__name__', 'name1'], ARRAY['test', 'value3']) f
+  INTO STRICT s3_series_id;
+
+ INSERT INTO prom_data.test(time,value,series_id)
+  VALUES
+   -- this will be dropped immediately (notice it's one second before the midnight)
+   ('2009-11-10 23:59:59.999+00',0.1,s1_series_id), 
+   -- same as the above
+   ('2009-11-10 23:59:59.999+00',0.1,s3_series_id),
+   -- this will remain after the drop
+   ('2009-11-11 00:00:00+00',    0.2,s2_series_id),
+   -- this will not be dropped and is more than an hour newer
+   ('2009-11-11 05:00:00+00',    0.1,s3_series_id); 
+
+ PERFORM
+    CASE current_epoch > 0::BIGINT + 1 WHEN true THEN _prom_catalog.epoch_abort(0) 
+    END
+  FROM _prom_catalog.ids_epoch 
+  LIMIT 1;
+
+ CALL _prom_catalog.finalize_metric_creation();
+END$$;
+-- Ingestion complete
+
+-- Checking state of the ingested data prior to drop attempts
+SELECT ok(count(*) = 4, 'none of the chunks are deleted') FROM prom_data.test;
+SELECT ok(count(*) = 3, 'none of the series should be removed yet') FROM _prom_catalog.series;
+SELECT ok(count(*) = 0, 'none of the series should be marked for deletion') FROM _prom_catalog.series WHERE delete_epoch IS NOT NULL;
+SELECT ok(count(*) = 3, 'none of the labels should deleted yet') FROM _prom_catalog.label where key='name1';
+
+-- Dropping the data
+CREATE FUNCTION asserts_before_deletion(msg TEXT)
+ RETURNS SETOF TEXT
+ LANGUAGE plpgsql VOLATILE AS
+$fnc$
+BEGIN
+ RETURN NEXT is(count(*), 2::BIGINT, msg || ': expired chunks are gone') FROM prom_data.test;
+ RETURN NEXT is(count(*), 3::BIGINT, msg || ': none of the series should be removed yet') FROM _prom_catalog.series;
+ RETURN NEXT is(count(*), 1::BIGINT, msg || ': one series should be marked for deletion') FROM _prom_catalog.series WHERE delete_epoch IS NOT NULL;
+ RETURN NEXT is(count(*), 3::BIGINT, msg || ': none of the labels should deleted yet') FROM _prom_catalog.label where key='name1';
+ RETURN;
+END;
+$fnc$;
+
+-- The first attempt to drop the chunks.
+CALL _prom_catalog.drop_metric_chunks('prom_data', 'test', E'2009-11-11 00:00:05+00');
+SELECT asserts_before_deletion('after the first timestamp');
+-- Attempting to drop chunks while incrementally moving `run_at` by an hour
+-- reruns shouldn't change anything until the epoch advances beyond current_epoch + 4
+-- 
+-- And current_epoch advances every time ran_at advances for the length of an epoch
+-- duration. Which we set to be 1h at the beginning of this test.
+CALL _prom_catalog.drop_metric_chunks('prom_data', 'test', E'2009-11-11 00:00:05+00');
+SELECT asserts_before_deletion('after iter 0');
+CALL _prom_catalog.drop_metric_chunks('prom_data', 'test', E'2009-11-11 00:00:05+00', now() + '1 hours');
+SELECT asserts_before_deletion('after iter 1');
+CALL _prom_catalog.drop_metric_chunks('prom_data', 'test', E'2009-11-11 00:00:05+00', now() + '2 hours');
+SELECT asserts_before_deletion('after iter 2');
+CALL _prom_catalog.drop_metric_chunks('prom_data', 'test', E'2009-11-11 00:00:05+00', now() + '3 hours');
+SELECT asserts_before_deletion('after iter 3');
+CALL _prom_catalog.drop_metric_chunks('prom_data', 'test', E'2009-11-11 00:00:05+00', now() + '4 hours');
+SELECT asserts_before_deletion('after iter 4');
+
+
+CREATE FUNCTION asserts_after_deletion(msg TEXT)
+ RETURNS SETOF TEXT
+ LANGUAGE plpgsql VOLATILE AS
+$fnc$
+BEGIN
+ RETURN NEXT is(count(*), 2::BIGINT, msg || ': expired chunks are gone') FROM prom_data.test;
+ RETURN NEXT is(count(*), 2::BIGINT, msg || ': one series should be removed') FROM _prom_catalog.series;
+ RETURN NEXT is(count(*), 0::BIGINT, msg || ': no series should be marked for deletion') FROM _prom_catalog.series WHERE delete_epoch IS NOT NULL;
+ RETURN NEXT is(count(*), 2::BIGINT, msg || ': unused labels should deleted') FROM _prom_catalog.label where key='name1';
+ RETURN;
+END;
+$fnc$;
+
+-- Now current_epoch advanced far enough and it is the time to actually drop the unused series
+CALL _prom_catalog.drop_metric_chunks('prom_data', 'test', E'2009-11-11 00:00:05+00', now() + '5 hours');
+SELECT asserts_after_deletion('after iter 5');            
+CALL _prom_catalog.drop_metric_chunks('prom_data', 'test', E'2009-11-11 00:00:05+00', now() + '6 hours');
+SELECT asserts_after_deletion('after iter 6');            
+CALL _prom_catalog.drop_metric_chunks('prom_data', 'test', E'2009-11-11 00:00:05+00', now() + '7 hours');
+SELECT asserts_after_deletion('after iter 7');            
+CALL _prom_catalog.drop_metric_chunks('prom_data', 'test', E'2009-11-11 00:00:05+00', now() + '8 hours');
+SELECT asserts_after_deletion('after iter 8');            
+CALL _prom_catalog.drop_metric_chunks('prom_data', 'test', E'2009-11-11 00:00:05+00', now() + '9 hours');
+SELECT asserts_after_deletion('after all iterations');
+
+SELECT throws_like(
+  'SELECT
+     CASE current_epoch > 0::BIGINT + 1 WHEN true THEN _prom_catalog.epoch_abort(0) 
+     END
+   FROM _prom_catalog.ids_epoch 
+   LIMIT 1;',
+   'epoch 0 to old to continue INSERT, current: %',
+   'Epoch has changed after a series was dropped'
+ );
+
+-- The end
+SELECT * FROM finish(true);

--- a/sql-tests/tests/snapshots/tests__testdata__drop_metric.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__drop_metric.sql.snap
@@ -1,0 +1,127 @@
+---
+source: sql-tests/tests/tests.rs
+expression: query_result
+---
+ plan  
+-------
+ 1..49
+(1 row)
+
+                  ok                   
+---------------------------------------
+ ok 1 - none of the chunks are deleted
+(1 row)
+
+                       ok                        
+-------------------------------------------------
+ ok 2 - none of the series should be removed yet
+(1 row)
+
+                           ok                            
+---------------------------------------------------------
+ ok 3 - none of the series should be marked for deletion
+(1 row)
+
+                      ok                      
+----------------------------------------------
+ ok 4 - none of the labels should deleted yet
+(1 row)
+
+                          asserts_before_deletion                           
+----------------------------------------------------------------------------
+ ok 5 - after the first timestamp: expired chunks are gone
+ ok 6 - after the first timestamp: none of the series should be removed yet
+ ok 7 - after the first timestamp: one series should be marked for deletion
+ ok 8 - after the first timestamp: none of the labels should deleted yet
+(4 rows)
+
+                    asserts_before_deletion                     
+----------------------------------------------------------------
+ ok 9 - after iter 0: expired chunks are gone
+ ok 10 - after iter 0: none of the series should be removed yet
+ ok 11 - after iter 0: one series should be marked for deletion
+ ok 12 - after iter 0: none of the labels should deleted yet
+(4 rows)
+
+                    asserts_before_deletion                     
+----------------------------------------------------------------
+ ok 13 - after iter 1: expired chunks are gone
+ ok 14 - after iter 1: none of the series should be removed yet
+ ok 15 - after iter 1: one series should be marked for deletion
+ ok 16 - after iter 1: none of the labels should deleted yet
+(4 rows)
+
+                    asserts_before_deletion                     
+----------------------------------------------------------------
+ ok 17 - after iter 2: expired chunks are gone
+ ok 18 - after iter 2: none of the series should be removed yet
+ ok 19 - after iter 2: one series should be marked for deletion
+ ok 20 - after iter 2: none of the labels should deleted yet
+(4 rows)
+
+                    asserts_before_deletion                     
+----------------------------------------------------------------
+ ok 21 - after iter 3: expired chunks are gone
+ ok 22 - after iter 3: none of the series should be removed yet
+ ok 23 - after iter 3: one series should be marked for deletion
+ ok 24 - after iter 3: none of the labels should deleted yet
+(4 rows)
+
+                    asserts_before_deletion                     
+----------------------------------------------------------------
+ ok 25 - after iter 4: expired chunks are gone
+ ok 26 - after iter 4: none of the series should be removed yet
+ ok 27 - after iter 4: one series should be marked for deletion
+ ok 28 - after iter 4: none of the labels should deleted yet
+(4 rows)
+
+                    asserts_after_deletion                     
+---------------------------------------------------------------
+ ok 29 - after iter 5: expired chunks are gone
+ ok 30 - after iter 5: one series should be removed
+ ok 31 - after iter 5: no series should be marked for deletion
+ ok 32 - after iter 5: unused labels should deleted
+(4 rows)
+
+                    asserts_after_deletion                     
+---------------------------------------------------------------
+ ok 33 - after iter 6: expired chunks are gone
+ ok 34 - after iter 6: one series should be removed
+ ok 35 - after iter 6: no series should be marked for deletion
+ ok 36 - after iter 6: unused labels should deleted
+(4 rows)
+
+                    asserts_after_deletion                     
+---------------------------------------------------------------
+ ok 37 - after iter 7: expired chunks are gone
+ ok 38 - after iter 7: one series should be removed
+ ok 39 - after iter 7: no series should be marked for deletion
+ ok 40 - after iter 7: unused labels should deleted
+(4 rows)
+
+                    asserts_after_deletion                     
+---------------------------------------------------------------
+ ok 41 - after iter 8: expired chunks are gone
+ ok 42 - after iter 8: one series should be removed
+ ok 43 - after iter 8: no series should be marked for deletion
+ ok 44 - after iter 8: unused labels should deleted
+(4 rows)
+
+                        asserts_after_deletion                         
+-----------------------------------------------------------------------
+ ok 45 - after all iterations: expired chunks are gone
+ ok 46 - after all iterations: one series should be removed
+ ok 47 - after all iterations: no series should be marked for deletion
+ ok 48 - after all iterations: unused labels should deleted
+(4 rows)
+
+                     throws_like                      
+------------------------------------------------------
+ ok 49 - Epoch has changed after a series was dropped
+(1 row)
+
+ finish 
+--------
+(0 rows)
+
+


### PR DESCRIPTION
## Description

Porting TestSQLDropMetricChunk from promscale into this repository because it mainly tests code that lives in this repository and is known to break when we simply change defaults. (See https://github.com/timescale/promscale/pull/1484)

One notable change between the original and this port is how the epoch is tested. This test just calls epoch_abort and asserts that it RAISEs an exception, while the original expects an actual ingestion failure.

Additionally, I fixed a minor bug in epoch_abort that caused a confusing message in RAISE.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] ~Updated the relevant documentation~