### PR TITLE
Upgrade tests should use the latest image for prior version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,6 +634,7 @@ dependencies = [
  "semver 1.0.12",
  "similar",
  "test-common",
+ "testcontainers",
 ]
 
 [[package]]

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -13,6 +13,7 @@ log = "0.4.17"
 test-common = "0.1.0"
 semver = "1.0.12"
 postgres = "0.19.2"
+testcontainers = "0.14.0"
 
 [build-dependencies]
 build-deps = "^0.1"

--- a/e2e/tests/dump-restore-test.rs
+++ b/e2e/tests/dump-restore-test.rs
@@ -424,7 +424,7 @@ fn are_snapshots_equal(snapshot0: String, snapshot1: String) -> bool {
 /// Tests the process of dumping and restoring a database using pg_dump
 #[test]
 fn dump_restore_test() {
-    let postgres_test_harness = PostgresContainerBlueprint::new()
+    let postgres_test_blueprint = PostgresContainerBlueprint::new()
         .with_volume(concat!(env!("CARGO_MANIFEST_DIR"), "/scripts"), "/scripts")
         .with_db("db")
         .with_user("postgres");
@@ -434,10 +434,10 @@ fn dump_restore_test() {
     let dump = dir.join("dump.sql");
 
     // create the first container, load it with data, snapshot it, and dump it
-    let snapshot0 = first_db(&postgres_test_harness, dir, &dump);
+    let snapshot0 = first_db(&postgres_test_blueprint, dir, &dump);
 
     // create the second container, restore into it, snapshot it, add more data
-    let snapshot1 = second_db(&postgres_test_harness, dir, &dump);
+    let snapshot1 = second_db(&postgres_test_blueprint, dir, &dump);
 
     // don't do `assert_eq!(snapshot0, snapshot1);`
     // it prints both entire snapshots and is impossible to read

--- a/e2e/tests/upgrade-test.rs
+++ b/e2e/tests/upgrade-test.rs
@@ -1,20 +1,282 @@
+extern crate core;
+
 use postgres::Client;
 use regex::Regex;
 use semver::Version;
 use similar::{ChangeTag, TextDiff};
-use std::path::Path;
+use std::fs::{create_dir_all, remove_dir_all, set_permissions, Permissions};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::{env, fs};
-use test_common::postgres_container;
+use test_common::postgres_container::{connect, postgres_image_uri, ImageOrigin, PgVersion};
 use test_common::{PostgresContainer, PostgresContainerBlueprint};
+use testcontainers::core::{ExecCommand, WaitFor};
 
-/// Removes the working directory if it exists, then creates it
-fn make_working_dir(dir: &Path) {
-    println!("temp dir at: {}", dir.to_str().unwrap());
-    if dir.exists() {
-        fs::remove_dir_all(dir).expect("failed to remove temp dir");
+// We expect the upgrade process to produce the same results as freshly installing the extension.
+// These tests enforce that expectation.
+//
+// In each of the upgrade test, we first produce a baseline snapshot. To do so, we create a
+// container using the docker image of the extension tagged as "latest". In this container, we
+// create the extension at the default version, which ought to be the latest version. Then, we
+// optionally create data using the extension APIs. Finally, we snapshot the state of the database
+// to a text file.
+//
+// Next, we create another container using the docker image of the extension tagged as "latest".
+// This container will use a docker volume mapping the postgres data dir to a host temp dir.
+// In this container, we create the extension at either the "first" version, or the "prior" version.
+// For our purposes, the "first" version ought to be 0.5.0 as this is the first
+// version in which the extension is able to install itself without the connector. The "prior"
+// version is the version just before the latest. These versions are determined using
+// pg_available_extension_versions. Then, we optionally create data using the extension APIs,
+// checkpoint the database, and stop the container.
+//
+// Then, we use the local docker image by default to create another container on top of the existing
+// data dir. In CI, the docker image is specified by env var. In this container, we update the
+// extension to the latest version and then snapshot the database to a text file.
+//
+// Finally, we compare the two database snapshots which should be identical.
+//
+// We have had at least one issue with a release in which the upgrade failed because of a database
+// migration that would not work if a given table was empty. So, we now have test scenarios both
+// with and without data. See issue: https://github.com/timescale/promscale/issues/330
+//
+// In CI, we run workflows with images based on both the "ha" image and alpine. The two image types
+// have the postgres data dir mapped to different paths. This is irritating. If the default image
+// starts with "ghcr.io/timescale/dev_promscale_extension:" then we assume we are running in CI.
+// Otherwise, we assume we are running on a developer's machine.
+
+enum FromVersion {
+    First,
+    Prior,
+}
+
+#[test]
+fn upgrade_first_no_data_test() {
+    test_upgrade(FromVersion::First, false);
+}
+
+#[test]
+fn upgrade_first_with_data_test() {
+    test_upgrade(FromVersion::First, true);
+}
+
+#[test]
+fn upgrade_prior_no_data_test() {
+    test_upgrade(FromVersion::Prior, false);
+}
+
+#[test]
+fn upgrade_prior_with_data_test() {
+    test_upgrade(FromVersion::Prior, true);
+}
+
+fn test_upgrade(from_version: FromVersion, with_data: bool) {
+    let to_image_uri = PostgresContainerBlueprint::default_image_uri();
+
+    // set up some working directories
+    let script_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/scripts");
+
+    let working_dir = match env::var("GITHUB_WORKSPACE") {
+        Ok(v) => {
+            let mut pb = PathBuf::new();
+            pb.push(v);
+            pb
+        }
+        Err(_) => env::temp_dir(),
     }
-    fs::create_dir_all(dir).expect("failed to create temp dir");
+    .join(temp_dir_name(&from_version, with_data));
+
+    if working_dir.exists() {
+        remove_dir_all(&working_dir).expect("failed to remove working dir");
+    }
+    create_dir_all(&working_dir).expect("failed to create working dir");
+
+    let host_data_dir = working_dir.clone().join("data");
+    if !host_data_dir.exists() {
+        create_dir_all(&host_data_dir).expect("failed to create working dir and data dir");
+    }
+    //let permissions = Permissions::from_mode(0o777);
+    //set_permissions(&working_dir, permissions.clone())
+    //    .expect("failed to chmod 0o777 on the host data directory");
+    let host_data_dir = host_data_dir.to_str().unwrap();
+    println!("working dir at {}", working_dir.to_str().unwrap());
+
+    // create a container using the target image
+    // determine the available extension versions and the postgres major version
+    // install the timescaledb extension and the promscale extension at the to_version
+    // optionally load test data
+    // snapshot the database
+    let (from_version, to_version, pg_version, data_dir, baseline_snapshot) = {
+        let baseline_blueprint = PostgresContainerBlueprint::new()
+            .with_image_uri(to_image_uri.clone())
+            .with_volume(script_dir, "/scripts")
+            .with_env_var("PGDATA", "/var/lib/postgresql/data")
+            .with_db("db")
+            .with_user("postgres");
+        let baseline_container = baseline_blueprint.run();
+
+        let mut client = connect(&baseline_blueprint, &baseline_container);
+        let (first_version, last_version, prior_version) =
+            available_extension_versions(&mut client);
+        let pg_version = pg_major_version(&mut client);
+        let data_dir = pg_data_dir(&mut client);
+
+        install_timescaledb_ext(&mut client);
+        install_promscale_ext(&mut client, &last_version);
+        if with_data {
+            load_data(&baseline_container);
+        }
+        let snapshot: String = snapshot_db(
+            &baseline_container,
+            "db",
+            "postgres",
+            working_dir
+                .join(format!(
+                    "snapshot-baseline-{}-{}.txt",
+                    last_version,
+                    match with_data {
+                        true => "with-data",
+                        false => "no-data",
+                    }
+                ))
+                .as_path(),
+        );
+        baseline_container.stop();
+        let from_version = match from_version {
+            FromVersion::First => first_version,
+            FromVersion::Prior => prior_version,
+        };
+        (from_version, last_version, pg_version, data_dir, snapshot)
+    };
+
+    let from_image_uri = if env::var("GITHUB_WORKSPACE").is_ok() {
+        format!(
+            "{}{}",
+            postgres_image_uri(ImageOrigin::Master, pg_version),
+            if to_image_uri.ends_with("-alpine") {
+                "-alpine"
+            } else {
+                ""
+            }
+        )
+        .to_string()
+    } else {
+        postgres_image_uri(ImageOrigin::Latest, pg_version)
+    };
+
+    println!("postgres data_directory: {}", data_dir.clone());
+    println!("from image {}", from_image_uri);
+    println!("to image {}", to_image_uri);
+    println!("from version {}", from_version);
+    println!("to version {}", to_version);
+
+    // create a container using the latest image
+    // map postgres' data dir to a temp dir
+    // install timescaledb and promscale at the from_version
+    // optionally load test data
+    {
+        println!(
+            "creating the database and extension with {}",
+            from_image_uri
+        );
+        let from_blueprint = PostgresContainerBlueprint::new()
+            .with_image_uri(from_image_uri.to_string())
+            .with_volume(script_dir, "/scripts")
+            .with_volume(host_data_dir, "/var/lib/postgresql/data")
+            .with_env_var("PGDATA", "/var/lib/postgresql/data")
+            .with_db("db")
+            .with_user("postgres");
+        let from_container = from_blueprint.run();
+        let mut from_client = connect(&from_blueprint, &from_container);
+        install_timescaledb_ext(&mut from_client);
+        install_promscale_ext(&mut from_client, &from_version);
+        if with_data {
+            load_data(&from_container);
+        }
+        from_client
+            .execute("checkpoint", &[])
+            .expect("failed to checkpoint");
+
+        //println!("{}", format!("chmod 0777 {}", data_dir));
+        //let cmd = ExecCommand {
+        //    cmd: format!("chmod 0777 {}", data_dir),
+        //    ready_conditions: vec![WaitFor::seconds(1)],
+        //};
+        //from_container.exec(cmd);
+
+        //let exit = Command::new("docker")
+        //    .arg("exec")
+        //    .arg(from_container.id())
+        //    .arg("chmod")
+        //    .arg("0777")
+        //    .arg(format!("{}", data_dir))
+        //    .spawn()
+        //    .unwrap()
+        //    .wait()
+        //    .unwrap();
+        //assert!(
+        //    exit.success(),
+        //    "executing chmod 0777 {} failed: {}",
+        //    data_dir,
+        //    exit
+        //);
+
+        from_container.stop();
+    }
+
+    //set_permissions(&host_data_dir, permissions)
+    //    .expect("failed to chmod 0o777 on the host data directory");
+
+    // create a container using the target image
+    // map postgres' data dir to the same temp dir from before
+    // update the promscale extension to the to_version
+    // snapshot the database
+    println!("starting {}", from_image_uri.clone());
+    let upgraded_snapshot = {
+        let to_blueprint = PostgresContainerBlueprint::new()
+            .with_image_uri(to_image_uri)
+            .with_volume(script_dir, "/scripts")
+            .with_volume(host_data_dir, "/var/lib/postgresql/data")
+            .with_env_var("PGDATA", "/var/lib/postgresql/data")
+            .with_db("db")
+            .with_user("postgres");
+        let to_container = to_blueprint.run();
+        let mut to_client = connect(&to_blueprint, &to_container);
+        update_promscale_ext(&mut to_client, &to_version);
+        let upgraded_snapshot = snapshot_db(
+            &to_container,
+            "db",
+            "postgres",
+            working_dir
+                .join(format!(
+                    "snapshot-{}-{}-{}.txt",
+                    from_version,
+                    to_version,
+                    if with_data { "with-data" } else { "no-data" }
+                ))
+                .as_path(),
+        );
+        to_container.stop();
+        upgraded_snapshot
+    };
+
+    let are_equal = are_snapshots_equal(baseline_snapshot, upgraded_snapshot);
+    assert!(are_equal);
+}
+
+fn temp_dir_name(from_version: &FromVersion, with_data: bool) -> String {
+    format!(
+        "test-upgrade-from-{}-{}",
+        match from_version {
+            FromVersion::First => "first",
+            FromVersion::Prior => "prior",
+        },
+        match with_data {
+            true => "with-data",
+            false => "no-data",
+        }
+    )
 }
 
 /// Runs a SQL script file in the docker container
@@ -161,13 +423,17 @@ fn snapshot_db(container: &PostgresContainer, db: &str, username: &str, path: &P
     normalize_snapshot(path)
 }
 
+/// Determines the first, last, and prior versions of the promscale extension available
 fn available_extension_versions(client: &mut Client) -> (Version, Version, Version) {
     let result = client
         .query(
-            "select version from pg_available_extension_versions where name = 'promscale' and version != '0.1';",
+            r"select version 
+                     from pg_available_extension_versions 
+                     where name = 'promscale' 
+                     and version not in ('0.1', '0.5.3') and version not like '0.5.3-%';",
             &[],
         )
-        .unwrap();
+        .expect("failed to select available extension versions");
     let mut versions: Vec<Version> = vec![];
     for row in result {
         let x: &str = row.get(0);
@@ -188,10 +454,49 @@ fn available_extension_versions(client: &mut Client) -> (Version, Version, Versi
     (first, last, prior)
 }
 
+/// Determines the major version of postgres running
+fn pg_major_version(client: &mut Client) -> PgVersion {
+    let result = client
+        .query(
+            "select setting::int / 10000 from pg_settings where name = 'server_version_num';",
+            &[],
+        )
+        .expect("failed to select server_version_num");
+    let pg_major_version: i32 = result
+        .first()
+        .expect("failed to get result from selecting server_version_num")
+        .get(0);
+    match pg_major_version {
+        14 => PgVersion::V14,
+        13 => PgVersion::V13,
+        12 => PgVersion::V12,
+        _ => panic!("unsupported postgres major version {}", pg_major_version),
+    }
+}
+
+/// Determines the data directory of the postgres cluster
+fn pg_data_dir(client: &mut Client) -> String {
+    let result = client
+        .query("show data_directory", &[])
+        .expect("failed to select data_directory");
+    let data_dir: String = result
+        .first()
+        .expect("failed to get result from selecting data_directory")
+        .get(0);
+    PathBuf::from(data_dir)
+        .parent()
+        .expect("failed to find the parent of the data_directory")
+        .to_str()
+        .unwrap()
+        .to_string()
+    //data_dir
+}
+
 /// Diffs the two snapshots.
 /// Differences are printed to the console.
 /// Returns a boolean. True indicates the two snapshots are identical
 fn are_snapshots_equal(snapshot0: String, snapshot1: String) -> bool {
+    println!("comparing the snapshots...");
     let are_snapshots_equal = snapshot0 == snapshot1;
     if !are_snapshots_equal {
         let diff = TextDiff::from_lines(snapshot0.as_str(), snapshot1.as_str());
@@ -206,16 +511,23 @@ fn are_snapshots_equal(snapshot0: String, snapshot1: String) -> bool {
             };
             println!("{} {}", sign, change);
         }
+    } else {
+        println!("snapshots are equal");
     }
     are_snapshots_equal
 }
 
+/// Installs the timescaledb extension
 fn install_timescaledb_ext(client: &mut Client) {
     client
-        .execute("create extension if not exists timescaledb;", &[])
+        .execute(
+            "create extension if not exists timescaledb version '2.7.0';",
+            &[],
+        )
         .expect("failed to install the timescaledb extension");
 }
 
+/// Installs the promscale extension at the specified version
 fn install_promscale_ext(client: &mut Client, version: &Version) {
     client
         .execute(
@@ -229,6 +541,7 @@ fn install_promscale_ext(client: &mut Client, version: &Version) {
         .expect("failed to install the promscale extension");
 }
 
+/// updates the promscale extension to the specified version
 fn update_promscale_ext(client: &mut Client, version: &Version) {
     client
         .execute(
@@ -240,164 +553,4 @@ fn update_promscale_ext(client: &mut Client, version: &Version) {
             &[],
         )
         .expect("failed to update the promscale extension");
-}
-
-fn baseline(
-    blueprint: &PostgresContainerBlueprint,
-    dir: &Path,
-    with_data: bool,
-) -> (Version, Version, Version, String) {
-    let container = blueprint.run();
-    let mut client = postgres_container::connect(&blueprint, &container);
-
-    let (first_version, last_version, prior_version) = available_extension_versions(&mut client);
-
-    install_timescaledb_ext(&mut client);
-    install_promscale_ext(&mut client, &last_version);
-    let snapshot: String = if !with_data {
-        snapshot_db(
-            &container,
-            "db",
-            "postgres",
-            dir.join(format!("snapshot-baseline-{}-no-data.txt", last_version))
-                .as_path(),
-        )
-    } else {
-        load_data(&container);
-        snapshot_db(
-            &container,
-            "db",
-            "postgres",
-            dir.join(format!("snapshot-baseline-{}-with-data.txt", last_version))
-                .as_path(),
-        )
-    };
-    container.stop();
-
-    (first_version, last_version, prior_version, snapshot)
-}
-
-fn upgrade(
-    blueprint: &PostgresContainerBlueprint,
-    dir: &Path,
-    first: &Version,
-    second: &Version,
-    with_data: bool,
-    baseline_snapshot: String,
-) {
-    let container = blueprint.run();
-    let mut client = postgres_container::connect(&blueprint, &container);
-    install_timescaledb_ext(&mut client);
-    install_promscale_ext(&mut client, first);
-    if with_data {
-        load_data(&container);
-    }
-    update_promscale_ext(&mut client, second);
-    let snapshot = snapshot_db(
-        &container,
-        "db",
-        "postgres",
-        dir.join(format!(
-            "snapshot-{}-{}-{}.txt",
-            first,
-            second,
-            if with_data { "with-data" } else { "no-data" }
-        ))
-        .as_path(),
-    );
-    container.stop();
-    let are_equal = are_snapshots_equal(baseline_snapshot, snapshot);
-    assert!(are_equal);
-}
-
-#[test]
-fn upgrade_first_no_data_test() {
-    let blueprint = PostgresContainerBlueprint::new()
-        .with_volume(concat!(env!("CARGO_MANIFEST_DIR"), "/scripts"), "/scripts")
-        .with_db("db")
-        .with_user("postgres");
-
-    let dir = &env::temp_dir().join("promscale-upgrade-first-no-data-test");
-    make_working_dir(dir);
-
-    let (first_version, last_version, _, snapshot) = baseline(&blueprint, dir, false);
-
-    println!("upgrading from {} to {}", first_version, last_version);
-    upgrade(
-        &blueprint,
-        dir,
-        &first_version,
-        &last_version,
-        false,
-        snapshot,
-    );
-}
-
-#[test]
-fn upgrade_first_with_data_test() {
-    let blueprint = PostgresContainerBlueprint::new()
-        .with_volume(concat!(env!("CARGO_MANIFEST_DIR"), "/scripts"), "/scripts")
-        .with_db("db")
-        .with_user("postgres");
-
-    let dir = &env::temp_dir().join("promscale-upgrade-first-with-data-test");
-    make_working_dir(dir);
-
-    let (first_version, last_version, _, snapshot) = baseline(&blueprint, dir, true);
-
-    println!("upgrading from {} to {}", first_version, last_version);
-    upgrade(
-        &blueprint,
-        dir,
-        &first_version,
-        &last_version,
-        true,
-        snapshot,
-    );
-}
-
-#[test]
-fn upgrade_prior_no_data_test() {
-    let blueprint = PostgresContainerBlueprint::new()
-        .with_volume(concat!(env!("CARGO_MANIFEST_DIR"), "/scripts"), "/scripts")
-        .with_db("db")
-        .with_user("postgres");
-
-    let dir = &env::temp_dir().join("promscale-upgrade-prior-no-data-test");
-    make_working_dir(dir);
-
-    let (_, last_version, prior_version, snapshot) = baseline(&blueprint, dir, false);
-
-    println!("upgrading from {} to {}", prior_version, last_version);
-    upgrade(
-        &blueprint,
-        dir,
-        &prior_version,
-        &last_version,
-        false,
-        snapshot,
-    );
-}
-
-#[test]
-fn upgrade_prior_with_data_test() {
-    let blueprint = PostgresContainerBlueprint::new()
-        .with_volume(concat!(env!("CARGO_MANIFEST_DIR"), "/scripts"), "/scripts")
-        .with_db("db")
-        .with_user("postgres");
-
-    let dir = &env::temp_dir().join("promscale-upgrade-prior-with-data-test");
-    make_working_dir(dir);
-
-    let (_, last_version, prior_version, snapshot) = baseline(&blueprint, dir, true);
-
-    println!("upgrading from {} to {}", prior_version, last_version);
-    upgrade(
-        &blueprint,
-        dir,
-        &prior_version,
-        &last_version,
-        true,
-        snapshot,
-    );
 }

--- a/e2e/tests/upgrade-test.rs
+++ b/e2e/tests/upgrade-test.rs
@@ -97,7 +97,7 @@ fn test_upgrade(from_version: FromVersion, with_data: bool) {
     }
     create_dir_all(&working_dir).expect("failed to create working dir");
 
-    let data_dir = working_dir.clone().join("data");
+    let data_dir = working_dir.clone().join("db");
     if !data_dir.exists() {
         create_dir_all(&data_dir).expect("failed to create working dir and data dir");
     }

--- a/e2e/tests/upgrade-test.rs
+++ b/e2e/tests/upgrade-test.rs
@@ -223,8 +223,8 @@ fn test_upgrade(from_version: FromVersion, with_data: bool) {
         from_timescaledb_version
     };
 
-    set_permissions(&data_dir, permissions)
-        .expect("failed to chmod 0o777 on the host data directory");
+    //set_permissions(&data_dir, permissions)
+    //    .expect("failed to chmod 0o777 on the host data directory");
 
     // create a container using the target image
     // map postgres' data dir to the same temp dir from before

--- a/e2e/tests/upgrade-test.rs
+++ b/e2e/tests/upgrade-test.rs
@@ -264,9 +264,15 @@ fn test_upgrade(from_version: FromVersion, with_data: bool) {
                 "upgrading from timescaledb {} to {}",
                 from_timescaledb_version, to_timescaledb_version
             );
-            update_timescaledb_ext(&to_container, "postgres", "db", &to_timescaledb_version);
+            update_extension(
+                &to_container,
+                "postgres",
+                "db",
+                "timescaledb",
+                &to_timescaledb_version,
+            );
         }
-        update_promscale_ext(&to_container, "postgres", "db", &to_version);
+        update_extension(&to_container, "postgres", "db", "promscale", &to_version);
         let upgraded_snapshot = snapshot_db(
             &to_container,
             "db",

--- a/e2e/tests/upgrade-test.rs
+++ b/e2e/tests/upgrade-test.rs
@@ -3,14 +3,12 @@ extern crate core;
 use postgres::Client;
 use regex::Regex;
 use semver::Version;
-use similar::{ChangeTag, DiffableStr, TextDiff};
+use similar::{ChangeTag, TextDiff};
 use std::fs::{create_dir_all, remove_dir_all, set_permissions, Permissions};
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::{env, fs};
-use test_common::postgres_container::{connect, postgres_image_uri, ImageOrigin, PgVersion};
-use test_common::{PostgresContainer, PostgresContainerBlueprint};
 
 // We expect the upgrade process to produce the same results as freshly installing the extension.
 // These tests enforce that expectation.
@@ -74,7 +72,8 @@ fn test_upgrade(from_version: FromVersion, with_data: bool) {
     // in local development, we want local/dev_promscale_extension:head-ts2-pg14
     // in ci, we want ghcr.io/timescale/dev_promscale_extension:<branch-name>-ts2.7.2-pg<version>
     // this image will be used for the baseline and for upgrading the version of promscale
-    let to_image_uri = PostgresContainerBlueprint::default_image_uri();
+    let to_image_uri = env::var("TS_DOCKER_IMAGE")
+        .unwrap_or_else(|_| "local/dev_promscale_extension:head-ts2-pg14".to_string());
 
     // we need to know whether we are using an ha or alpine image in order to pick an appropriate
     // corresponding "from" image used the create the older version of promscale
@@ -85,37 +84,36 @@ fn test_upgrade(from_version: FromVersion, with_data: bool) {
             false => "ha",
         },
     };
-    println!("image flavor: {}", &flavor);
+    eprintln!("image flavor: {}", &flavor);
 
     // we also need to know which version of postgres we have been instructed to use
     let pg_version = pg_version_from_image_uri(&to_image_uri);
-    println!("postgresql version: {}", &pg_version);
+    eprintln!("postgresql version: {}", &pg_version);
 
     // are we running in ci?
     // https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
     let is_ci = env::var("CI").is_ok();
-    println!("running in ci: {}", is_ci);
+    eprintln!("running in ci: {}", is_ci);
 
     // pick the appropriate corresponding "from" image used the create the older version of promscale
     let from_image_uri = image_uri_from_flavor_pg_version(&flavor, &pg_version);
-    println!("from image {}", from_image_uri);
-    println!("to image {}", to_image_uri);
+    eprintln!("from image {}", from_image_uri);
+    eprintln!("to image {}", to_image_uri);
 
     // set up some working directories
 
     // this dir has our sql scripts. we'll mount it into the docker containers and use them via psql
     let script_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/scripts");
 
+    let name = name(&from_version, with_data, flavor, pg_version);
+
     // in this directory we'll put our db snapshots we'll compare
-    let working_dir = env::temp_dir().join(name(&from_version, with_data, flavor, pg_version));
+    let working_dir = env::temp_dir().join(&name);
     if working_dir.exists() {
         remove_dir_all(&working_dir).expect("failed to remove working dir");
     }
     create_dir_all(&working_dir).expect("failed to create working dir");
-    println!("working dir at {}", working_dir.to_str().unwrap());
-
-    //let vol_name = create_docker_volume(&from_version, with_data, flavor, pg_version);
-    //println!("docker volume name: {}", vol_name);
+    eprintln!("working dir at {}", working_dir.to_str().unwrap());
 
     // for the database we're upgrading, we need to use two containers and the data_directory
     // needs to be persistent in this dir
@@ -127,7 +125,7 @@ fn test_upgrade(from_version: FromVersion, with_data: bool) {
     set_permissions(&data_dir, permissions.clone())
         .expect("failed to chmod 0o777 on the data directory");
     let data_dir = data_dir.to_str().unwrap();
-    println!("data dir at {}", &data_dir);
+    eprintln!("data dir at {}", &data_dir);
 
     // BASELINE
     // create a container using the target image
@@ -135,28 +133,58 @@ fn test_upgrade(from_version: FromVersion, with_data: bool) {
     // install the timescaledb extension and the promscale extension at the to_version
     // optionally load test data
     // snapshot the database
-    /*
     let (from_version, to_version, to_timescaledb_version, baseline_snapshot) = {
-        let baseline_blueprint = PostgresContainerBlueprint::new()
-            .with_image_uri(to_image_uri.clone())
-            .with_volume(script_dir, "/scripts")
-            .with_env_var("PGDATA", "/var/lib/postgresql/data")
-            .with_db("db")
-            .with_user("postgres");
-        let baseline_container = baseline_blueprint.run();
+        eprintln!("BASELINE");
+        let child = Command::new("docker")
+            .arg("run")
+            .arg("-d")
+            .args([
+                "--mount",
+                format!("type=bind,src={},dst=/scripts", script_dir).as_str(),
+            ])
+            .args(["--env", "PGDATA=/var/lib/postgresql/data/data"])
+            .args(["--env", "POSTGRES_HOST_AUTH_METHOD=trust"])
+            .args(["--env", "POSTGRES_DB=db"])
+            .args(["--env", "POSTGRES_DB=db"])
+            .args(["--env", "POSTGRES_USER=postgres"])
+            .args(["--env", "POSTGRES_PASSWORD=password"])
+            .args(["-p", "5554:5432"])
+            .arg(&to_image_uri)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("failed to create and run the docker container");
+        let output = child
+            .wait_with_output()
+            .expect("failed to wait on docker run");
+        assert!(
+            output.status.success(),
+            "docker run failed {}",
+            std::str::from_utf8(output.stderr.as_slice()).expect("stderr is not valid utf8")
+        );
+        let baseline_container_id = std::str::from_utf8(output.stdout.as_slice())
+            .expect("stdout is not valid utf8")
+            .trim()
+            .to_string();
+        assert_ne!(baseline_container_id, "");
+        eprintln!("baseline_container_id: {}", &baseline_container_id);
+        wait_for_pg_ready(&baseline_container_id);
+        wait_for_log_msg(&baseline_container_id);
+        let mut baseline_client =
+            Client::connect("postgres://postgres@localhost:5555/db", postgres::NoTls)
+                .expect("failed to connect to postgres");
 
-        let mut client = connect(&baseline_blueprint, &baseline_container);
         let (first_version, last_version, prior_version) =
-            available_extension_versions(&mut client);
-        //let pg_version = pg_major_version(&mut client);
+            available_extension_versions(&mut baseline_client);
 
-        let to_timescaledb_version = install_timescaledb_ext(&mut client);
-        install_promscale_ext(&mut client, &last_version);
+        let to_timescaledb_version = install_timescaledb_ext(&mut baseline_client);
+        install_promscale_ext(&mut baseline_client, &last_version);
         if with_data {
-            load_data(&baseline_container);
+            load_data(&baseline_container_id);
         }
         let snapshot: String = snapshot_db(
-            &baseline_container,
+            &baseline_container_id,
             "db",
             "postgres",
             working_dir
@@ -170,18 +198,15 @@ fn test_upgrade(from_version: FromVersion, with_data: bool) {
                 ))
                 .as_path(),
         );
-        baseline_container.stop();
+        stop_container(&baseline_container_id);
         let from_version = match from_version {
             FromVersion::First => first_version,
             FromVersion::Prior => prior_version,
         };
         (from_version, last_version, to_timescaledb_version, snapshot)
     };
-    */
-    let from_version = Version::new(0, 5, 2);
-    let to_version = Version::new(0, 5, 5);
-    println!("from promscale version {}", from_version);
-    println!("to promscale version {}", to_version);
+    eprintln!("from promscale version {}", from_version);
+    eprintln!("to promscale version {}", to_version);
 
     // UPGRADE FROM
     // create a container using the latest image
@@ -189,11 +214,12 @@ fn test_upgrade(from_version: FromVersion, with_data: bool) {
     // install timescaledb and promscale at the from_version
     // optionally load test data
     let from_timescaledb_version = {
-        println!("UPGRADE FROM");
+        eprintln!("UPGRADE FROM");
 
         let child = Command::new("docker")
             .arg("run")
             .arg("-d")
+            //.args(["--name", &name])
             .args([
                 "--mount",
                 format!("type=bind,src={},dst=/scripts", script_dir).as_str(),
@@ -208,6 +234,7 @@ fn test_upgrade(from_version: FromVersion, with_data: bool) {
             .args(["--env", "POSTGRES_DB=db"])
             .args(["--env", "POSTGRES_USER=postgres"])
             .args(["--env", "POSTGRES_PASSWORD=password"])
+            .args(["-p", "5555:5432"])
             .arg(from_image_uri)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
@@ -227,122 +254,180 @@ fn test_upgrade(from_version: FromVersion, with_data: bool) {
             .trim()
             .to_string();
         assert_ne!(from_container_id, "");
-        println!("from_container_id: {}", &from_container_id);
-
-        loop {
-            let exit = Command::new("docker")
-                .arg("exec")
-                .arg(&from_container_id)
-                .arg("pg_isready")
-                .args(["-t", "10"])
-                .arg("-q")
-                .spawn()
-                .unwrap()
-                .wait()
-                .unwrap();
-            let exit_code = exit.code().unwrap();
-            assert!(
-                exit_code < 3,
-                "failed to wait for postgresql to be ready: {}",
-                exit
-            );
-            if exit_code == 2 {
-                println!("postgres is not answering yet");
-                std::thread::sleep(std::time::Duration::from_secs(1));
-            }
-            if exit_code == 0 {
-                println!("postgres is ready!");
-                break;
-            }
+        eprintln!("from_container_id: {}", &from_container_id);
+        wait_for_pg_ready(&from_container_id);
+        wait_for_log_msg(&from_container_id);
+        let mut from_client =
+            Client::connect("postgres://postgres@localhost:5555/db", postgres::NoTls)
+                .expect("failed to connect to postgres");
+        eprintln!(
+            "postgres thinks the data_directory is {}",
+            pg_data_dir(&mut from_client)
+        );
+        let from_timescaledb_version = install_timescaledb_ext(&mut from_client);
+        install_promscale_ext(&mut from_client, &from_version);
+        if with_data {
+            load_data(&from_container_id);
         }
-        println!("done");
-        /*
-               let from_blueprint = PostgresContainerBlueprint::new()
-                   .with_image_uri(from_image_uri.to_string())
-                   .with_volume(script_dir, "/scripts")
-                   .with_volume(&vol_name, "/var/lib/postgresql/data")
-                   .with_env_var("PGDATA", "/var/lib/postgresql/data/data")
-                   .with_db("db")
-                   .with_user("postgres");
-               let from_container = from_blueprint.run();
-               let mut from_client = connect(&from_blueprint, &from_container);
-               println!(
-                   "postgres thinks the data_directory is {}",
-                   pg_data_dir(&mut from_client)
-               );
-               let from_timescaledb_version = install_timescaledb_ext(&mut from_client);
-               install_promscale_ext(&mut from_client, &from_version);
-               if with_data {
-                   load_data(&from_container);
-               }
-               from_client
-                   .execute("checkpoint", &[])
-                   .expect("failed to checkpoint");
-               from_container.stop();
-               from_timescaledb_version
-
-        */
-        Version::new(2, 7, 0)
+        from_client
+            .execute("checkpoint", &[])
+            .expect("failed to checkpoint");
+        stop_container(&from_container_id);
+        from_timescaledb_version
     };
-    /*
-       //set_permissions(&data_dir, permissions).expect("failed to chmod 0o777 on the data directory");
 
-       // UPGRADE TO
-       // create a container using the target image
-       // map postgres' data dir to the same temp dir from before
-       // update the promscale extension to the to_version
-       // snapshot the database
-       println!("starting {}", from_image_uri.clone());
-       let upgraded_snapshot = {
-           let to_blueprint = PostgresContainerBlueprint::new()
-               .with_image_uri(to_image_uri)
-               .with_volume(script_dir, "/scripts")
-               .with_volume(&vol_name, "/var/lib/postgresql/data")
-               .with_env_var("PGDATA", "/var/lib/postgresql/data")
-               .with_db("db")
-               .with_user("postgres");
-           let to_container = to_blueprint.run();
-           let mut to_client = connect(&to_blueprint, &to_container);
-           println!(
-               "postgres thinks the data_directory is {}",
-               pg_data_dir(&mut to_client)
-           );
-           if from_timescaledb_version != to_timescaledb_version {
-               assert!(from_timescaledb_version < to_timescaledb_version);
-               println!(
-                   "upgrading from timescaledb {} to {}",
-                   from_timescaledb_version, to_timescaledb_version
-               );
-               update_extension(
-                   &to_container,
-                   "postgres",
-                   "db",
-                   "timescaledb",
-                   &to_timescaledb_version,
-               );
-           }
-           update_extension(&to_container, "postgres", "db", "promscale", &to_version);
-           let upgraded_snapshot = snapshot_db(
-               &to_container,
-               "db",
-               "postgres",
-               working_dir
-                   .join(format!(
-                       "snapshot-{}-{}-{}.txt",
-                       from_version,
-                       to_version,
-                       if with_data { "with-data" } else { "no-data" }
-                   ))
-                   .as_path(),
-           );
-           to_container.stop();
-           upgraded_snapshot
-       };
+    set_permissions(&data_dir, permissions).expect("failed to chmod 0o777 on the data directory");
 
-       let are_equal = are_snapshots_equal(baseline_snapshot, upgraded_snapshot);
-       assert!(are_equal);
+    // UPGRADE TO
+    // create a container using the target image
+    // map postgres' data dir to the same temp dir from before
+    // update the promscale extension to the to_version
+    // snapshot the database
+    let upgraded_snapshot = {
+        eprintln!("UPGRADE TO");
+        let child = Command::new("docker")
+            .arg("run")
+            .arg("-d")
+            .args([
+                "--mount",
+                format!("type=bind,src={},dst=/scripts", script_dir).as_str(),
+            ])
+            .args([
+                "--mount",
+                format!("type=bind,src={},dst=/var/lib/postgresql/data", data_dir).as_str(),
+            ])
+            .args(["--env", "PGDATA=/var/lib/postgresql/data/data"])
+            .args(["--env", "POSTGRES_HOST_AUTH_METHOD=trust"])
+            .args(["--env", "POSTGRES_DB=db"])
+            .args(["--env", "POSTGRES_DB=db"])
+            .args(["--env", "POSTGRES_USER=postgres"])
+            .args(["--env", "POSTGRES_PASSWORD=password"])
+            .args(["-p", "5556:5432"])
+            .arg(to_image_uri)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("failed to create and run the docker container");
+        let output = child
+            .wait_with_output()
+            .expect("failed to wait on docker run");
+        assert!(
+            output.status.success(),
+            "docker run failed {}",
+            std::str::from_utf8(output.stderr.as_slice()).expect("stderr is not valid utf8")
+        );
+        let to_container_id = std::str::from_utf8(output.stdout.as_slice())
+            .expect("stdout is not valid utf8")
+            .trim()
+            .to_string();
+        assert_ne!(to_container_id, "");
+        eprintln!("to_container_id: {}", &to_container_id);
+        wait_for_pg_ready(&to_container_id);
+        wait_for_log_msg(&to_container_id);
+        let mut to_client =
+            Client::connect("postgres://postgres@localhost:5556/db", postgres::NoTls)
+                .expect("failed to connect to postgres");
+        eprintln!(
+            "postgres thinks the data_directory is {}",
+            pg_data_dir(&mut to_client)
+        );
+        if from_timescaledb_version != to_timescaledb_version {
+            assert!(from_timescaledb_version < to_timescaledb_version);
+            eprintln!(
+                "upgrading from timescaledb {} to {}",
+                from_timescaledb_version, to_timescaledb_version
+            );
+            update_extension(
+                &to_container_id,
+                "postgres",
+                "db",
+                "timescaledb",
+                &to_timescaledb_version,
+            );
+        }
+        update_extension(&to_container_id, "postgres", "db", "promscale", &to_version);
+        let upgraded_snapshot = snapshot_db(
+            &to_container_id,
+            "db",
+            "postgres",
+            working_dir
+                .join(format!(
+                    "snapshot-{}-{}-{}.txt",
+                    from_version,
+                    to_version,
+                    if with_data { "with-data" } else { "no-data" }
+                ))
+                .as_path(),
+        );
+        stop_container(&to_container_id);
+        upgraded_snapshot
+    };
 
-    */
+    let are_equal = are_snapshots_equal(baseline_snapshot, upgraded_snapshot);
+    assert!(are_equal);
+}
+
+fn stop_container(container_id: &str) {
+    let exit = Command::new("docker")
+        .arg("stop")
+        .arg(&container_id)
+        .spawn()
+        .unwrap()
+        .wait()
+        .unwrap();
+    assert!(
+        exit.success(),
+        "failed to stop container {}: {}",
+        &container_id,
+        exit
+    );
+}
+
+fn wait_for_log_msg(container_id: &str) {
+    loop {
+        let output = Command::new("docker")
+            .arg("logs")
+            .arg(&container_id)
+            .output()
+            .expect("failed to get container logs");
+        assert!(output.status.success());
+        let logs = std::str::from_utf8(output.stdout.as_slice()).expect("stdout is not valid utf8");
+        if logs.contains("LOG: database system is ready to accept connections") {
+            break;
+        }
+        eprintln!("postgres is not ready yet");
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+}
+
+fn wait_for_pg_ready(container_id: &str) {
+    loop {
+        let exit = Command::new("docker")
+            .arg("exec")
+            .arg(&container_id)
+            .arg("pg_isready")
+            //.args(["-t", "10"])
+            .arg("-q")
+            .spawn()
+            .unwrap()
+            .wait()
+            .unwrap();
+        let exit_code = exit.code().unwrap();
+        assert!(
+            exit_code < 3,
+            "failed to wait for postgresql to be ready: {}",
+            exit
+        );
+        if exit_code == 2 {
+            eprintln!("postgres is not answering yet");
+            std::thread::sleep(std::time::Duration::from_secs(1));
+        }
+        if exit_code == 0 {
+            eprintln!("postgres is ready!");
+            break;
+        }
+    }
 }
 
 fn image_uri_from_flavor_pg_version(flavor: &str, pg_version: &str) -> String {
@@ -380,6 +465,7 @@ fn name(from_version: &FromVersion, with_data: bool, flavor: &str, pg_version: &
     )
 }
 
+/*
 fn create_docker_volume(
     from_version: &FromVersion,
     with_data: bool,
@@ -441,6 +527,7 @@ fn create_docker_volume(
     );
     vol_name
 }
+*/
 
 /// Runs a SQL script file in the docker container
 ///
@@ -453,11 +540,11 @@ fn create_docker_volume(
 /// * `username` - the username to be used on the psql connection with the `-U` flag
 /// * `path` - the path to the sql script on the host to execute using the `-f` flag
 ///
-fn psql_file(container: &PostgresContainer, db: &str, username: &str, path: &Path) {
+fn psql_file(container_id: &str, db: &str, username: &str, path: &Path) {
     println!("executing psql script {}...", path.display());
     let exit = Command::new("docker")
         .arg("exec")
-        .arg(container.id())
+        .arg(&container_id)
         .arg("psql")
         .args(["-U", username])
         .args(["-d", db])
@@ -480,9 +567,9 @@ fn psql_file(container: &PostgresContainer, db: &str, username: &str, path: &Pat
 }
 
 /// Runs the load-data sql script in the container
-fn load_data(container: &PostgresContainer) {
+fn load_data(container_id: &str) {
     psql_file(
-        container,
+        container_id,
         "db",
         "postgres",
         Path::new("/scripts/load-data.sql"),
@@ -498,13 +585,13 @@ fn load_data(container: &PostgresContainer) {
 /// * `dest` - the path on the host to copy the file to
 ///
 #[allow(dead_code)]
-fn copy_out(container: &PostgresContainer, src: &Path, dest: &Path) {
+fn copy_out(container_id: &str, src: &Path, dest: &Path) {
     if dest.exists() {
         fs::remove_file(dest).expect("failed to remove existing dest file");
     }
     let exit = Command::new("docker")
         .arg("cp")
-        .arg(format!("{}:{}", container.id(), src.display()))
+        .arg(format!("{}:{}", &container_id, src.display()))
         .arg(dest.to_str().unwrap())
         .spawn()
         .unwrap()
@@ -552,12 +639,12 @@ fn normalize_snapshot(path: &Path) -> String {
 /// * `username` - the user to connect to the database with
 /// * `path` - the path on the host to which the snapshot should be written
 ///
-fn snapshot_db(container: &PostgresContainer, db: &str, username: &str, path: &Path) -> String {
+fn snapshot_db(container_id: &str, db: &str, username: &str, path: &Path) -> String {
     let snapshot = Path::new("/tmp/snapshot.txt");
     println!("snapshotting database {} via {} user...", db, username);
     let exit = Command::new("docker")
         .arg("exec")
-        .arg(container.id())
+        .arg(&container_id)
         .arg("psql")
         .args(["-U", username])
         .args(["-d", db])
@@ -582,7 +669,7 @@ fn snapshot_db(container: &PostgresContainer, db: &str, username: &str, path: &P
         username,
         exit
     );
-    copy_out(container, snapshot, path);
+    copy_out(&container_id, snapshot, path);
     normalize_snapshot(path)
 }
 
@@ -653,7 +740,7 @@ fn pg_data_dir(client: &mut Client) -> String {
 /// Differences are printed to the console.
 /// Returns a boolean. True indicates the two snapshots are identical
 fn are_snapshots_equal(snapshot0: String, snapshot1: String) -> bool {
-    println!("comparing the snapshots...");
+    eprintln!("comparing the snapshots...");
     let are_snapshots_equal = snapshot0 == snapshot1;
     if !are_snapshots_equal {
         let diff = TextDiff::from_lines(snapshot0.as_str(), snapshot1.as_str());
@@ -666,10 +753,10 @@ fn are_snapshots_equal(snapshot0: String, snapshot1: String) -> bool {
                 ChangeTag::Insert => "+",
                 ChangeTag::Equal => " ",
             };
-            println!("{} {}", sign, change);
+            eprintln!("{} {}", sign, change);
         }
     } else {
-        println!("snapshots are equal");
+        eprintln!("snapshots are equal");
     }
     are_snapshots_equal
 }
@@ -707,7 +794,7 @@ fn install_promscale_ext(client: &mut Client, version: &Version) {
 }
 
 fn update_extension(
-    container: &PostgresContainer,
+    container_id: &str,
     username: &str,
     db: &str,
     extension: &str,
@@ -715,7 +802,7 @@ fn update_extension(
 ) {
     let exit = Command::new("docker")
         .arg("exec")
-        .arg(container.id())
+        .arg(&container_id)
         .arg("psql")
         .args(["-U", username])
         .args(["-d", db])

--- a/e2e/tests/upgrade-test.rs
+++ b/e2e/tests/upgrade-test.rs
@@ -76,22 +76,7 @@ fn test_upgrade(from_version: FromVersion, with_data: bool) {
     // set up some working directories
     let script_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/scripts");
 
-    //let working_dir = match env::var("GITHUB_WORKSPACE") {
-    //    Ok(v) => {
-    //        let mut pb = PathBuf::new();
-    //        pb.push(v);
-    //        pb
-    //    }
-    //    Err(_) => env::temp_dir(),
-    //}
-    //.join(temp_dir_name(&from_version, with_data));
-
     let working_dir = env::temp_dir().join(temp_dir_name(&from_version, with_data));
-
-    //let mut working_dir = PathBuf::new();
-    //working_dir.push("/tmp");
-    //working_dir.push(temp_dir_name(&from_version, with_data));
-
     if working_dir.exists() {
         remove_dir_all(&working_dir).expect("failed to remove working dir");
     }
@@ -199,45 +184,11 @@ fn test_upgrade(from_version: FromVersion, with_data: bool) {
         from_client
             .execute("checkpoint", &[])
             .expect("failed to checkpoint");
-
-        //println!("{}", format!("chmod 0777 {}", data_dir));
-        //let cmd = ExecCommand {
-        //    cmd: format!("chmod 0777 {}", data_dir),
-        //    ready_conditions: vec![WaitFor::seconds(1)],
-        //};
-        //from_container.exec(cmd);
-
-        //let exit = Command::new("docker")
-        //    .arg("exec")
-        //    .arg(from_container.id())
-        //    .arg("chmod")
-        //    .arg("0777")
-        //    .arg(format!("{}", data_dir))
-        //    .spawn()
-        //    .unwrap()
-        //    .wait()
-        //    .unwrap();
-        //assert!(
-        //    exit.success(),
-        //    "executing chmod 0777 {} failed: {}",
-        //    data_dir,
-        //    exit
-        //);
-        println!(
-            "{} files in {} just BEFORE stopping container",
-            dir_contents(&Path::new(data_dir)),
-            data_dir
-        );
         from_container.stop();
         from_timescaledb_version
     };
-    println!(
-        "{} files in {} just AFTER stopping container",
-        dir_contents(&Path::new(data_dir)),
-        data_dir
-    );
 
-    set_permissions(&data_dir, permissions).expect("failed to chmod 0o777 on the data directory");
+    //set_permissions(&data_dir, permissions).expect("failed to chmod 0o777 on the data directory");
 
     // create a container using the target image
     // map postgres' data dir to the same temp dir from before
@@ -326,6 +277,7 @@ fn temp_dir_name(from_version: &FromVersion, with_data: bool) -> String {
     )
 }
 
+#[allow(dead_code)]
 fn dir_contents(dir: &Path) -> i64 {
     fn recurse(d: &Path, mut c: i64) -> i64 {
         if d.is_dir() {

--- a/test-common/src/postgres_container/mod.rs
+++ b/test-common/src/postgres_container/mod.rs
@@ -28,7 +28,7 @@ pub enum PgVersion {
 pub fn postgres_image_uri(origin: ImageOrigin, version: PgVersion) -> String {
     let prefix = match origin {
         ImageOrigin::Local => "local/dev_promscale_extension:head-ts2-",
-        ImageOrigin::Latest => "timescaledev/promscale-extension:latest-ts2.7.0-",
+        ImageOrigin::Latest => "timescaledev/promscale-extension:latest-ts2-",
         ImageOrigin::Master => "ghcr.io/timescale/dev_promscale_extension:master-ts2-",
     };
     let version = match version {


### PR DESCRIPTION
## Description

When testing the upgrade process, we want to use the "latest" image to create the version of the extension that we will be upgrading from. We want to use the local image by default or the one specified via env var to do the upgrade to the latest version.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation