### PR TITLE
Use actual logging in dump-restore tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,10 +552,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "duct"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc6a0a59ed0888e0041cf708e66357b7ae1a82f1c67247e1f93b5e0818f7d8d"
+dependencies = [
+ "libc",
+ "once_cell",
+ "os_pipe",
+ "shared_child",
+]
+
+[[package]]
 name = "e2e"
 version = "0.1.0"
 dependencies = [
  "build-deps",
+ "duct",
  "hex",
  "log",
  "md-5",
@@ -1208,6 +1221,16 @@ name = "once_cell"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+
+[[package]]
+name = "os_pipe"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb233f06c2307e1f5ce2ecad9f8121cffbbee2c95428f44ea85222e460d0d213"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "owo-colors"
@@ -2041,6 +2064,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shared_child"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6be9f7d5565b1483af3e72975e2dee33879b3b86bd48c0929fccf6585d79e65a"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dev-dependencies]
+duct = "0.13.5"
 hex = "0.4.3"
 log = "0.4.17"
 md-5 = "0.10.1"

--- a/e2e/tests/incremental-freeze-test.rs
+++ b/e2e/tests/incremental-freeze-test.rs
@@ -6,6 +6,8 @@ use std::{env, fs};
 /// Ensures that released incremental migrations scripts are not modified.
 #[test]
 fn incremental_freeze_test() {
+    let _ = pretty_env_logger::try_init();
+
     // The sql scripts in migration/incremental/ are not idempotent. They are meant to be run once
     // and only once on any given promscale installation. We track whether or not these files have
     // been applied in the _ps_catalog.migration table. Once we have released a version of

--- a/e2e/tests/util/mod.rs
+++ b/e2e/tests/util/mod.rs
@@ -1,0 +1,7 @@
+use log::debug;
+
+pub fn debug_lines(stdout: Vec<u8>) {
+    String::from_utf8(stdout).unwrap().lines().for_each(|line| {
+        debug!("{}", line);
+    })
+}


### PR DESCRIPTION
## Description

This change replaces usages of `println!()` with the logging-specific
macros (`info!()` and `debug!()`), allowing test execution logging to be
controlled.

To set the log level, set the RUST_LOG environment to one of `debug`,
`info`, etc.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~