### PR TITLE
Bump compiler to Rust 1.59.0

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: 1.58.0
+            toolchain: 1.59.0
             override: true
             components: rustfmt, clippy
 
@@ -33,7 +33,7 @@ jobs:
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: 1.58.0
+            toolchain: 1.59.0
             override: true
             components: rustfmt, clippy
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
   package:
     runs-on: ubuntu-latest
     env:
-      RUST_VERSION: "1.58.0"
+      RUST_VERSION: "1.59.0"
     strategy:
       fail-fast: false
       matrix:

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -5,7 +5,7 @@ ARG PREVIOUS_IMAGE=timescaledev/promscale-extension:latest-ts2-pg${PG_VERSION}
 FROM timescale/timescaledb:${TIMESCALEDB_VERSION_FULL}-pg${PG_VERSION} as builder
 
 MAINTAINER Timescale https://www.timescale.com
-ARG RUST_VERSION=1.58.1
+ARG RUST_VERSION=1.59.0
 ARG PG_VERSION
 
 RUN \

--- a/ha.Dockerfile
+++ b/ha.Dockerfile
@@ -36,7 +36,7 @@ RUN chown postgres:postgres /home/promscale
 
 USER postgres
 
-ENV RUST_VERSION=1.58.1
+ENV RUST_VERSION=1.59.0
 
 RUN \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --component rustfmt --default-toolchain ${RUST_VERSION} && \


### PR DESCRIPTION
## Description

A transitive dependency of cargo-pgx, which we install via
`cargo install`, has bumped its MSRV to 1.59.0. Unfortunately this
affects us because we're not using a lock file for the cargo-pgx
install.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation