### PR TITLE
Fix and simplify chunks_to_vacuum_freeze

### DIFF
--- a/migration/idempotent/016-vacuum-engine.sql
+++ b/migration/idempotent/016-vacuum-engine.sql
@@ -3,35 +3,14 @@ BEGIN
     IF _prom_catalog.is_timescaledb_installed() THEN
         CREATE OR REPLACE VIEW _ps_catalog.chunks_to_vacuum_freeze AS
         SELECT
-            c.hypertable_id,
-            c.id as chunk_id,
-            cc.id as compressed_chunk_id,
+            cc.id,
             cc.schema_name,
-            cc.table_name,
-            t.vacuum_count,
-            t.autovacuum_count,
-            t.last_vacuum,
-            t.last_autovacuum,
-            k.relallvisible
+            cc.table_name
         FROM _timescaledb_catalog.chunk c
         INNER JOIN _timescaledb_catalog.chunk cc ON (c.dropped = false and c.compressed_chunk_id = cc.id)
-        INNER JOIN
-        (
-            SELECT
-              d.id,
-              d.hypertable_id,
-              row_number() OVER (PARTITION BY d.hypertable_id ORDER BY d.id) as dimension_nbr
-            FROM _timescaledb_catalog.dimension d
-        ) d ON (c.hypertable_id = d.hypertable_id and d.dimension_nbr = 1)
-        INNER JOIN _timescaledb_catalog.dimension_slice ds on (d.id = ds.dimension_id)
-        INNER JOIN _timescaledb_catalog.chunk_constraint con on (ds.id = con.dimension_slice_id and con.chunk_id = c.id)
         INNER JOIN pg_class k ON (k.oid = format('%I.%I', cc.schema_name, cc.table_name)::regclass::oid)
-        INNER JOIN pg_stat_all_tables t ON (t.relid = k.oid)
-        WHERE k.relallvisible = 0 -- not already fully frozen
-        ORDER BY
-            greatest(t.vacuum_count, t.autovacuum_count), -- chunks vacuumed fewest times first
-            greatest(t.last_vacuum, t.last_autovacuum) NULLS FIRST, -- chunks never vacuumed first followed by ones vacuumed furthest in the past
-            ds.range_start -- chunks that represent older data first
+        WHERE k.relallvisible < k.relpages
+        ORDER BY age(k.relfrozenxid) desc
         ;
         GRANT SELECT ON _ps_catalog.chunks_to_vacuum_freeze TO prom_reader;
         COMMENT ON VIEW _ps_catalog.chunks_to_vacuum_freeze IS 'Lists chunks that need to be vacuumed and frozen';

--- a/sql-tests/tests/snapshots/tests__testdata__chunks_to_vacuum_freeze.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__chunks_to_vacuum_freeze.sql.snap
@@ -2,9 +2,9 @@
 source: sql-tests/tests/tests.rs
 expression: query_result
 ---
- plan 
-------
- 1..8
+ plan  
+-------
+ 1..14
 (1 row)
 
    create_hypertable   
@@ -62,9 +62,40 @@ expression: query_result
  ok 7 - view should return the 5 chosen compressed chunks
 (1 row)
 
-                   is_empty                   
-----------------------------------------------
- ok 8 - zero results after chunks were frozen
+psql:testdata/chunks_to_vacuum_freeze.sql:162: NOTICE:  table "_the_one" does not exist, skipping
+                      set_hasnt                       
+------------------------------------------------------
+ ok 8 - vacuumed chunk should disappear from the view
+(1 row)
+
+                     results_eq                     
+----------------------------------------------------
+ ok 9 - unvacuumed chunks should remain in the view
+(1 row)
+
+                       set_hasnt                       
+-------------------------------------------------------
+ ok 10 - vacuumed chunk should disappear from the view
+(1 row)
+
+                     results_eq                      
+-----------------------------------------------------
+ ok 11 - unvacuumed chunks should remain in the view
+(1 row)
+
+                       set_hasnt                       
+-------------------------------------------------------
+ ok 12 - vacuumed chunk should disappear from the view
+(1 row)
+
+                     results_eq                      
+-----------------------------------------------------
+ ok 13 - unvacuumed chunks should remain in the view
+(1 row)
+
+                   is_empty                    
+-----------------------------------------------
+ ok 14 - zero results after chunks were frozen
 (1 row)
 
  finish 


### PR DESCRIPTION
## Description

Fix and simplify chunks_to_vacuum_freeze

- relallvisible is a count, not a boolean.
- order by relfrozenxid to remove a bunch of joins

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation