### PR TITLE
Upgrade tests should use the latest image for prior version

### DIFF
--- a/e2e/tests/upgrade-test.rs
+++ b/e2e/tests/upgrade-test.rs
@@ -90,6 +90,27 @@ Variations we run:
 │ local │ alpine │ 14 │ without │ first │
 │ local │ alpine │ 14 │ without │ prior │
 └───────┴────────┴────┴─────────┴───────┘
+
+PGDATA:
+> This optional variable can be used to define another location - like a subdirectory - for the
+> database files. The default is /var/lib/postgresql/data. If the data volume you're using is a
+> filesystem mountpoint (like with GCE persistent disks) or remote folder that cannot be chowned to
+> the postgres user (like some NFS mounts), Postgres initdb recommends a subdirectory be created to
+> contain the data.
+>
+> For example:
+>
+> $ docker run -d \
+> 	--name some-postgres \
+> 	-e POSTGRES_PASSWORD=mysecretpassword \
+> 	-e PGDATA=/var/lib/postgresql/data/pgdata \
+> 	-v /custom/mount:/var/lib/postgresql/data \
+> 	postgres
+>
+> This is an environment variable that is not Docker specific. Because the variable is used by the
+> postgres server binary (see the PostgreSQL docs), the entrypoint script takes it into account.
+- https://hub.docker.com/_/postgres
+
 */
 
 enum FromVersion {


### PR DESCRIPTION
## Description

When testing the upgrade process, we want to use the "latest" image to create the version of the extension that we will be upgrading from. We want to use the local image by default or the one specified via env var to do the upgrade to the latest version.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation