### PR TITLE
Another attempt at fixing the bug with tag_v type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ We use the following categories for changes:
 - Added `prom_api.get_default_chunk_interval()` and `prom_api.get_metric_chunk_interval(TEXT)` [#464].
 
 ### Fixed
-- Incorrect type coercion when using `tag_map` with `=` operator [#345]
+- Incorrect type coercion when using `tag_map` with `=` operator [#462]
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ We use the following categories for changes:
 
 ## [Unreleased]
 
+### Fixed
+- Incorrect type coercion when using `tag_map` with `=` operator [#345]
+
 ### Changed
 
 - `ps_trace.delete_all_traces()` can only be executed when no Promscale connectors are running [#437].

--- a/docs/sql-api.md
+++ b/docs/sql-api.md
@@ -1411,18 +1411,52 @@ This function supports the @? operator.
 __Function:__ tag_op_jsonb_path_exists
 
 __Schema:__ ps_tag
+### _ps_trace.tag_v %< _ps_trace.tag_v → boolean
+This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
+
+__Function:__ tag_v_lt
+
+__Schema:__ ps_trace
+### _ps_trace.tag_v %<= _ps_trace.tag_v → boolean
+This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
+
+__Function:__ tag_v_le
+
+__Schema:__ ps_trace
+### _ps_trace.tag_v %<> _ps_trace.tag_v → boolean
+This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
+
+__Function:__ ps_trace.tag_v_ne
+
+__Schema:__ ps_trace
+### _ps_trace.tag_v %= _ps_trace.tag_v → boolean
+This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
+
+__Function:__ ps_trace.tag_v_eq
+
+__Schema:__ ps_trace
+### _ps_trace.tag_v %> _ps_trace.tag_v → boolean
+This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.
+
+__Function:__ tag_v_gt
+
+__Schema:__ ps_trace
+### _ps_trace.tag_v %>= _ps_trace.tag_v → boolean
+This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
+the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
+
+__Function:__ tag_v_ge
+
+__Schema:__ ps_trace
 ### tag_map -> text → _ps_trace.tag_v
 This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
 the built-in jsonb. It is the same as its jsonb_ namesake, but returns _ps_trace.tag_v.
 
 __Function:__ tag_map_object_field
-
-__Schema:__ ps_trace
-### _ps_trace.tag_v < _ps_trace.tag_v → boolean
-This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
-the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
-
-__Function:__ tag_v_lt
 
 __Schema:__ ps_trace
 ### trace_id < trace_id → boolean
@@ -1431,24 +1465,10 @@ This function is a part of custom ps_trace.tag_traceid type which is a wrapper f
 __Function:__ _ps_trace.trace_id_lt
 
 __Schema:__ ps_trace
-### _ps_trace.tag_v <= _ps_trace.tag_v → boolean
-This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
-the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
-
-__Function:__ tag_v_le
-
-__Schema:__ ps_trace
 ### trace_id <= trace_id → boolean
 This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.
 
 __Function:__ _ps_trace.trace_id_le
-
-__Schema:__ ps_trace
-### _ps_trace.tag_v <> _ps_trace.tag_v → boolean
-This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
-the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
-
-__Function:__ ps_trace.tag_v_ne
 
 __Schema:__ ps_trace
 ### _ps_trace.tag_v <> jsonb → boolean
@@ -1464,13 +1484,6 @@ This function is a part of custom ps_trace.tag_traceid type which is a wrapper f
 __Function:__ _ps_trace.trace_id_ne
 
 __Schema:__ ps_trace
-### _ps_trace.tag_v = _ps_trace.tag_v → boolean
-This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
-the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
-
-__Function:__ ps_trace.tag_v_eq
-
-__Schema:__ ps_trace
 ### _ps_trace.tag_v = jsonb → boolean
 This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
 the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
@@ -1484,23 +1497,10 @@ This function is a part of custom ps_trace.tag_traceid type which is a wrapper f
 __Function:__ _ps_trace.trace_id_eq
 
 __Schema:__ ps_trace
-### _ps_trace.tag_v > _ps_trace.tag_v → boolean
-This function is a part of custom _ps_trace.tag_v type which is a wrapper for the built-in jsonb. It is the same as its jsonb_ namesake.
-
-__Function:__ tag_v_gt
-
-__Schema:__ ps_trace
 ### trace_id > trace_id → boolean
 This function is a part of custom ps_trace.tag_traceid type which is a wrapper for the built-in uuid. It is the same as its uuid_ namesake.
 
 __Function:__ _ps_trace.trace_id_gt
-
-__Schema:__ ps_trace
-### _ps_trace.tag_v >= _ps_trace.tag_v → boolean
-This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
-the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.
-
-__Function:__ tag_v_ge
 
 __Schema:__ ps_trace
 ### trace_id >= trace_id → boolean

--- a/migration/idempotent/007-tracing-tags.sql
+++ b/migration/idempotent/007-tracing-tags.sql
@@ -123,7 +123,6 @@ the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map
 
 DO $do$
 BEGIN
-	DROP OPERATOR IF EXISTS ps_trace.= (_ps_trace.tag_v, _ps_trace.tag_v) CASCADE;
 	CREATE OPERATOR ps_trace.%= (
 	    FUNCTION       = ps_trace.tag_v_eq,
 	    LEFTARG        = _ps_trace.tag_v,
@@ -210,7 +209,6 @@ the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map
 
 DO $do$
 BEGIN
-	DROP OPERATOR IF EXISTS ps_trace.<> (_ps_trace.tag_v, _ps_trace.tag_v)  CASCADE;
 	CREATE OPERATOR ps_trace.%<> (
 	    FUNCTION       = ps_trace.tag_v_ne,
 	    LEFTARG        = _ps_trace.tag_v,
@@ -289,7 +287,6 @@ IS 'This function is a part of custom _ps_trace.tag_v type which is a wrapper fo
 
 DO $do$
 BEGIN
-	DROP OPERATOR IF EXISTS ps_trace.> (_ps_trace.tag_v, _ps_trace.tag_v) CASCADE;
 	CREATE OPERATOR ps_trace.%> (
 	    FUNCTION       = ps_trace.tag_v_gt,
 	    LEFTARG        = _ps_trace.tag_v,
@@ -307,7 +304,6 @@ $do$;
 
 DO $do$
 BEGIN
-	DROP OPERATOR IF EXISTS ps_trace.>= (_ps_trace.tag_v, _ps_trace.tag_v) CASCADE;
 	CREATE OPERATOR ps_trace.%>= (
 	    FUNCTION       = ps_trace.tag_v_ge,
 	    LEFTARG        = _ps_trace.tag_v,
@@ -327,7 +323,6 @@ the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map
 
 DO $do$
 BEGIN
-	DROP OPERATOR IF EXISTS ps_trace.< (_ps_trace.tag_v, _ps_trace.tag_v) CASCADE;
 	CREATE OPERATOR ps_trace.%< (
 	    FUNCTION       = ps_trace.tag_v_lt,
 	    LEFTARG        = _ps_trace.tag_v,
@@ -347,7 +342,6 @@ the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map
 
 DO $do$
 BEGIN
-	DROP OPERATOR IF EXISTS ps_trace.<= (_ps_trace.tag_v, _ps_trace.tag_v) CASCADE;
 	CREATE OPERATOR ps_trace.%<= (
 	    FUNCTION       = ps_trace.tag_v_le,
 	    LEFTARG        = _ps_trace.tag_v,
@@ -370,20 +364,15 @@ the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map
 
 DO $do$
 BEGIN
-    DROP OPERATOR CLASS IF EXISTS public.btree_tag_v_ops USING btree;
-    DROP OPERATOR CLASS IF EXISTS ps_trace.btree_tag_v_ops USING btree;
-    DROP OPERATOR FAMILY IF EXISTS public.btree_tag_v_ops USING btree;
-    DROP OPERATOR FAMILY IF EXISTS ps_trace.btree_tag_v_ops USING btree;
-
     CREATE OPERATOR CLASS ps_trace.btree_tag_v_ops
-    DEFAULT FOR TYPE _ps_trace.tag_v USING btree
-    AS
-            OPERATOR        1       ps_trace.%<  ,
-            OPERATOR        2       ps_trace.%<= ,
-            OPERATOR        3       ps_trace.%=  ,
-            OPERATOR        4       ps_trace.%>= ,
-            OPERATOR        5       ps_trace.%>  ,
-            FUNCTION        1       _ps_trace.tag_v_cmp(_ps_trace.tag_v, _ps_trace.tag_v);
+        DEFAULT FOR TYPE _ps_trace.tag_v USING btree
+        AS
+                OPERATOR        1       ps_trace.%<  ,
+                OPERATOR        2       ps_trace.%<= ,
+                OPERATOR        3       ps_trace.%=  ,
+                OPERATOR        4       ps_trace.%>= ,
+                OPERATOR        5       ps_trace.%>  ,
+                FUNCTION        1       _ps_trace.tag_v_cmp(_ps_trace.tag_v, _ps_trace.tag_v);
 EXCEPTION
     WHEN SQLSTATE '42710' THEN -- object already exists
         EXECUTE format($q$ALTER OPERATOR CLASS ps_trace.btree_tag_v_ops USING btree OWNER TO %I$q$, current_user);

--- a/migration/idempotent/007-tracing-tags.sql
+++ b/migration/idempotent/007-tracing-tags.sql
@@ -123,7 +123,7 @@ the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map
 
 DO $do$
 BEGIN
-	DROP OPERATOR IF EXISTS ps_trace.= (_ps_trace.tag_v, _ps_trace.tag_v);
+	DROP OPERATOR IF EXISTS ps_trace.= (_ps_trace.tag_v, _ps_trace.tag_v) CASCADE;
 	CREATE OPERATOR ps_trace.%= (
 	    FUNCTION       = ps_trace.tag_v_eq,
 	    LEFTARG        = _ps_trace.tag_v,
@@ -210,7 +210,7 @@ the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map
 
 DO $do$
 BEGIN
-	DROP OPERATOR IF EXISTS ps_trace.<> (_ps_trace.tag_v, _ps_trace.tag_v);
+	DROP OPERATOR IF EXISTS ps_trace.<> (_ps_trace.tag_v, _ps_trace.tag_v)  CASCADE;
 	CREATE OPERATOR ps_trace.%<> (
 	    FUNCTION       = ps_trace.tag_v_ne,
 	    LEFTARG        = _ps_trace.tag_v,
@@ -289,7 +289,7 @@ IS 'This function is a part of custom _ps_trace.tag_v type which is a wrapper fo
 
 DO $do$
 BEGIN
-	DROP OPERATOR IF EXISTS ps_trace.> (_ps_trace.tag_v, _ps_trace.tag_v);
+	DROP OPERATOR IF EXISTS ps_trace.> (_ps_trace.tag_v, _ps_trace.tag_v) CASCADE;
 	CREATE OPERATOR ps_trace.%> (
 	    FUNCTION       = ps_trace.tag_v_gt,
 	    LEFTARG        = _ps_trace.tag_v,
@@ -307,7 +307,7 @@ $do$;
 
 DO $do$
 BEGIN
-	DROP OPERATOR IF EXISTS ps_trace.>= (_ps_trace.tag_v, _ps_trace.tag_v);
+	DROP OPERATOR IF EXISTS ps_trace.>= (_ps_trace.tag_v, _ps_trace.tag_v) CASCADE;
 	CREATE OPERATOR ps_trace.%>= (
 	    FUNCTION       = ps_trace.tag_v_ge,
 	    LEFTARG        = _ps_trace.tag_v,
@@ -327,7 +327,7 @@ the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map
 
 DO $do$
 BEGIN
-	DROP OPERATOR IF EXISTS ps_trace.< (_ps_trace.tag_v, _ps_trace.tag_v);
+	DROP OPERATOR IF EXISTS ps_trace.< (_ps_trace.tag_v, _ps_trace.tag_v) CASCADE;
 	CREATE OPERATOR ps_trace.%< (
 	    FUNCTION       = ps_trace.tag_v_lt,
 	    LEFTARG        = _ps_trace.tag_v,
@@ -347,7 +347,7 @@ the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map
 
 DO $do$
 BEGIN
-	DROP OPERATOR IF EXISTS ps_trace.<= (_ps_trace.tag_v, _ps_trace.tag_v);
+	DROP OPERATOR IF EXISTS ps_trace.<= (_ps_trace.tag_v, _ps_trace.tag_v) CASCADE;
 	CREATE OPERATOR ps_trace.%<= (
 	    FUNCTION       = ps_trace.tag_v_le,
 	    LEFTARG        = _ps_trace.tag_v,

--- a/migration/idempotent/007-tracing-tags.sql
+++ b/migration/idempotent/007-tracing-tags.sql
@@ -195,7 +195,7 @@ BEGIN
 	    FUNCTION       = ps_trace.tag_v_ne,
 	    LEFTARG        = _ps_trace.tag_v,
 	    RIGHTARG       = pg_catalog.jsonb,
-	    NEGATOR        = OPERATOR(ps_trace.%=),
+	    NEGATOR        = OPERATOR(ps_trace.=),
 	    RESTRICT       = neqsel,
 	    JOIN           = neqjoinsel
 	);
@@ -370,8 +370,9 @@ the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map
 
 DO $do$
 BEGIN
-    DROP OPERATOR CLASS IF EXISTS btree_tag_v_ops USING btree;
-    CREATE OPERATOR CLASS btree_tag_v_ops
+    DROP OPERATOR CLASS IF EXISTS public.btree_tag_v_ops USING btree;
+    DROP OPERATOR CLASS IF EXISTS ps_trace.btree_tag_v_ops USING btree;
+    CREATE OPERATOR CLASS ps_trace.btree_tag_v_ops
     DEFAULT FOR TYPE _ps_trace.tag_v USING btree
     AS
             OPERATOR        1       ps_trace.%<  ,

--- a/migration/idempotent/007-tracing-tags.sql
+++ b/migration/idempotent/007-tracing-tags.sql
@@ -123,21 +123,22 @@ the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map
 
 DO $do$
 BEGIN
-	CREATE OPERATOR ps_trace.= (
+	DROP OPERATOR IF EXISTS ps_trace.= (_ps_trace.tag_v, _ps_trace.tag_v);
+	CREATE OPERATOR ps_trace.%= (
 	    FUNCTION       = ps_trace.tag_v_eq,
 	    LEFTARG        = _ps_trace.tag_v,
 	    RIGHTARG       = _ps_trace.tag_v,
-        NEGATOR        = OPERATOR(ps_trace.<>),
+        NEGATOR        = OPERATOR(ps_trace.%<>),
 	    RESTRICT       = eqsel,
 	    JOIN           = eqjoinsel,
 	    HASHES, MERGES
 	);
 EXCEPTION
     WHEN SQLSTATE '42723' THEN -- operator already exists
-        EXECUTE format($q$ALTER OPERATOR ps_trace.=(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
+        EXECUTE format($q$ALTER OPERATOR ps_trace.%=(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
 END;
 $do$;
-COMMENT ON OPERATOR ps_trace.= (_ps_trace.tag_v, _ps_trace.tag_v)
+COMMENT ON OPERATOR ps_trace.%= (_ps_trace.tag_v, _ps_trace.tag_v)
 IS 'This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
 the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.';
 
@@ -194,7 +195,7 @@ BEGIN
 	    FUNCTION       = ps_trace.tag_v_ne,
 	    LEFTARG        = _ps_trace.tag_v,
 	    RIGHTARG       = pg_catalog.jsonb,
-	    NEGATOR        = OPERATOR(ps_trace.=),
+	    NEGATOR        = OPERATOR(ps_trace.%=),
 	    RESTRICT       = neqsel,
 	    JOIN           = neqjoinsel
 	);
@@ -209,20 +210,21 @@ the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map
 
 DO $do$
 BEGIN
-	CREATE OPERATOR ps_trace.<> (
+	DROP OPERATOR IF EXISTS ps_trace.<> (_ps_trace.tag_v, _ps_trace.tag_v);
+	CREATE OPERATOR ps_trace.%<> (
 	    FUNCTION       = ps_trace.tag_v_ne,
 	    LEFTARG        = _ps_trace.tag_v,
 	    RIGHTARG       = _ps_trace.tag_v,
-	    NEGATOR        = OPERATOR(ps_trace.=),
+	    NEGATOR        = OPERATOR(ps_trace.%=),
 	    RESTRICT       = neqsel,
 	    JOIN           = neqjoinsel
 	);
 EXCEPTION
     WHEN SQLSTATE '42723' THEN -- operator already exists
-        EXECUTE format($q$ALTER OPERATOR ps_trace.<>(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
+        EXECUTE format($q$ALTER OPERATOR ps_trace.%<>(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
 END;
 $do$;
-COMMENT ON OPERATOR ps_trace.<> (_ps_trace.tag_v, _ps_trace.tag_v)
+COMMENT ON OPERATOR ps_trace.%<> (_ps_trace.tag_v, _ps_trace.tag_v)
 IS 'This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
 the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.';
 
@@ -287,75 +289,79 @@ IS 'This function is a part of custom _ps_trace.tag_v type which is a wrapper fo
 
 DO $do$
 BEGIN
-	CREATE OPERATOR ps_trace.> (
+	DROP OPERATOR IF EXISTS ps_trace.> (_ps_trace.tag_v, _ps_trace.tag_v);
+	CREATE OPERATOR ps_trace.%> (
 	    FUNCTION       = ps_trace.tag_v_gt,
 	    LEFTARG        = _ps_trace.tag_v,
 	    RIGHTARG       = _ps_trace.tag_v,
-	    NEGATOR        = OPERATOR(ps_trace.<=),
+	    NEGATOR        = OPERATOR(ps_trace.%<=),
 	    RESTRICT       = scalargtsel,
 	    JOIN           = scalargtjoinsel
 	);
 EXCEPTION
     WHEN SQLSTATE '42723' THEN -- operator already exists
-        EXECUTE format($q$ALTER OPERATOR ps_trace.>(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
+        EXECUTE format($q$ALTER OPERATOR ps_trace.%>(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
 END;
 $do$;
 
 
 DO $do$
 BEGIN
-	CREATE OPERATOR ps_trace.>= (
+	DROP OPERATOR IF EXISTS ps_trace.>= (_ps_trace.tag_v, _ps_trace.tag_v);
+	CREATE OPERATOR ps_trace.%>= (
 	    FUNCTION       = ps_trace.tag_v_ge,
 	    LEFTARG        = _ps_trace.tag_v,
 	    RIGHTARG       = _ps_trace.tag_v,
-	    NEGATOR        = OPERATOR(ps_trace.<),
+	    NEGATOR        = OPERATOR(ps_trace.%<),
 	    RESTRICT       = scalargesel,
 	    JOIN           = scalargejoinsel
 	);
 EXCEPTION
     WHEN SQLSTATE '42723' THEN -- operator already exists
-        EXECUTE format($q$ALTER OPERATOR ps_trace.>=(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
+        EXECUTE format($q$ALTER OPERATOR ps_trace.%>=(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
 END;
 $do$;
-COMMENT ON OPERATOR ps_trace.>= (_ps_trace.tag_v, _ps_trace.tag_v)
+COMMENT ON OPERATOR ps_trace.%>= (_ps_trace.tag_v, _ps_trace.tag_v)
 IS 'This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
 the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.';
 
 DO $do$
 BEGIN
-	CREATE OPERATOR ps_trace.< (
+	DROP OPERATOR IF EXISTS ps_trace.< (_ps_trace.tag_v, _ps_trace.tag_v);
+	CREATE OPERATOR ps_trace.%< (
 	    FUNCTION       = ps_trace.tag_v_lt,
 	    LEFTARG        = _ps_trace.tag_v,
 	    RIGHTARG       = _ps_trace.tag_v,
-	    NEGATOR        = OPERATOR(ps_trace.>=),
+	    NEGATOR        = OPERATOR(ps_trace.%>=),
 	    RESTRICT       = scalarltsel,
 	    JOIN           = scalarltjoinsel
 	);
 EXCEPTION
     WHEN SQLSTATE '42723' THEN -- operator already exists
-        EXECUTE format($q$ALTER OPERATOR ps_trace.<(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
+        EXECUTE format($q$ALTER OPERATOR ps_trace.%<(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
 END;
 $do$;
-COMMENT ON OPERATOR ps_trace.< (_ps_trace.tag_v, _ps_trace.tag_v)
+COMMENT ON OPERATOR ps_trace.%< (_ps_trace.tag_v, _ps_trace.tag_v)
 IS 'This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
 the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.';
 
 DO $do$
 BEGIN
-	CREATE OPERATOR ps_trace.<= (
+	DROP OPERATOR IF EXISTS ps_trace.<= (_ps_trace.tag_v, _ps_trace.tag_v);
+	CREATE OPERATOR ps_trace.%<= (
 	    FUNCTION       = ps_trace.tag_v_le,
 	    LEFTARG        = _ps_trace.tag_v,
 	    RIGHTARG       = _ps_trace.tag_v,
-	    NEGATOR        = OPERATOR(ps_trace.>),
+	    NEGATOR        = OPERATOR(ps_trace.%>),
 	    RESTRICT       = scalarlesel,
 	    JOIN           = scalarlejoinsel
 	);
 EXCEPTION
     WHEN SQLSTATE '42723' THEN -- operator already exists
-        EXECUTE format($q$ALTER OPERATOR ps_trace.<=(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
+        EXECUTE format($q$ALTER OPERATOR ps_trace.%<=(_ps_trace.tag_v, _ps_trace.tag_v) OWNER TO %I$q$, current_user);
 END;
 $do$;
-COMMENT ON OPERATOR ps_trace.<= (_ps_trace.tag_v, _ps_trace.tag_v)
+COMMENT ON OPERATOR ps_trace.%<= (_ps_trace.tag_v, _ps_trace.tag_v)
 IS 'This operator is a part of custom ps_trace.tag_map type which is a wrapper for 
 the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map_* functions.';
 
@@ -364,14 +370,15 @@ the built-in jsonb. It is the same as its jsonb_ namesake, but relies on tag_map
 
 DO $do$
 BEGIN
+    DROP OPERATOR CLASS IF EXISTS btree_tag_v_ops USING btree;
     CREATE OPERATOR CLASS btree_tag_v_ops
     DEFAULT FOR TYPE _ps_trace.tag_v USING btree
     AS
-            OPERATOR        1       ps_trace.<  ,
-            OPERATOR        2       ps_trace.<= ,
-            OPERATOR        3       ps_trace.=  ,
-            OPERATOR        4       ps_trace.>= ,
-            OPERATOR        5       ps_trace.>  ,
+            OPERATOR        1       ps_trace.%<  ,
+            OPERATOR        2       ps_trace.%<= ,
+            OPERATOR        3       ps_trace.%=  ,
+            OPERATOR        4       ps_trace.%>= ,
+            OPERATOR        5       ps_trace.%>  ,
             FUNCTION        1       _ps_trace.tag_v_cmp(_ps_trace.tag_v, _ps_trace.tag_v);
 EXCEPTION
     WHEN SQLSTATE '42710' THEN -- object already exists

--- a/migration/idempotent/007-tracing-tags.sql
+++ b/migration/idempotent/007-tracing-tags.sql
@@ -372,6 +372,9 @@ DO $do$
 BEGIN
     DROP OPERATOR CLASS IF EXISTS public.btree_tag_v_ops USING btree;
     DROP OPERATOR CLASS IF EXISTS ps_trace.btree_tag_v_ops USING btree;
+    DROP OPERATOR FAMILY IF EXISTS public.btree_tag_v_ops USING btree;
+    DROP OPERATOR FAMILY IF EXISTS ps_trace.btree_tag_v_ops USING btree;
+
     CREATE OPERATOR CLASS ps_trace.btree_tag_v_ops
     DEFAULT FOR TYPE _ps_trace.tag_v USING btree
     AS
@@ -383,6 +386,7 @@ BEGIN
             FUNCTION        1       _ps_trace.tag_v_cmp(_ps_trace.tag_v, _ps_trace.tag_v);
 EXCEPTION
     WHEN SQLSTATE '42710' THEN -- object already exists
-        EXECUTE format($q$ALTER OPERATOR CLASS public.btree_tag_v_ops USING btree OWNER TO %I$q$, current_user);
+        EXECUTE format($q$ALTER OPERATOR CLASS ps_trace.btree_tag_v_ops USING btree OWNER TO %I$q$, current_user);
+        EXECUTE format($q$ALTER OPERATOR FAMILY ps_trace.btree_tag_v_ops USING btree OWNER TO %I$q$, current_user);
 END;
 $do$;

--- a/migration/incremental/031-remove-superfluous-tag_v-ops.sql
+++ b/migration/incremental/031-remove-superfluous-tag_v-ops.sql
@@ -1,0 +1,15 @@
+/* Initially a set of operators were defined for the btree-opclass.
+ * Those caused type coercion conflicts with operators intended to be
+ * used with tag_v.
+ * Here we drop those operators and other objects created by pg implicitly
+ */
+
+DROP OPERATOR IF EXISTS ps_trace.= (_ps_trace.tag_v, _ps_trace.tag_v) CASCADE;
+DROP OPERATOR IF EXISTS ps_trace.<> (_ps_trace.tag_v, _ps_trace.tag_v)  CASCADE;
+DROP OPERATOR IF EXISTS ps_trace.> (_ps_trace.tag_v, _ps_trace.tag_v) CASCADE;
+DROP OPERATOR IF EXISTS ps_trace.>= (_ps_trace.tag_v, _ps_trace.tag_v) CASCADE;
+DROP OPERATOR IF EXISTS ps_trace.< (_ps_trace.tag_v, _ps_trace.tag_v) CASCADE;
+DROP OPERATOR IF EXISTS ps_trace.<= (_ps_trace.tag_v, _ps_trace.tag_v) CASCADE;
+
+DROP OPERATOR CLASS IF EXISTS public.btree_tag_v_ops USING btree;
+DROP OPERATOR FAMILY IF EXISTS public.btree_tag_v_ops USING btree;


### PR DESCRIPTION
## Description

<!--Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.-->
Fixes timescale/o11y-team-data-platform#56

We want to redefine the opclass for tag_v type to not use = operator.
This will improve type coercion for the typical use case.
Simply dropping the opclass should be safe since we don't expect anyone
to ever index using this opclass.

NOTE: We currently have two distinct types:

_ps_trace.tag_v and
ps_trace.tag_v
This is not ideal.
## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation