### PR TITLE
Prevent ps_trace.delete_all_traces() when Promscale connector running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ We use the following categories for changes:
 
 ## [Unreleased]
 
+### Changed
+
+- `ps_trace.delete_all_traces()` can only be executed when no Promscale connectors are running [#437].
+
 ## [0.5.4] - 2022-07-18
 
 Due to a critical bug in upgrading to 0.5.3, we're skipping version 0.5.3 and

--- a/e2e/tests/ps_trace_delete_all_traces.rs
+++ b/e2e/tests/ps_trace_delete_all_traces.rs
@@ -1,0 +1,35 @@
+use test_common::PostgresContainerBlueprint;
+use test_common::{new_test_container_instance, PostgresTestInstance};
+
+#[test]
+fn delete_all_traces_blocks_if_advisory_lock_already_taken() {
+    let _ = pretty_env_logger::try_init();
+    let pg_blueprint = PostgresContainerBlueprint::new();
+    let test_pg_instance = new_test_container_instance(&pg_blueprint);
+    let mut conn_one = test_pg_instance.connect();
+    let mut conn_two = test_pg_instance.connect();
+
+    let result = conn_one
+        .simple_query("CREATE EXTENSION promscale;")
+        .unwrap();
+    assert_eq!(result.len(), 1);
+    let result = conn_one
+        .query("SELECT pg_advisory_lock(5585198506344173278);", &[])
+        .unwrap();
+    assert_eq!(result.len(), 1);
+
+    // Set statement timeout low, because we expect the following query to block on the advisory lock
+    let result = conn_two
+        .simple_query("SET statement_timeout=1000;")
+        .unwrap();
+    assert_eq!(result.len(), 1);
+
+    let result = conn_two.query("SELECT ps_trace.delete_all_traces();", &[]);
+
+    assert!(result.is_err());
+    let error = result.expect_err("expected error");
+    assert_eq!(
+        error.as_db_error().unwrap().message(),
+        "canceling statement due to statement timeout"
+    );
+}

--- a/sql-tests/testdata/ps_trace.delete_all_traces.sql
+++ b/sql-tests/testdata/ps_trace.delete_all_traces.sql
@@ -1,0 +1,86 @@
+\unset ECHO
+\set QUIET 1
+\i '/testdata/scripts/pgtap-1.2.0.sql'
+
+SELECT * FROM plan(16);
+
+CREATE EXTENSION promscale;
+
+INSERT INTO _ps_trace.schema_url (url)
+VALUES ('fake.url.com');
+
+INSERT INTO _ps_trace.instrumentation_lib (name, version, schema_url_id)
+    (
+        SELECT 'inst_lib_1', '1.0.0', id
+        FROM _ps_trace.schema_url
+        WHERE url = 'fake.url.com'
+        LIMIT 1
+    );
+
+SELECT ps_trace.put_operation('my.service.name', 'my.span.name', 'unspecified');
+
+SELECT ps_trace.put_tag_key('my.tag.key', 1::ps_trace.tag_type);
+
+SELECT ps_trace.put_tag('my.tag.key', 'true'::jsonb, 1::ps_trace.tag_type);
+
+INSERT INTO _ps_trace.span
+(trace_id, span_id, parent_span_id, operation_id, start_time, end_time, duration_ms, span_tags, status_code,
+ resource_tags, resource_schema_url_id)
+VALUES ('3dadb2bf-0035-433e-b74b-9075cc9260e8',
+        1234,
+        null,
+        -1,
+        now(),
+        now(),
+        0,
+        '{}'::jsonb::tag_map,
+        'ok',
+        '{}'::jsonb::tag_map,
+        -1);
+
+INSERT INTO _ps_trace.link
+(trace_id, span_id, span_start_time, linked_trace_id, linked_span_id, link_nbr, trace_state,
+ tags, dropped_tags_count)
+SELECT s.trace_id,
+       s.span_id,
+       s.start_time,
+       s.trace_id,
+       s.span_id,
+       1,
+       'OK',
+       '{}'::jsonb::tag_map,
+       0
+FROM _ps_trace.span s;
+
+INSERT INTO _ps_trace.event
+(time, trace_id, span_id, event_nbr, name, tags, dropped_tags_count)
+SELECT now(),
+       s.trace_id,
+       s.span_id,
+       1,
+       'my.event',
+       '{}'::jsonb::tag_map,
+       0
+FROM _ps_trace.span s;
+
+SELECT is(count(*), 1::BIGINT, '_ps_trace.schema_url has 1 row') FROM _ps_trace.schema_url;
+SELECT is(count(*), 1::BIGINT, '_ps_trace.instrumentation_lib has 1 row') FROM _ps_trace.instrumentation_lib;
+SELECT is(count(*), 1::BIGINT, '_ps_trace.operation has 1 row') FROM _ps_trace.operation;
+SELECT is(count(*), 1::BIGINT, '_ps_trace.tag_key has 1 row') FROM _ps_trace.tag_key WHERE id >= 1000;
+SELECT is(count(*), 2::BIGINT, '_ps_trace.tag has 2 rows') FROM _ps_trace.tag;
+SELECT is(count(*), 1::BIGINT, '_ps_trace.span has 1 row') FROM _ps_trace.span;
+SELECT is(count(*), 1::BIGINT, '_ps_trace.link has 1 row') FROM _ps_trace.link;
+SELECT is(count(*), 1::BIGINT, '_ps_trace.event has 1 row') FROM _ps_trace.event;
+
+SELECT ps_trace.delete_all_traces();
+
+SELECT is(count(*), 0::BIGINT, '_ps_trace.schema_url has 0 rows') FROM _ps_trace.schema_url;
+SELECT is(count(*), 0::BIGINT, '_ps_trace.instrumentation_lib has 0 rows') FROM _ps_trace.instrumentation_lib;
+SELECT is(count(*), 0::BIGINT, '_ps_trace.operation has 0 rows') FROM _ps_trace.operation;
+SELECT is(count(*), 0::BIGINT, '_ps_trace.tag_key has 0 rows') FROM _ps_trace.tag_key WHERE id >= 1000;
+SELECT is(count(*), 0::BIGINT, '_ps_trace.tag has 0 rows') FROM _ps_trace.tag;
+SELECT is(count(*), 0::BIGINT, '_ps_trace.span has 0 rows') FROM _ps_trace.span;
+SELECT is(count(*), 0::BIGINT, '_ps_trace.link has 0 rows') FROM _ps_trace.link;
+SELECT is(count(*), 0::BIGINT, '_ps_trace.event has 0 rows') FROM _ps_trace.event;
+
+SELECT * FROM finish(true);

--- a/sql-tests/tests/snapshots/tests__testdata__ps_trace.delete_all_traces.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__ps_trace.delete_all_traces.sql.snap
@@ -1,0 +1,115 @@
+---
+source: sql-tests/tests/tests.rs
+expression: query_result
+---
+ plan  
+-------
+ 1..16
+(1 row)
+
+ put_operation 
+---------------
+             1
+(1 row)
+
+ put_tag_key 
+-------------
+        1001
+(1 row)
+
+ put_tag 
+---------
+       2
+(1 row)
+
+                  is                   
+---------------------------------------
+ ok 1 - _ps_trace.schema_url has 1 row
+(1 row)
+
+                       is                       
+------------------------------------------------
+ ok 2 - _ps_trace.instrumentation_lib has 1 row
+(1 row)
+
+                  is                  
+--------------------------------------
+ ok 3 - _ps_trace.operation has 1 row
+(1 row)
+
+                 is                 
+------------------------------------
+ ok 4 - _ps_trace.tag_key has 1 row
+(1 row)
+
+               is                
+---------------------------------
+ ok 5 - _ps_trace.tag has 2 rows
+(1 row)
+
+               is                
+---------------------------------
+ ok 6 - _ps_trace.span has 1 row
+(1 row)
+
+               is                
+---------------------------------
+ ok 7 - _ps_trace.link has 1 row
+(1 row)
+
+                is                
+----------------------------------
+ ok 8 - _ps_trace.event has 1 row
+(1 row)
+
+psql:/testdata/ps_trace.delete_all_traces.sql:75: NOTICE:  truncate cascades to table "instrumentation_lib"
+ delete_all_traces 
+-------------------
+ 
+(1 row)
+
+                   is                   
+----------------------------------------
+ ok 9 - _ps_trace.schema_url has 0 rows
+(1 row)
+
+                        is                        
+--------------------------------------------------
+ ok 10 - _ps_trace.instrumentation_lib has 0 rows
+(1 row)
+
+                   is                   
+----------------------------------------
+ ok 11 - _ps_trace.operation has 0 rows
+(1 row)
+
+                  is                  
+--------------------------------------
+ ok 12 - _ps_trace.tag_key has 0 rows
+(1 row)
+
+                is                
+----------------------------------
+ ok 13 - _ps_trace.tag has 0 rows
+(1 row)
+
+                is                 
+-----------------------------------
+ ok 14 - _ps_trace.span has 0 rows
+(1 row)
+
+                is                 
+-----------------------------------
+ ok 15 - _ps_trace.link has 0 rows
+(1 row)
+
+                 is                 
+------------------------------------
+ ok 16 - _ps_trace.event has 0 rows
+(1 row)
+
+ finish 
+--------
+(0 rows)
+
+


### PR DESCRIPTION
## Description

The Promscale connector caches trace tags, schema_urls, operations, and
instrumentation_libs. If these values are removed from the database
while the connector is running, it will insert corrupted data.

Closes https://github.com/timescale/promscale/issues/1518.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation https://github.com/timescale/docs/pull/1338