### PR TITLE
Tag and release `timescaledev/promscale-extension:latest-ts2-pg<PGVER>`

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -121,6 +121,7 @@ jobs:
           dst: |
             timescaledev/promscale-extension:${{steps.metadata.outputs.image_branch_name}}-ts${{matrix.tsversion}}-pg${{matrix.pgversion}}
             timescaledev/promscale-extension:latest-ts${{matrix.tsversion}}-pg${{matrix.pgversion}}
+            timescaledev/promscale-extension:latest-ts${{steps.metadata.outputs.tsmajor}}-pg${{matrix.pgversion}}
 
   call-connector-e2e:
     name: call connector e2e test


### PR DESCRIPTION
## Description

When we added the automatic tagging and releasing of the
`timescaledev/promscale-extension` docker images, we forgot to tag the
`latest-ts2-pg<PGVER>`. This change fixes this for future releases.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation