### PR TITLE
Use a faster linker in the devenv container

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -46,12 +46,15 @@ RUN sed -i "s#127.0.0.1/32#0.0.0.0/0#" ~/.pgx/data-{12,13,14}/pg_hba.conf
 # Disable telemetry
 RUN echo "timescaledb.telemetry_level=off" | tee -a ~/.pgx/data-{12,13,14}/postgresql.conf
 
-RUN sudo apt-get install -y vim
+RUN sudo apt-get install -y vim lld
 
 RUN mkdir -p ~/.cargo
 # Make cargo put compile artifacts in non-bind-mounted directory
 # To re-use compiled artifacts, mount a docker volume to /tmp/target
 RUN echo -e '[build]\ntarget-dir="/tmp/target"' > ~/.cargo/config.toml
+# Tell rustc to use a fast linker
+RUN echo 'rustflags=["-C", "link-arg=-fuse-ld=lld"]' >> ~/.cargo/config.toml
+
 # Sources should be bind-mounted to /code/
 WORKDIR /code/
 


### PR DESCRIPTION

## Description

Using lld instead of the default linker reduces recompile times when
only modifying SQL on an M1 mac from ~30s to ~2s.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~