### PR TITLE
Use Cargo.lock when installing cargo-pgx

### DIFF
--- a/install-cargo-pgx.sh
+++ b/install-cargo-pgx.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-cargo install cargo-pgx --git https://github.com/timescale/pgx --branch v0.4.5-create-replace-fix --rev 96ece243
+cargo install --locked cargo-pgx --git https://github.com/timescale/pgx --branch v0.4.5-create-replace-fix --rev 96ece243


### PR DESCRIPTION
## Description

Using the lock file ensures that we're not affected by breaking releases
imposed by transitive dependencies of cargo-pgx.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation