### PR TITLE
Remove unnecessary warning

### DIFF
--- a/templates/incremental-wrapper.sql
+++ b/templates/incremental-wrapper.sql
@@ -14,8 +14,9 @@ BEGIN
     WHERE name = _migration.name;
     IF _migration_name IS NOT NULL THEN
         RAISE LOG 'Migration "{{filename}}" already applied, skipping';
-        IF _body_differs THEN
-            RAISE WARNING 'Checksum of migration "{{filename}}" has changed';
+        -- 001-extension.sql changes are expected until this issue is resolved: https://github.com/timescale/promscale_extension/issues/350
+        IF _body_differs AND _migration_name != '001-extension.sql' THEN
+            RAISE WARNING 'The contents of migration "{{filename}}" have changed';
         END IF;
         RETURN;
     END IF;


### PR DESCRIPTION
## Description

The 001-extension.sql migration is expected to change. It references the versioned .so file which changes with each version. No need to warn about expected behavior.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation