### PR TITLE
During upgrade from 0.3.x only alter relations which actually exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We use the following categories for changes:
 
 ### Fixed
 - Incorrect type coercion when using `tag_map` with `=` operator [#462]
+- During upgrade from 0.3.x only alter relations which actually exist [#474]
 
 ### Changed
 

--- a/sql/promscale--0.0.0.sql
+++ b/sql/promscale--0.0.0.sql
@@ -407,10 +407,10 @@ BEGIN
         ORDER BY m.table_schema, m.table_name
     )
     LOOP
-        EXECUTE format($sql$ALTER TABLE %I.%I OWNER TO prom_admin $sql$, _rec.table_schema, _rec.table_name);
-        EXECUTE format($sql$ALTER TABLE prom_data_series.%I OWNER TO prom_admin $sql$, _rec.series_table);
-        EXECUTE format($sql$ALTER VIEW prom_series.%I OWNER TO prom_admin $sql$, _rec.series_table);
-        EXECUTE format($sql$ALTER VIEW prom_metric.%I OWNER TO prom_admin $sql$, _rec.table_name);
+        EXECUTE format($sql$ALTER TABLE IF EXISTS %I.%I OWNER TO prom_admin $sql$, _rec.table_schema, _rec.table_name);
+        EXECUTE format($sql$ALTER TABLE IF EXISTS prom_data_series.%I OWNER TO prom_admin $sql$, _rec.series_table);
+        EXECUTE format($sql$ALTER VIEW IF EXISTS prom_series.%I OWNER TO prom_admin $sql$, _rec.series_table);
+        EXECUTE format($sql$ALTER VIEW IF EXISTS prom_metric.%I OWNER TO prom_admin $sql$, _rec.table_name);
    END LOOP;
 END
 $block$;
@@ -427,7 +427,7 @@ $block$;
          ORDER BY e.table_name
      )
      LOOP
-         EXECUTE format($sql$ALTER TABLE prom_data_exemplar.%I OWNER TO prom_admin $sql$, _rec.table_name);
+         EXECUTE format($sql$ALTER TABLE IF EXISTS prom_data_exemplar.%I OWNER TO prom_admin $sql$, _rec.table_name);
      END LOOP;
  END;
  $block$


### PR DESCRIPTION
## Description

It is possible that not all of these tables and views exist. For
instance if metric creation has not been finalized, or if there have not
yet been any samples ingested for a metric.

There are also degenerate cases in which tables which we expect to be
present are not present (e.g. `prom_data.<metric name>`). Being too
strict here results in our users having to do a bunch of cleanup.

Fixes https://github.com/timescale/promscale_extension/issues/473

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] ~~Updated the relevant documentation~~