### PR TITLE
Don't fail metric deletion if some tables or views are missing

### DIFF
--- a/migration/idempotent/001-base.sql
+++ b/migration/idempotent/001-base.sql
@@ -980,10 +980,10 @@ $$
           RAISE '% is not a metric. unable to drop it.', metric_name_to_be_dropped;
         END IF;
         RAISE NOTICE 'deleting "%" metric with metric_id as "%" and table_name as "%"', metric_name_to_be_dropped, deletable_metric_id, hypertable_name;
-        EXECUTE FORMAT('DROP VIEW prom_series.%1$I;', hypertable_name);
-        EXECUTE FORMAT('DROP VIEW prom_metric.%1$I;', hypertable_name);
-        EXECUTE FORMAT('DROP TABLE prom_data_series.%1$I;', hypertable_name);
-        EXECUTE FORMAT('DROP TABLE prom_data.%1$I;', hypertable_name);
+        EXECUTE FORMAT('DROP VIEW IF EXISTS prom_series.%1$I;', hypertable_name);
+        EXECUTE FORMAT('DROP VIEW IF EXISTS prom_metric.%1$I;', hypertable_name);
+        EXECUTE FORMAT('DROP TABLE IF EXISTS prom_data_series.%1$I;', hypertable_name);
+        EXECUTE FORMAT('DROP TABLE IF EXISTS prom_data.%1$I;', hypertable_name);
         DELETE FROM _prom_catalog.metric WHERE id=deletable_metric_id;
         -- clean up unreferenced labels, label_keys and its position.
         DELETE FROM _prom_catalog.label_key_position WHERE metric_name=metric_name_to_be_dropped;


### PR DESCRIPTION
## Description

Due to a manual intervention to the database some tables or views for
metrics may be deleted. It's nice if `drop_metric` can still work in
this conditions and do a proper cleanup.

There was a previous attempt to pull it https://github.com/timescale/promscale_extension/pull/458.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation

The change looks minor and internal enough that it does not need to be communicated to end users.