### PR TITLE
Dockerless SQL tests

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -95,6 +95,7 @@ jobs:
           args: -p sql-tests
         env:
           TS_DOCKER_IMAGE: ghcr.io/timescale/dev_promscale_extension:${{steps.metadata.outputs.image_branch_name}}-ts${{matrix.tsversion}}-pg${{matrix.pgversion}}${{steps.metadata.outputs.build_type_suffix}}
+          USE_DOCKER: true
 
       - name: Check SQL Documentation
         if: ${{ matrix.pgversion == 14 && matrix.base == 'ha' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,10 @@ codegen-units = 1
 [profile.dev]
 panic = "unwind"
 # It's currently broken on Apple Silicon. 1.64 seems to include a fix.
-# lto = "thin"
+# If your tests fail with SIGSEGV try and use 1.64 or newer.
+# Sadly, we can't just drop it because it's a workaround for
+# another issue https://github.com/tcdi/pgx/pull/208
+lto = "thin"
 
 [features]
 default = ["pg14", "serde_json", "proptest"] # used by rust-analyzer in VSCode

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development
 
-This document covers important topics for developing in this repository.
+This document covers important topics for contributing to this repository.
 
 ## Development environment
 
@@ -17,7 +17,7 @@ Run `make devenv` to build the docker image, start it, and expose it on port
 into the `/code` directory in the container. By default, it runs postgres 14
 and continually recompiles and reinstalls the promscale extension on source
 modifications. This means that you can edit the sources locally, and run SQL 
-tests against the container: `make dev-sql-tests`.
+tests against the container.
 
 You can adjust the postgres version through the `DEVENV_PG_VERSION` env var,
 for example: `DEVENV_PG_VERSION=12 make devenv`
@@ -35,43 +35,56 @@ convenient formats, for example:
 To permanently configure `POSTGRES_URL` when you change into this directory,
 you may consider using a tool like [direnv](https://direnv.net/).
 
-## Updating public API documentation
+## Modifying and testing SQL migrations
+
+All SQL source code resides in `./migration` subdirectory. (The `./sql` subdirectory
+contains nothing but generated code and symlinks.) Our general approach to writing
+migrations is documented [here](./migration/README.md). Please, give it a read before
+proceeding further.
+
+### Running SQL tests
+
+After you modified or added migration tests can be executed in the devcontainer
+by running `make dev-sql-tests`. Our approach to adding tests is described 
+[below](#testing).
+
+### Updating public API documentation
 
 Our CI validates `./docs/sql-api.md` is up to date. If you added a new function
-you can update it by running `make dev-gendoc`. Note: it relies on the devcontainer.
+you can update the docs by running `make dev-gendoc`.
+Note: it relies on the devcontainer.
 
 ## Testing
 
 Testing in this repository is split into three different kinds of tests, each
 of which are found in their own directory or workspace:
 
-- pgx tests
+- PGX tests
 - End-to-end SQL tests
 - End-to-end Rust tests
 
-pgx tests are found in the `src` directory, typically in the same source file
+PGX tests are found in the `src` directory, typically in the same source file
 as a function defined in Rust. These tests are solely intended to test the
 behaviour of Postgres functions implemented in Rust.
 
 End-to-end SQL tests are found in the `sql-tests` workspace, in the `testdata`
 directory. The tests are written in SQL and intended to be used to test
-functions which we write in SQL (in the `migration` directory), or complex
-interactions involving both SQL and native functions. Each SQL file  is run
+functions we write in SQL (in the `migration` directory), or complex
+interactions involving both SQL and native functions. Each SQL file is run
 against a test database, but the test has no control over database or
 connection creation, so it is not possible to test certain behaviours. For more
 information, see the [README](sql-tests/README.md).
 
 End-to-end Rust tests are found in the `e2e` directory. They are intended to
 be used as an upgrade to end-to-end SQL tests, as the test has full control
-over test setup, can create multiple connections. For more information, see the
-[README](e2e/README.md).
+over test setup, and can create multiple connections. For more information,
+see the [README](e2e/README.md).
 
 ### Which test method to use?
 
-If you're adding a Rust function, use pgx tests. If you're adding/testing a
+If you're adding a Rust function, use PGX tests. If you're adding/testing a
 SQL migration, try to test it with an end-to-end SQL test. If that is not
 possible, write it as an end-to-end Rust test.
-
 
 ### Running PGX tests
 
@@ -85,3 +98,16 @@ Firstly, you'll need to install and configure PGX:
 Then you can run PGX tests by executing: `cargo pgx test`. If you need to run
 them against a specific PostgreSQL version you can use a corresponding feature 
 flag: `cargo pgx test pg12`.
+
+### Running end-to-end Rust tests
+
+End-to-end tests rely on a docker image that needs to contain PostgreSQL with both
+TimescaleDB and Promscale extensions. You can either obtain that image from CI or
+build it yourself: `make docker-image-14` (there are also targets for 12 and 13).
+
+If you have already built a local docker image and your changes are limited to
+SQL migrations there is also `make docker-quick-NN` family of targets. It's faster
+but could be finicky.
+
+To run the e2e tests against the locally build image run: `cargo test -p e2e`.
+Further details could be found in the [corresponding document](./e2e/README.md).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,7 +17,7 @@ Run `make devenv` to build the docker image, start it, and expose it on port
 into the `/code` directory in the container. By default, it runs postgres 14
 and continually recompiles and reinstalls the promscale extension on source
 modifications. This means that you can edit the sources locally, and run SQL 
-tests against the container: `make sql-tests`.
+tests against the container: `make dev-sql-tests`.
 
 You can adjust the postgres version through the `DEVENV_PG_VERSION` env var,
 for example: `DEVENV_PG_VERSION=12 make devenv`
@@ -38,7 +38,7 @@ you may consider using a tool like [direnv](https://direnv.net/).
 ## Updating public API documentation
 
 Our CI validates `./docs/sql-api.md` is up to date. If you added a new function
-you can update it by running `make gendoc`. By default it will use the devenv container.
+you can update it by running `make dev-gendoc`. Note: it relies on the devcontainer.
 
 ## Testing
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,13 +10,14 @@ with timescaledb, and Rust dependencies. For more information, see the
 
 To spare you the effort of getting this set up yourself, we provide a docker
 image with all required dependencies, which allows you to just get started.
+Although, `make` and `cargo` have to be installed on the host system nonetheless.
 
 Run `make devenv` to build the docker image, start it, and expose it on port
 54321 on your local machine. This docker image mounts the current directory
 into the `/code` directory in the container. By default, it runs postgres 14
 and continually recompiles and reinstalls the promscale extension on source
-modifications. This means that you can edit the sources locally, and run tests
-against the container.
+modifications. This means that you can edit the sources locally, and run SQL 
+tests against the container: `make sql-tests`.
 
 You can adjust the postgres version through the `DEVENV_PG_VERSION` env var,
 for example: `DEVENV_PG_VERSION=12 make devenv`
@@ -29,10 +30,15 @@ The `devenv-url` and `devenv-export-url` make targets output the URL above in
 convenient formats, for example:
 
 - To connect to the devenv db with psql: `psql $(make devenv-url)`
-- To set the `POSTGRES_URL` for all subshells: `eval $(make devenv-export-url`
+- To set the `POSTGRES_URL` for all subshells: `eval $(make devenv-export-url)`
 
 To permanently configure `POSTGRES_URL` when you change into this directory,
 you may consider using a tool like [direnv](https://direnv.net/).
+
+## Updating public API documentation
+
+Our CI validates `./docs/sql-api.md` is up to date. If you added a new function
+you can update it by running `make gendoc`. By default it will use the devenv container.
 
 ## Testing
 
@@ -65,3 +71,17 @@ over test setup, can create multiple connections. For more information, see the
 If you're adding a Rust function, use pgx tests. If you're adding/testing a
 SQL migration, try to test it with an end-to-end SQL test. If that is not
 possible, write it as an end-to-end Rust test.
+
+
+### Running PGX tests
+
+If you need to modify Rust code you should also run corresponding tests.
+Unfortunately, our dev environment doesn't handle this yet.
+
+Firstly, you'll need to install and configure PGX:
+- `cargo install cargo-pgx --git https://github.com/timescale/pgx --branch promscale-staging --rev ee52db6b` (the branch and rev are subject to change)
+- `cargo pgx init`
+
+Then you can run PGX tests by executing: `cargo pgx test`. If you need to run
+them against a specific PostgreSQL version you can use a corresponding feature 
+flag: `cargo pgx test pg12`.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -92,7 +92,7 @@ If you need to modify Rust code you should also run corresponding tests.
 Unfortunately, our dev environment doesn't handle this yet.
 
 Firstly, you'll need to install and configure PGX:
-- `cargo install cargo-pgx --git https://github.com/timescale/pgx --branch promscale-staging --rev ee52db6b` (the branch and rev are subject to change)
+- `./install-cargo-pgx.sh`
 - `cargo pgx init`
 
 Then you can run PGX tests by executing: `cargo pgx test`. If you need to run

--- a/Makefile
+++ b/Makefile
@@ -262,6 +262,6 @@ DEVENV_EXEC ?= docker exec -it -e POSTGRES_URL=postgres://ubuntu@localhost:${DEV
 dev-sql-tests:
 	${DEVENV_EXEC} make sql-tests
 
-.PHONY: dev-dendoc
+.PHONY: dev-gendoc
 dev-gendoc:
 	${DEVENV_EXEC} make gendoc

--- a/sql-tests/README.md
+++ b/sql-tests/README.md
@@ -5,11 +5,25 @@ the usage of `pgtap.sql` is highly encouraged.
 
 ## Running tests
 
-Run the tests with `cargo test -p sql-tests`. The tests are run against a docker image. Set the value of
-the `TS_DOCKER_IMAGE` env var to override the default docker image, e.g.:
+Run the tests with `cargo test -p sql-tests`.  By default, the tests are run
+against `localhost:5432`. You can override it either by specifying
+`POSTGRES_URL` or a combination of `POSTGRES_USER`, `POSTGRES_HOST`, `POSTGRES_PORT`
+and `POSTGRES_DB` environment variables.
 
 ```
-TS_DOCKER_IMAGE=ghcr.io/timescale/dev_promscale_extension:master-ts2-pg13 cargo test -p e2e
+POSTGRES_URL=postgres://ubuntu@localhost:54321/ cargo test -p sql-tests
+```
+
+or
+
+```
+POSTGRES_USER=postgres POSTGRES_HOST=localhost POSTGRES_PORT=5432 cargo test -p sql-tests
+```
+
+The tests are run against a docker image. Set the value of the `TS_DOCKER_IMAGE` env var to override the default docker image, e.g.:
+
+```
+TS_DOCKER_IMAGE=ghcr.io/timescale/dev_promscale_extension:master-ts2-pg13 cargo test -p sql-tests
 ```
 
 ## SQL Snapshot tests

--- a/sql-tests/README.md
+++ b/sql-tests/README.md
@@ -20,7 +20,7 @@ or
 POSTGRES_USER=postgres POSTGRES_HOST=localhost POSTGRES_PORT=5432 cargo test -p sql-tests
 ```
 
-The tests are run against a docker image. Set the value of the `TS_DOCKER_IMAGE` env var to override the default docker image, e.g.:
+To run the tests against a docker image set the value of the `TS_DOCKER_IMAGE` to the desired docker image, e.g.:
 
 ```
 TS_DOCKER_IMAGE=ghcr.io/timescale/dev_promscale_extension:master-ts2-pg13 cargo test -p sql-tests

--- a/sql-tests/testdata/create_ingest_temp_table.sql
+++ b/sql-tests/testdata/create_ingest_temp_table.sql
@@ -1,8 +1,6 @@
 \unset ECHO
 \set QUIET 1
-\i '/testdata/scripts/pgtap-1.2.0.sql'
-
-CREATE EXTENSION promscale;
+\i 'testdata/scripts/pgtap-1.2.0.sql'
 
 CREATE TEMP TABLE test_data(metric_name TEXT, prefix TEXT);
 

--- a/sql-tests/testdata/defaults.sql
+++ b/sql-tests/testdata/defaults.sql
@@ -1,6 +1,5 @@
 \set ECHO all
 \set ON_ERROR_STOP 1
-create extension promscale;
 
 \echo make sure the view returns what we expect it to
 select key, value

--- a/sql-tests/testdata/drop_metric.sql
+++ b/sql-tests/testdata/drop_metric.sql
@@ -1,10 +1,8 @@
 \unset ECHO
 \set QUIET 1
-\i '/testdata/scripts/pgtap-1.2.0.sql'
+\i 'testdata/scripts/pgtap-1.2.0.sql'
 
 SELECT * FROM plan(49);
-CREATE EXTENSION promscale;
-
 --
 -- Moved from TestSQLDropMetricChunk
 --

--- a/sql-tests/testdata/info_view.sql
+++ b/sql-tests/testdata/info_view.sql
@@ -1,8 +1,6 @@
 \set ECHO all
 \set ON_ERROR_STOP 1
 
-CREATE EXTENSION promscale;
-
 SELECT _prom_catalog.get_or_create_metric_table_name('cpu_usage');
 SELECT _prom_catalog.get_or_create_metric_table_name('cpu_total');
 CALL _prom_catalog.finalize_metric_creation();

--- a/sql-tests/testdata/large_tracing_tags_support.sql
+++ b/sql-tests/testdata/large_tracing_tags_support.sql
@@ -1,8 +1,6 @@
 \set ECHO all
 \set ON_ERROR_STOP 1
 
-CREATE EXTENSION promscale;
-
 -- We don't want retention to mess with the test data
 SELECT ps_trace.set_trace_retention_period('100 years'::INTERVAL);
 

--- a/sql-tests/testdata/metric-retention.sql
+++ b/sql-tests/testdata/metric-retention.sql
@@ -1,10 +1,8 @@
 \unset ECHO
 \set QUIET 1
-\i '/testdata/scripts/pgtap-1.2.0.sql'
+\i 'testdata/scripts/pgtap-1.2.0.sql'
 
 SELECT * FROM plan(4);
-
-CREATE EXTENSION promscale;
 
 SELECT is(prom_api.get_default_metric_retention_period(), '90 days'::INTERVAL, 'default metric retention period is 90 days');
 

--- a/sql-tests/testdata/ps_trace.delete_all_traces.sql
+++ b/sql-tests/testdata/ps_trace.delete_all_traces.sql
@@ -1,10 +1,8 @@
 \unset ECHO
 \set QUIET 1
-\i '/testdata/scripts/pgtap-1.2.0.sql'
+\i 'testdata/scripts/pgtap-1.2.0.sql'
 
 SELECT * FROM plan(16);
-
-CREATE EXTENSION promscale;
 
 INSERT INTO _ps_trace.schema_url (url)
 VALUES ('fake.url.com');

--- a/sql-tests/testdata/support.sql
+++ b/sql-tests/testdata/support.sql
@@ -1,8 +1,6 @@
 \set ECHO all
 \set ON_ERROR_STOP 1
 
-CREATE EXTENSION promscale;
-
 SELECT _prom_catalog.get_or_create_metric_table_name('cpu_usage');
 SELECT _prom_catalog.get_or_create_metric_table_name('cpu_total');
 CALL _prom_catalog.finalize_metric_creation();

--- a/sql-tests/testdata/tag_map.sql
+++ b/sql-tests/testdata/tag_map.sql
@@ -1,7 +1,5 @@
 \set ECHO all
 
-CREATE EXTENSION promscale;
-
 -- We don't want retention to mess with the test data
 SELECT ps_trace.set_trace_retention_period('100 years'::INTERVAL);
 

--- a/sql-tests/testdata/trace_compression.sql
+++ b/sql-tests/testdata/trace_compression.sql
@@ -1,8 +1,6 @@
 \set ECHO all
 \set ON_ERROR_STOP 1
 
-CREATE EXTENSION promscale;
-
 -- We don't want retention to mess with the test data
 SELECT ps_trace.set_trace_retention_period('100 years'::INTERVAL);
 

--- a/sql-tests/testdata/views.sql
+++ b/sql-tests/testdata/views.sql
@@ -1,8 +1,6 @@
 \set ECHO all
 \set ON_ERROR_STOP 1
 
-CREATE EXTENSION promscale;
-
 SELECT _prom_catalog.get_or_create_metric_table_name('cpu_usage');
 SELECT _prom_catalog.get_or_create_metric_table_name('cpu_total');
 CALL _prom_catalog.finalize_metric_creation();

--- a/sql-tests/tests/snapshots/tests__testdata__defaults.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__defaults.sql.snap
@@ -1,10 +1,8 @@
 ---
-source: e2e/tests/golden-tests.rs
+source: sql-tests/tests/tests.rs
 expression: query_result
 ---
 \set ON_ERROR_STOP 1
-create extension promscale;
-CREATE EXTENSION
 \echo make sure the view returns what we expect it to
 make sure the view returns what we expect it to
 select key, value

--- a/sql-tests/tests/snapshots/tests__testdata__info_view.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__info_view.sql.snap
@@ -1,10 +1,8 @@
 ---
-source: e2e/tests/golden-tests.rs
+source: sql-tests/tests/tests.rs
 expression: query_result
 ---
 \set ON_ERROR_STOP 1
-CREATE EXTENSION promscale;
-CREATE EXTENSION
 SELECT _prom_catalog.get_or_create_metric_table_name('cpu_usage');
  get_or_create_metric_table_name 
 ---------------------------------

--- a/sql-tests/tests/snapshots/tests__testdata__large_tracing_tags_support.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__large_tracing_tags_support.sql.snap
@@ -1,10 +1,8 @@
 ---
-source: e2e/tests/golden-tests.rs
+source: sql-tests/tests/tests.rs
 expression: query_result
 ---
 \set ON_ERROR_STOP 1
-CREATE EXTENSION promscale;
-CREATE EXTENSION
 -- We don't want retention to mess with the test data
 SELECT ps_trace.set_trace_retention_period('100 years'::INTERVAL);
  set_trace_retention_period 

--- a/sql-tests/tests/snapshots/tests__testdata__ps_trace.delete_all_traces.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__ps_trace.delete_all_traces.sql.snap
@@ -62,7 +62,7 @@ expression: query_result
  ok 8 - _ps_trace.event has 1 row
 (1 row)
 
-psql:/testdata/ps_trace.delete_all_traces.sql:75: NOTICE:  truncate cascades to table "instrumentation_lib"
+psql:testdata/ps_trace.delete_all_traces.sql:73: NOTICE:  truncate cascades to table "instrumentation_lib"
  delete_all_traces 
 -------------------
  

--- a/sql-tests/tests/snapshots/tests__testdata__support.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__support.sql.snap
@@ -1,10 +1,8 @@
 ---
-source: e2e/tests/golden-tests.rs
+source: sql-tests/tests/tests.rs
 expression: query_result
 ---
 \set ON_ERROR_STOP 1
-CREATE EXTENSION promscale;
-CREATE EXTENSION
 SELECT _prom_catalog.get_or_create_metric_table_name('cpu_usage');
  get_or_create_metric_table_name 
 ---------------------------------

--- a/sql-tests/tests/snapshots/tests__testdata__tag_map.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__tag_map.sql.snap
@@ -1,9 +1,7 @@
 ---
-source: e2e/tests/golden-tests.rs
+source: sql-tests/tests/tests.rs
 expression: query_result
 ---
-CREATE EXTENSION promscale;
-CREATE EXTENSION
 -- We don't want retention to mess with the test data
 SELECT ps_trace.set_trace_retention_period('100 years'::INTERVAL);
  set_trace_retention_period 

--- a/sql-tests/tests/snapshots/tests__testdata__trace_compression.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__trace_compression.sql.snap
@@ -1,10 +1,8 @@
 ---
-source: e2e/tests/golden-tests.rs
+source: sql-tests/tests/tests.rs
 expression: query_result
 ---
 \set ON_ERROR_STOP 1
-CREATE EXTENSION promscale;
-CREATE EXTENSION
 -- We don't want retention to mess with the test data
 SELECT ps_trace.set_trace_retention_period('100 years'::INTERVAL);
  set_trace_retention_period 

--- a/sql-tests/tests/snapshots/tests__testdata__views.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__views.sql.snap
@@ -1,10 +1,8 @@
 ---
-source: e2e/tests/golden-tests.rs
+source: sql-tests/tests/tests.rs
 expression: query_result
 ---
 \set ON_ERROR_STOP 1
-CREATE EXTENSION promscale;
-CREATE EXTENSION
 SELECT _prom_catalog.get_or_create_metric_table_name('cpu_usage');
  get_or_create_metric_table_name 
 ---------------------------------

--- a/sql-tests/tests/tests.rs
+++ b/sql-tests/tests/tests.rs
@@ -1,15 +1,40 @@
 use insta::assert_snapshot;
-use std::env;
+use std::{env, sync::{Mutex, Once}, mem::MaybeUninit};
 use test_common::*;
 use test_generator::test_resources;
 
 const TESTDATA: &'static str = concat!(env!("CARGO_MANIFEST_DIR"), "/testdata");
 
+fn init_lock() -> &'static Mutex<()> {
+    static mut SINGLETON: MaybeUninit<Mutex<()>> = MaybeUninit::uninit();
+    static ONCE: Once = Once::new();
+
+    unsafe {
+        ONCE.call_once(|| {
+            let singleton = Mutex::new(());
+            SINGLETON.write(singleton);
+        });
+
+        SINGLETON.assume_init_ref()
+    }
+}
+
 #[test_resources("testdata/*.sql")]
 fn sql_tests(resource: &str) {
     let pg_blueprint = PostgresContainerBlueprint::new().with_testdata(TESTDATA);
-    let test_pg_instance = new_test_container_instance(&pg_blueprint);
-    let query_result = test_pg_instance.exec_sql_script(resource);
+    let test_pg_instance = new_test_instance_from_env(&pg_blueprint);
+    let mut init_conn = test_pg_instance.connect();
+    // This lock prevents multiple callers from running 
+    // CREATE EXTENSION simultaneously. In case of
+    // promscale_extension concurrent CREATE EXTENSION causes
+    // issues when migration incremental/003-users.sql executes.
+    {
+        let _init_lock = init_lock().lock().unwrap();
+        init_conn
+            .simple_query("CREATE EXTENSION promscale;")
+            .expect("Unable to create extension promscale.");
+    }
 
+    let query_result = test_pg_instance.exec_sql_script(resource);
     assert_snapshot!(resource, query_result);
 }

--- a/sql-tests/tests/tests.rs
+++ b/sql-tests/tests/tests.rs
@@ -1,5 +1,9 @@
 use insta::assert_snapshot;
-use std::{env, sync::{Mutex, Once}, mem::MaybeUninit};
+use std::{
+    env,
+    mem::MaybeUninit,
+    sync::{Mutex, Once},
+};
 use test_common::*;
 use test_generator::test_resources;
 
@@ -24,7 +28,7 @@ fn sql_tests(resource: &str) {
     let pg_blueprint = PostgresContainerBlueprint::new().with_testdata(TESTDATA);
     let test_pg_instance = new_test_instance_from_env(&pg_blueprint);
     let mut init_conn = test_pg_instance.connect();
-    // This lock prevents multiple callers from running 
+    // This lock prevents multiple callers from running
     // CREATE EXTENSION simultaneously. In case of
     // promscale_extension concurrent CREATE EXTENSION causes
     // issues when migration incremental/003-users.sql executes.

--- a/test-common/src/test_container_instance.rs
+++ b/test-common/src/test_container_instance.rs
@@ -29,9 +29,10 @@ impl<'h> PostgresTestInstance for TestContainerInstance<'h> {
 
     fn exec_sql_script(&self, script_path: &str) -> String {
         let id = self.container.id();
-        let abs_script_path = "/".to_owned() + script_path;
         let output = Command::new("docker")
             .arg("exec")
+            .arg("-w")
+            .arg("/")
             .arg(id)
             .arg("bash")
             .arg("-c")
@@ -39,7 +40,7 @@ impl<'h> PostgresTestInstance for TestContainerInstance<'h> {
                 "psql -U {} -d {} -f {} 2>&1",
                 self.pg_blueprint.user(),
                 self.pg_blueprint.db(),
-                abs_script_path
+                script_path
             ))
             .stdout(Stdio::piped())
             .spawn()

--- a/test-common/src/test_container_instance.rs
+++ b/test-common/src/test_container_instance.rs
@@ -11,9 +11,10 @@ pub struct TestContainerInstance<'h> {
 
 impl<'pg_inst> TestContainerInstance<'pg_inst> {
     pub(crate) fn fresh_instance(pg_blueprint: &'pg_inst PostgresContainerBlueprint) -> Self {
+        let container = pg_blueprint.run();
         TestContainerInstance {
             pg_blueprint: pg_blueprint,
-            container: pg_blueprint.run(),
+            container: container,
         }
     }
 }


### PR DESCRIPTION
## Description

This is a somewhat slow but safe and predictable way to run sql-tests against a set connection string instead of one-off docker containers.

Resolves #276 

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation