### PR TITLE
Build with timescaledb 2.7.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PG_RELEASE_VERSION ?= $(shell ${PG_CONFIG} --version | awk -F'[ \. ]' '{print $$
 PG_BUILD_VERSION = $(shell ${PG_CONFIG} --version | awk -F'[ \. ]' '{print $$2}')
 # If set to a non-empty value, docker builds will be pushed to the registry
 PUSH ?=
-TIMESCALEDB_VERSION_FULL=2.7.0
+TIMESCALEDB_VERSION_FULL=2.7.2
 TIMESCALEDB_VERSION_MAJMIN=$(shell echo $(TIMESCALEDB_VERSION_FULL) | cut -d. -f 1,2)
 TIMESCALEDB_VERSION_MAJOR=$(shell echo $(TIMESCALEDB_VERSION_FULL) | cut -d. -f 1)
 TS_DOCKER_IMAGE ?= local/dev_promscale_extension:head-ts2-pg14

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3-labs
 ARG PG_VERSION=14
-ARG TIMESCALEDB_VERSION_FULL=2.7.0
+ARG TIMESCALEDB_VERSION_FULL=2.7.2
 ARG PREVIOUS_IMAGE=timescaledev/promscale-extension:latest-ts2-pg${PG_VERSION}
 FROM timescale/timescaledb:${TIMESCALEDB_VERSION_FULL}-pg${PG_VERSION} as builder
 


### PR DESCRIPTION
## Description

The Makefile and alpine.Dockerfile needed the timescaledb version to be bumped to 2.7.2

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation