### PR TITLE
Fix release build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,6 @@ jobs:
             - ubuntu/bionic
             - ubuntu/focal
             - ubuntu/jammy
-            - ubuntu/impish
           pkg_type: deb
         - name: linux
           distro: centos

--- a/dist/rpm.dockerfile
+++ b/dist/rpm.dockerfile
@@ -69,6 +69,8 @@ yum install -y \
 # Use UTFF-8 as the locale
 localedef -f UTF-8 -i en_US en_US.UTF-8
 
+# Pin dotenv gem because 2.8.0 is not compatible with earlier ruby
+gem install --version 2.7.6 dotenv
 # Install FPM
 gem install fpm
 


### PR DESCRIPTION
## Description

The recently-released version 2.8.0 of the dotenv gem dropped support
for older ruby installations, which we're using on CentOS.

Ubuntu Impish is EOL, so we can't test our debian package on it.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation