### PR TITLE
Another attempt at fixing CI for third party PRs

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         env:
-          DOCKER_PUSH_REQUIRED: ${{ github.event.type != 'PullRequestEvent' || github.event.pull_request.head.repo.owner.login == 'timescale' }} # Don't run docker push when this is a PR from a fork
+          DOCKER_PUSH_REQUIRED: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'timescale' }} # Don't run docker push when this is a PR from a fork
         with:
           build-args: |
             PG_VERSION=${{ matrix.pgversion }}


### PR DESCRIPTION
## Description

A fix for the third-party pull request CI path. `github.event.type` doesn't seem to be set to anything, thus `github.event.type != 'PullRequestEvent'` always evaluates to `true`.
## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation