### PR TITLE
drop the get_confirmed_unused_series function so we can rename a param

### DIFF
--- a/migration/incremental/030-remove-get-confirmed-unused-series.sql
+++ b/migration/incremental/030-remove-get-confirmed-unused-series.sql
@@ -1,0 +1,2 @@
+-- renaming an argument, so we have to drop the prev version first
+DROP FUNCTION IF EXISTS _prom_catalog.get_confirmed_unused_series(TEXT, TEXT, TEXT, BIGINT[], TIMESTAMPTZ);


### PR DESCRIPTION
## Description

This commit https://github.com/timescale/promscale_extension/commit/88416098bf4acb46dac936b58df93d934c4b9364 introduced a bug that prevents upgrading. We rename a parameter of the get_confirmed_unused_series function. This can't be done in `create or replace`. You have to drop the function first. This commit provides a migration that drops the function.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation