### PR TITLE
Add matcher for textual representation of json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use the following categories for changes:
 ### Added
 
 - Added `prom_api.get_default_chunk_interval()` and `prom_api.get_metric_chunk_interval(TEXT)` [#464].
+- Added `_ps_trace.text_matches()` and `_ps_trace.tag_v_text_eq_matching_tags()` [#461]
 
 ### Fixed
 - Incorrect type coercion when using `tag_map` with `=` operator [#462]

--- a/docs/sql-api.md
+++ b/docs/sql-api.md
@@ -397,7 +397,7 @@ This function is a part of custom ps_trace.tag_map type which is a wrapper for t
 function tag_map **ps_trace.tag_map_in**(cstring)
 ```
 ### ps_trace.tag_map_object_field
-This function is a part of custom ps_trace.tag_map type which is a wrapper for 
+This function is a part of custom ps_trace.tag_map type which is a wrapper for
 the built-in jsonb. It is the same as its jsonb_ namesake, but returns _ps_trace.tag_v.
 ```
 function _ps_trace.tag_v **ps_trace.tag_map_object_field**(tag_map, text)
@@ -423,13 +423,13 @@ This function is a part of custom ps_trace.tag_map type which is a wrapper for t
 function internal **ps_trace.tag_map_subscript_handler**(internal)
 ```
 ### ps_trace.tag_v_eq
-This function is a part of custom _ps_trace.tag_v type which is a wrapper for 
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for
 the built-in jsonb. It is the same as its jsonb_ namesake, but has a support function attached.
 ```
 function boolean **ps_trace.tag_v_eq**(_ps_trace.tag_v, _ps_trace.tag_v)
 ```
 ### ps_trace.tag_v_eq
-This function is a part of custom _ps_trace.tag_v type which is a wrapper for 
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for
 the built-in jsonb. It is the same as its jsonb_ namesake, but has a support function attached.
 ```
 function boolean **ps_trace.tag_v_eq**(_ps_trace.tag_v, jsonb)
@@ -455,13 +455,13 @@ This function is a part of custom _ps_trace.tag_v type which is a wrapper for th
 function boolean **ps_trace.tag_v_lt**(_ps_trace.tag_v, _ps_trace.tag_v)
 ```
 ### ps_trace.tag_v_ne
-This function is a part of custom _ps_trace.tag_v type which is a wrapper for 
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for
 the built-in jsonb. It is the same as its jsonb_ namesake, but has a support function attached.
 ```
 function boolean **ps_trace.tag_v_ne**(_ps_trace.tag_v, _ps_trace.tag_v)
 ```
 ### ps_trace.tag_v_ne
-This function is a part of custom _ps_trace.tag_v type which is a wrapper for 
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for
 the built-in jsonb. It is the same as its jsonb_ namesake, but has a support function attached.
 ```
 function boolean **ps_trace.tag_v_ne**(_ps_trace.tag_v, jsonb)
@@ -1174,7 +1174,7 @@ This function is a part of custom _ps_trace.tag_v type which is a wrapper for th
 function integer **_ps_trace.tag_v_cmp**(_ps_trace.tag_v, _ps_trace.tag_v)
 ```
 ### _ps_trace.tag_v_eq_matching_tags
-This function is a part of custom _ps_trace.tag_v type which is a wrapper for 
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for
 the built-in jsonb. The tag_map_rewrite support function, attached to tag_v_eq,
 will use this function instead, if it can.
 ```
@@ -1186,7 +1186,7 @@ This function is a part of custom _ps_trace.tag_v type which is a wrapper for th
 function _ps_trace.tag_v **_ps_trace.tag_v_in**(cstring)
 ```
 ### _ps_trace.tag_v_ne_matching_tags
-This function is a part of custom _ps_trace.tag_v type which is a wrapper for 
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for
 the built-in jsonb. The tag_map_rewrite support function, attached to tag_v_ne,
 will use this function instead, if it can.
 ```
@@ -1211,6 +1211,19 @@ function bytea **_ps_trace.tag_v_send**(_ps_trace.tag_v)
 This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.
 ```
 function internal **_ps_trace.tag_v_subscript_handler**(internal)
+```
+### _ps_trace.tag_v_text_eq_matching_tags
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for
+the built-in jsonb. This function returns all the jsonb { tag_key_id, tag_value_id } pairs where
+the tag key matches _tag_key and the textual output of tag value matches _tag_value_text
+```
+function jsonb[] **_ps_trace.tag_v_text_eq_matching_tags**(_tag_key text, _tag_value_text text)
+```
+### _ps_trace.text_matches
+This function is an internal function that given a peice of text, returns all the possible
+jsonb representations of that text. I.e. it is the inverse of the jsonb ->> operator.
+```
+function jsonb[] **_ps_trace.text_matches**(_value text)
 ```
 ### _ps_trace.trace_id_cmp
 This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.
@@ -1412,28 +1425,28 @@ __Function:__ tag_op_jsonb_path_exists
 
 __Schema:__ ps_tag
 ### _ps_trace.tag_v %< _ps_trace.tag_v → boolean
-This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+This operator is a part of custom ps_trace.tag_map type which is a wrapper for
 the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
 
 __Function:__ tag_v_lt
 
 __Schema:__ ps_trace
 ### _ps_trace.tag_v %<= _ps_trace.tag_v → boolean
-This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+This operator is a part of custom ps_trace.tag_map type which is a wrapper for
 the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
 
 __Function:__ tag_v_le
 
 __Schema:__ ps_trace
 ### _ps_trace.tag_v %<> _ps_trace.tag_v → boolean
-This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+This operator is a part of custom ps_trace.tag_map type which is a wrapper for
 the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
 
 __Function:__ ps_trace.tag_v_ne
 
 __Schema:__ ps_trace
 ### _ps_trace.tag_v %= _ps_trace.tag_v → boolean
-This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+This operator is a part of custom ps_trace.tag_map type which is a wrapper for
 the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
 
 __Function:__ ps_trace.tag_v_eq
@@ -1446,14 +1459,14 @@ __Function:__ tag_v_gt
 
 __Schema:__ ps_trace
 ### _ps_trace.tag_v %>= _ps_trace.tag_v → boolean
-This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+This operator is a part of custom ps_trace.tag_map type which is a wrapper for
 the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
 
 __Function:__ tag_v_ge
 
 __Schema:__ ps_trace
 ### tag_map -> text → _ps_trace.tag_v
-This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+This operator is a part of custom ps_trace.tag_map type which is a wrapper for
 the built-in jsonb. It is the same as its jsonb_ namesake, but returns _ps_trace.tag_v.
 
 __Function:__ tag_map_object_field
@@ -1472,7 +1485,7 @@ __Function:__ _ps_trace.trace_id_le
 
 __Schema:__ ps_trace
 ### _ps_trace.tag_v <> jsonb → boolean
-This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+This operator is a part of custom ps_trace.tag_map type which is a wrapper for
 the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
 
 __Function:__ ps_trace.tag_v_ne
@@ -1485,7 +1498,7 @@ __Function:__ _ps_trace.trace_id_ne
 
 __Schema:__ ps_trace
 ### _ps_trace.tag_v = jsonb → boolean
-This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+This operator is a part of custom ps_trace.tag_map type which is a wrapper for
 the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
 
 __Function:__ ps_trace.tag_v_eq

--- a/sql-tests/tests/snapshots/tests__testdata__tag_map.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__tag_map.sql.snap
@@ -55,7 +55,7 @@ CREATE FUNCTION explain_jsonb(_query pg_catalog.text, OUT _result pg_catalog.jso
     LANGUAGE plpgsql VOLATILE AS
 $fnc$
 BEGIN
-    EXECUTE 'explain (format json) ' || _query INTO _result;
+    EXECUTE 'explain (format json, verbose, analyze) ' || _query INTO _result;
     RETURN;
 END;
 $fnc$;
@@ -168,5 +168,36 @@ SELECT span_tags -> 'pwlen' AS tagv FROM span  GROUP BY tagv;
  18
  25
 (2 rows)
+
+\unset ECHO
+ plan  
+-------
+ 1..10
+(1 row)
+
+            is            
+--------------------------
+ ok 1 - test text_matches
+ ok 2 - test text_matches
+ ok 3 - test text_matches
+ ok 4 - test text_matches
+ ok 5 - test text_matches
+ ok 6 - test text_matches
+ ok 7 - test text_matches
+(7 rows)
+
+           ok           |        ok         
+------------------------+-------------------
+ ok 8 - subplan is used | ok 9 - uses index
+(1 row)
+
+                ok                 
+-----------------------------------
+ ok 10 - exclusion does not happen
+(1 row)
+
+ finish 
+--------
+(0 rows)
 
 


### PR DESCRIPTION
The _ps_trace.tag_v_text_eq_matching_tags matcher tests
equality for a tag_key to the textual representation of
the tag value. This means that a match for the string
"3" will match a jsonb string "3" or a jsonb int 3.

Please note: this does not yet handle the nested json
case.

## Description

<!--Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.-->

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation