### PR TITLE
Bump ha dockerfile base to Ubuntu 22.04

### DIFF
--- a/ha.Dockerfile
+++ b/ha.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.3-labs
 ARG PG_VERSION=14
 ARG TIMESCALEDB_VERSION_MAJMIN=2.6
-FROM ubuntu:21.10 as builder
+FROM ubuntu:22.04 as builder
 ARG PG_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Description

Ubuntu 21.10 is EOL, we can no longer build from it.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~