### PR TITLE
Ensure upgrade test only uses installable versions

### DIFF
--- a/e2e/tests/test.rs
+++ b/e2e/tests/test.rs
@@ -40,6 +40,7 @@ fn upgrade_promscale_extension_all_versions() {
                     AND
                     split_part(source, '.', 2)::INT < 5
                 )
+                AND source IN (SELECT version FROM pg_available_extension_versions WHERE name = 'promscale')
             "#, &[])
         .unwrap();
 


### PR DESCRIPTION
## Description

We would like to provide an upgrade path from 0.5.3 to 0.5.4, but it's
not possible to install version 0.5.3 because it's broken. The test
assumed that if it's possible to upgrade from a source version to a
target version, that it's also possible to install the source version.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~