### PR TITLE
Add convenience functions for getting metric chunk interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ We use the following categories for changes:
 
 ## [Unreleased]
 
+### Added
+
+- Added `prom_api.get_default_chunk_interval()` and `prom_api.get_metric_chunk_interval(TEXT)` [#464].
+
 ### Changed
 
 - `ps_trace.delete_all_traces()` can only be executed when no Promscale connectors are running [#437].

--- a/docs/sql-api.md
+++ b/docs/sql-api.md
@@ -36,10 +36,20 @@ Execute maintenance tasks like dropping data according to retention policy. This
 ```
 procedure void **prom_api.execute_maintenance**(IN log_verbose boolean DEFAULT false)
 ```
+### prom_api.get_default_chunk_interval
+Get the default chunk interval for all metrics
+```
+function interval **prom_api.get_default_chunk_interval**()
+```
 ### prom_api.get_default_metric_retention_period
 get the default retention period for all metrics
 ```
 function interval **prom_api.get_default_metric_retention_period**()
+```
+### prom_api.get_metric_chunk_interval
+Get the chunk interval for a specific metric, or the default chunk interval if not explicitly set
+```
+function interval **prom_api.get_metric_chunk_interval**(metric_name text)
 ```
 ### prom_api.get_metric_metadata
 

--- a/sql-tests/testdata/metric-chunk-interval.sql
+++ b/sql-tests/testdata/metric-chunk-interval.sql
@@ -1,0 +1,34 @@
+\unset ECHO
+\set QUIET 1
+\i 'testdata/scripts/pgtap-1.2.0.sql'
+
+CREATE OR REPLACE FUNCTION approx_is(range1 INTERVAL, range2 INTERVAL, bound NUMERIC, description TEXT)
+    RETURNS TEXT AS $$
+DECLARE
+    result BOOLEAN;
+BEGIN
+    result := range1 > range2 * (1-bound) AND range1 < range2 * (1+bound);
+    RETURN ok( result, description);
+END
+$$ LANGUAGE plpgsql;
+
+
+SELECT * FROM plan(4);
+
+SELECT is(prom_api.get_default_chunk_interval(), '8 hours'::INTERVAL, 'default metric chunk interval is 8 hours');
+
+SELECT prom_api.set_default_chunk_interval('1 hour'::INTERVAL);
+
+SELECT is(prom_api.get_default_chunk_interval(), '1 hour'::INTERVAL, 'default metric chunk interval is 1 hour');
+
+
+SELECT _prom_catalog.get_or_create_metric_table_name('cpu_usage');
+CALL _prom_catalog.finalize_metric_creation();
+
+SELECT is(prom_api.get_metric_chunk_interval('cpu_usage'), '1 hour'::INTERVAL, 'get_metric_chunk_interval returns default chunk interval');
+
+SELECT prom_api.set_metric_chunk_interval('cpu_usage', '15 minutes'::INTERVAL);
+
+SELECT approx_is(prom_api.get_metric_chunk_interval('cpu_usage'), '15 minutes'::INTERVAL, 0.01, 'get_metric_chunk_interval returns chunk interval');
+
+SELECT * FROM finish(true);

--- a/sql-tests/tests/snapshots/tests__testdata__metric-chunk-interval.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__metric-chunk-interval.sql.snap
@@ -1,0 +1,49 @@
+---
+source: sql-tests/tests/tests.rs
+expression: query_result
+---
+ plan 
+------
+ 1..4
+(1 row)
+
+                       is                        
+-------------------------------------------------
+ ok 1 - default metric chunk interval is 8 hours
+(1 row)
+
+ set_default_chunk_interval 
+----------------------------
+ t
+(1 row)
+
+                       is                       
+------------------------------------------------
+ ok 2 - default metric chunk interval is 1 hour
+(1 row)
+
+ get_or_create_metric_table_name 
+---------------------------------
+ (1,cpu_usage,t)
+(1 row)
+
+                               is                                
+-----------------------------------------------------------------
+ ok 3 - get_metric_chunk_interval returns default chunk interval
+(1 row)
+
+ set_metric_chunk_interval 
+---------------------------
+ t
+(1 row)
+
+                        approx_is                        
+---------------------------------------------------------
+ ok 4 - get_metric_chunk_interval returns chunk interval
+(1 row)
+
+ finish 
+--------
+(0 rows)
+
+


### PR DESCRIPTION
## Description

`SELECT prom_api.get_default_chunk_interval();` returns the current
default chunk interval for all metrics.

`SELECT prom_api.get_metric_chunk_interval(<metric name>);` returns the
chunk interval for the configured metric, or the default chunk interval
if not explicitly set.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation