### PR TITLE
Fix migration when a metric is not compressed

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -16,7 +16,7 @@ Run `make devenv` to build the docker image, start it, and expose it on port
 54321 on your local machine. This docker image mounts the current directory
 into the `/code` directory in the container. By default, it runs postgres 14
 and continually recompiles and reinstalls the promscale extension on source
-modifications. This means that you can edit the sources locally, and run SQL 
+modifications. This means that you can edit the sources locally, and run SQL
 tests against the container.
 
 You can adjust the postgres version through the `DEVENV_PG_VERSION` env var,
@@ -45,7 +45,7 @@ proceeding further.
 ### Running SQL tests
 
 After you modified or added migration tests can be executed in the devcontainer
-by running `make dev-sql-tests`. Our approach to adding tests is described 
+by running `make dev-sql-tests`. Our approach to adding tests is described
 [below](#testing).
 
 ### Updating public API documentation
@@ -96,7 +96,7 @@ Firstly, you'll need to install and configure PGX:
 - `cargo pgx init`
 
 Then you can run PGX tests by executing: `cargo pgx test`. If you need to run
-them against a specific PostgreSQL version you can use a corresponding feature 
+them against a specific PostgreSQL version you can use a corresponding feature
 flag: `cargo pgx test pg12`.
 
 ### Running end-to-end Rust tests
@@ -111,3 +111,15 @@ but could be finicky.
 
 To run the e2e tests against the locally build image run: `cargo test -p e2e`.
 Further details could be found in the [corresponding document](./e2e/README.md).
+
+## Known Issues
+
+Older versions of Rust misbehaved on Apple Sillicon during panic unwind. Leading to
+errors like `(signal: 11, SIGSEGV: invalid memory reference)` during test failures.
+The solution is to upgrade to Rust >1.64 via:
+- `rustup toolchain install nightly`
+- `rustup default nightly`
+
+## Tips and tricks
+
+Use `RUST_LOG=DEBUG` to get more test output from cargo tests

--- a/e2e/scripts/load-data.sql
+++ b/e2e/scripts/load-data.sql
@@ -7,13 +7,20 @@ data structures
 SELECT _prom_catalog.set_default_value('ha_lease_timeout'::text, '200 hours'::text);
 
 SELECT _prom_catalog.get_or_create_metric_table_name('cpu_usage');
+SELECT _prom_catalog.get_or_create_metric_table_name('cpu_usage_no_compression');
 SELECT _prom_catalog.get_or_create_metric_table_name('cpu_total');
 CALL _prom_catalog.finalize_metric_creation();
+
+SELECT set_compression_on_metric_table('cpu_usage_no_compression', false);
+
 INSERT INTO prom_data.cpu_usage
 SELECT timestamptz '2030-01-01 02:03:04'+(interval '1s' * g), 100.1 + g, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_usage", "namespace":"dev", "node": "brain"}')
 FROM generate_series(1,10) g;
 INSERT INTO prom_data.cpu_usage
 SELECT timestamptz '2030-01-01 02:03:04'+(interval '1s' * g), 100.1 + g, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_usage", "namespace":"production", "node": "pinky", "new_tag":"foo"}')
+FROM generate_series(1,10) g;
+INSERT INTO prom_data.cpu_usage_no_compression
+SELECT timestamptz '2030-01-01 02:03:04'+(interval '1s' * g), 100.1 + g, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_usage_no_compression", "namespace":"production", "node": "pinky", "new_tag":"foo"}')
 FROM generate_series(1,10) g;
 INSERT INTO prom_data.cpu_total
 SELECT timestamptz '2030-01-01 02:03:04'+(interval '1s' * g), 100.0, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_total", "namespace":"dev", "node": "brain"}')

--- a/e2e/scripts/snapshot.sql
+++ b/e2e/scripts/snapshot.sql
@@ -87,8 +87,9 @@ select
     case
         -- we don't care about comparing the applied_at_version and applied_at columns of the migration table
         -- the 001-extension.sql script is problematic because we keep on changing the .so that functions point to, so skip it
+        -- the 024-adjust_autovacuum.sql script had a bug and had to be modified, so skip it
         when n.nspname = '_ps_catalog'::name and k.relname = 'migration'::name
-            then 'select name, body from _ps_catalog.migration where name != ''001-extension.sql'' order by name, body;'
+            then 'select name, body from _ps_catalog.migration where name != ''001-extension.sql'' AND name != ''024-adjust_autovacuum.sql'' order by name, body;'
         when n.nspname = '_timescaledb_internal' and (k.relname like '_compressed_hypertable_%' or k.relname like 'compress_hyper_%_chunk')
             -- cannot order by tbl on compressed hypertables
             then format('select * from %I.%I', n.nspname, k.relname)

--- a/e2e/tests/incremental-freeze-test.rs
+++ b/e2e/tests/incremental-freeze-test.rs
@@ -81,7 +81,7 @@ fn incremental_freeze_test() {
         ("023-privileges.sql", "7a810fe5538653ce6e06674dbbdf7451"),
         (
             "024-adjust_autovacuum.sql",
-            "0fe28659efa74be9663cc158f84294cb",
+            "de0600ff3288e6fb3aa8dafc279bd5ff",
         ),
         // ↓↓↓ frozen in 0.5.2 ↓↓↓
         (

--- a/e2e/tests/upgrade-test.rs
+++ b/e2e/tests/upgrade-test.rs
@@ -460,6 +460,7 @@ fn psql_file(container: &PostgresContainer, db: &str, username: &str, path: &Pat
     )
     .stderr_to_stdout()
     .stdout_capture()
+    .unchecked()
     .run()
     .unwrap();
     debug_lines(output.stdout);

--- a/migration/incremental/024-adjust_autovacuum.sql
+++ b/migration/incremental/024-adjust_autovacuum.sql
@@ -31,10 +31,12 @@ DO $doit$
         EXECUTE FORMAT($$ ALTER TABLE prom_data.%I RESET (autovacuum_vacuum_threshold) $$, r.table_name);
 
         SELECT c.schema_name, c.table_name
-        INTO STRICT _compressed_schema, _compressed_hypertable
+        INTO _compressed_schema, _compressed_hypertable
         FROM _timescaledb_catalog.hypertable h
         INNER JOIN _timescaledb_catalog.hypertable c ON (h.compressed_hypertable_id= c.id)
         WHERE h.schema_name = 'prom_data' AND h.table_name = r.table_name;
+
+        CONTINUE WHEN NOT FOUND;
 
         IF current_setting('server_version_num')::integer >= 130000 THEN
             EXECUTE FORMAT($$

--- a/templates/incremental-wrapper.sql
+++ b/templates/incremental-wrapper.sql
@@ -15,7 +15,8 @@ BEGIN
     IF _migration_name IS NOT NULL THEN
         RAISE LOG 'Migration "{{filename}}" already applied, skipping';
         -- 001-extension.sql changes are expected until this issue is resolved: https://github.com/timescale/promscale_extension/issues/350
-        IF _body_differs AND _migration_name != '001-extension.sql' THEN
+        -- 024-adjust_autovacuum.sql had a bug in it and had to be changed
+        IF _body_differs AND _migration_name != '001-extension.sql' and _migration_name != '024-adjust_autovacuum.sql' THEN
             RAISE WARNING 'The contents of migration "{{filename}}" have changed';
         END IF;
         RETURN;


### PR DESCRIPTION
Previously, the migration logic assumed the existance of a compressed hypertable. This is not the case when compression is disabled.

Solve this case and add tests.

Fixes #504 

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation