### PR TITLE
Switch from logical to time-based epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ We use the following categories for changes:
   `_prom_catalog.lock_for_vacuum_engine`, and 
   `_prom_catalog.unlock_for_vacuum_engine()` [#511]
 
+### Changed
+
+- Switch from logical to time-based epoch [#512]
+
 ## [0.6.0] - 2022-08-25
 
 ### Added

--- a/docs/sql-api.md
+++ b/docs/sql-api.md
@@ -564,7 +564,7 @@ function void **_prom_catalog.delay_compression_job**(ht_table text, new_start t
 ### _prom_catalog.delete_expired_series
 
 ```
-function void **_prom_catalog.delete_expired_series**(metric_schema text, metric_table text, metric_series_table text, ran_at timestamp with time zone, present_epoch bigint, last_updated_epoch timestamp with time zone)
+function void **_prom_catalog.delete_expired_series**(metric_schema text, metric_table text, metric_series_table text, ran_at timestamp with time zone)
 ```
 ### _prom_catalog.delete_series_catalog_row
 
@@ -594,7 +594,7 @@ procedure void **_prom_catalog.drop_metric_chunks**(IN schema_name text, IN metr
 ### _prom_catalog.epoch_abort
 ABORT an INSERT transaction due to the ID epoch being out of date
 ```
-function void **_prom_catalog.epoch_abort**(user_epoch bigint)
+function void **_prom_catalog.epoch_abort**(user_epoch timestamp with time zone)
 ```
 ### _prom_catalog.execute_compression_policy
 compress data according to the policy. This procedure should be run regularly in a cron job
@@ -820,6 +820,12 @@ function TABLE(hypertable_name text, node_name text, node_up boolean) **_prom_ca
 
 ```
 function TABLE(hypertable_name text, table_bytes bigint, index_bytes bigint, toast_bytes bigint, total_bytes bigint) **_prom_catalog.hypertable_remote_size**(schema_name_in text)
+```
+### _prom_catalog.initialize_current_epoch
+The current_epoch field of _prom_catalog.global_epoch is initialized to a value in the past.
+       This must be correctly initialized to prevent spurious epoch aborts during ingestion.
+```
+function void **_prom_catalog.initialize_current_epoch**()
 ```
 ### _prom_catalog.insert_exemplar_row
 

--- a/migration/idempotent/001-base.sql
+++ b/migration/idempotent/001-base.sql
@@ -488,7 +488,7 @@ BEGIN
     --these indexes are logically on all series tables but they cannot be defined on the parent due to
     --dump/restore issues.
     EXECUTE format('CREATE INDEX series_labels_%s ON prom_data_series.%I USING GIN (labels)', NEW.id, NEW.table_name);
-    EXECUTE format('CREATE INDEX series_mark_for_deletion_epoch_id_%s ON prom_data_series.%I (mark_for_deletion_epoch, id) WHERE mark_for_deletion_epoch IS NOT NULL', NEW.id, NEW.table_name);
+    EXECUTE format('CREATE INDEX series_mark_for_deletion_epoch_id_%s ON prom_data_series.%I (mark_for_deletion_epoch) INCLUDE (id) WHERE mark_for_deletion_epoch IS NOT NULL', NEW.id, NEW.table_name);
 
     EXECUTE format('ALTER TABLE prom_data_series.%1$I OWNER TO prom_admin', NEW.table_name);
     EXECUTE format('GRANT ALL PRIVILEGES ON TABLE prom_data_series.%I TO prom_admin', NEW.table_name);

--- a/migration/idempotent/011-maintenance.sql
+++ b/migration/idempotent/011-maintenance.sql
@@ -86,7 +86,7 @@ CREATE OR REPLACE FUNCTION _prom_catalog.initialize_current_epoch()
     SET search_path = pg_catalog, pg_temp
 AS $func$
     UPDATE _prom_catalog.global_epoch e SET current_epoch = now()
-    WHERE e.current_epoch = '2020-01-01 00:00:00'::TIMESTAMPTZ;
+    WHERE e.current_epoch = 'epoch'::TIMESTAMPTZ;
 $func$
 LANGUAGE SQL;
 --redundant given schema settings but extra caution for security definers

--- a/migration/incremental/032-logical-epoch-to-time-epoch.sql
+++ b/migration/incremental/032-logical-epoch-to-time-epoch.sql
@@ -1,0 +1,96 @@
+CREATE TABLE _prom_catalog.global_epoch (
+    current_epoch TIMESTAMPTZ NOT NULL,
+    delete_epoch TIMESTAMPTZ NOT NULL,
+    -- force there to only be a single row
+    is_unique BOOLEAN NOT NULL DEFAULT true CHECK (is_unique = true),
+    UNIQUE (is_unique)
+);
+GRANT SELECT ON TABLE _prom_catalog.global_epoch TO prom_reader;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE _prom_catalog.global_epoch TO prom_writer;
+
+DO $block$
+    DECLARE
+        _is_restore_in_progress boolean = false;
+    BEGIN
+        _is_restore_in_progress = coalesce((SELECT setting::boolean from pg_catalog.pg_settings where name = 'timescaledb.restoring'), false);
+        IF _is_restore_in_progress THEN
+            -- if a restore is in progress, we want the value from the backup, not this hardcoded init value
+            RAISE NOTICE 'restore in progress. skipping insert into _prom_catalog.global_epoch';
+            RETURN;
+        END IF;
+        -- this ensures that pristine and migrated DBs have the same values
+        -- it's also important that current_epoch > delete_epoch
+        INSERT INTO _prom_catalog.global_epoch (current_epoch, delete_epoch, is_unique)
+            VALUES ('2020-01-01 00:00:00 UTC', '1970-01-01 00:00:00 UTC', true);
+    END;
+$block$;
+
+ALTER TABLE _prom_catalog.series ADD COLUMN
+    mark_for_deletion_epoch TIMESTAMPTZ NULL DEFAULT NULL;
+
+-- We're changing the signature of epoch_abort, it will be recreated in the
+-- idempotent migration script.
+DROP FUNCTION IF EXISTS _prom_catalog.epoch_abort(BIGINT);
+
+DROP FUNCTION IF EXISTS _prom_catalog.delete_expired_series(text, text, text, timestamptz, BIGINT, timestamptz);
+
+UPDATE _prom_catalog.series s
+SET mark_for_deletion_epoch = now() -- NOTE: we can't use current_epoch because we've initialized it to a value in the past
+FROM (SELECT current_epoch FROM _prom_catalog.global_epoch) as global_epoch
+WHERE s.delete_epoch IS NOT NULL;
+
+DROP TABLE _prom_catalog.ids_epoch;
+-- This cascades to the prom_series.<metric_name> views
+ALTER TABLE _prom_catalog.series DROP COLUMN delete_epoch CASCADE;
+
+DO $block$
+    DECLARE
+        _rec record;
+        label_value_cols text;
+    BEGIN
+        FOR _rec IN (
+            SELECT * FROM _prom_catalog.metric
+            WHERE table_schema = 'prom_data'
+        )
+        LOOP
+            -- Add partial index on mark_for_deletion epoch for all existing partitions of _prom_catalog.series
+            EXECUTE format($$
+                CREATE INDEX IF NOT EXISTS
+                    series_mark_for_deletion_epoch_id_%s
+                ON prom_data_series.%I (mark_for_deletion_epoch, id)
+                WHERE mark_for_deletion_epoch IS NOT NULL
+                $$, _rec.id, _rec.table_name);
+
+            -- Drop the prom_series views
+            EXECUTE format('DROP VIEW IF EXISTS prom_series.%1$I', _rec.table_name);
+
+            -- Note: we cannot use `_prom_catalog.create_series_view` here because it has not been updated yet,
+            -- so we are forced to copy the relevant part of the method body here
+            SELECT
+                ',' || string_agg(
+                    format ('prom_api.val(series.labels[%s]) AS %I',pos::int, _prom_catalog.get_label_key_column_name_for_view(key, false))
+                , ', ' ORDER BY pos)
+            INTO STRICT label_value_cols
+            FROM _prom_catalog.label_key_position lkp
+            WHERE lkp.metric_name = _rec.metric_name and key != '__name__';
+
+            EXECUTE FORMAT($$
+                CREATE OR REPLACE VIEW prom_series.%1$I AS
+                SELECT
+                    id AS series_id,
+                    labels
+                    %2$s
+                FROM
+                    prom_data_series.%1$I AS series
+                WHERE mark_for_deletion_epoch IS NULL
+                $$, _rec.metric_name, label_value_cols);
+
+            EXECUTE FORMAT('GRANT SELECT ON prom_series.%1$I TO prom_reader', _rec.metric_name);
+            EXECUTE FORMAT('ALTER VIEW prom_series.%1$I OWNER TO prom_admin', _rec.metric_name);
+
+            -- The views that we recreated belong to the extension, which we don't want.
+            -- So we drop them from the extension.
+            EXECUTE FORMAT('ALTER EXTENSION promscale DROP VIEW prom_series.%1$I', _rec.metric_name);
+        END LOOP;
+    END;
+$block$;

--- a/sql-tests/testdata/drop_metric.sql
+++ b/sql-tests/testdata/drop_metric.sql
@@ -2,7 +2,7 @@
 \set QUIET 1
 \i 'testdata/scripts/pgtap-1.2.0.sql'
 
-SELECT * FROM plan(49);
+SELECT * FROM plan(45);
 --
 -- Moved from TestSQLDropMetricChunk
 --
@@ -16,8 +16,8 @@ BEGIN
  -- Avoid randomness in chunk interval size by setting explicitly.
  PERFORM _prom_catalog.get_or_create_metric_table_name('test');
  PERFORM public.set_chunk_time_interval('prom_data.test', interval '8 hours');
- -- Set 1h epoch duration to prevent changing defaults from affecting this test's outcome.
- PERFORM _prom_catalog.set_default_value('epoch_duration', (interval '1 hour')::text);
+ -- Explicitly set epoch duration to prevent changing defaults from affecting this test's outcome.
+ PERFORM _prom_catalog.set_default_value('epoch_duration', (interval '4 hour')::text);
 
 
  -- this series (s1) will be deleted along with it's label
@@ -43,9 +43,9 @@ BEGIN
    ('2009-11-11 05:00:00+00',    0.1,s3_series_id); 
 
  PERFORM
-    CASE current_epoch > 0::BIGINT + 1 WHEN true THEN _prom_catalog.epoch_abort(0) 
+    CASE current_epoch <= delete_epoch WHEN true THEN _prom_catalog.epoch_abort(current_epoch)
     END
-  FROM _prom_catalog.ids_epoch 
+  FROM _prom_catalog.global_epoch
   LIMIT 1;
 
  CALL _prom_catalog.finalize_metric_creation();
@@ -55,7 +55,7 @@ END$$;
 -- Checking state of the ingested data prior to drop attempts
 SELECT ok(count(*) = 4, 'none of the chunks are deleted') FROM prom_data.test;
 SELECT ok(count(*) = 3, 'none of the series should be removed yet') FROM _prom_catalog.series;
-SELECT ok(count(*) = 0, 'none of the series should be marked for deletion') FROM _prom_catalog.series WHERE delete_epoch IS NOT NULL;
+SELECT ok(count(*) = 0, 'none of the series should be marked for deletion') FROM _prom_catalog.series WHERE mark_for_deletion_epoch IS NOT NULL;
 SELECT ok(count(*) = 3, 'none of the labels should deleted yet') FROM _prom_catalog.label where key='name1';
 
 -- Dropping the data
@@ -66,7 +66,7 @@ $fnc$
 BEGIN
  RETURN NEXT is(count(*), 2::BIGINT, msg || ': expired chunks are gone') FROM prom_data.test;
  RETURN NEXT is(count(*), 3::BIGINT, msg || ': none of the series should be removed yet') FROM _prom_catalog.series;
- RETURN NEXT is(count(*), 1::BIGINT, msg || ': one series should be marked for deletion') FROM _prom_catalog.series WHERE delete_epoch IS NOT NULL;
+ RETURN NEXT is(count(*), 1::BIGINT, msg || ': one series should be marked for deletion') FROM _prom_catalog.series WHERE mark_for_deletion_epoch IS NOT NULL;
  RETURN NEXT is(count(*), 3::BIGINT, msg || ': none of the labels should deleted yet') FROM _prom_catalog.label where key='name1';
  RETURN;
 END;
@@ -76,10 +76,7 @@ $fnc$;
 CALL _prom_catalog.drop_metric_chunks('prom_data', 'test', E'2009-11-11 00:00:05+00');
 SELECT asserts_before_deletion('after the first timestamp');
 -- Attempting to drop chunks while incrementally moving `run_at` by an hour
--- reruns shouldn't change anything until the epoch advances beyond current_epoch + 4
--- 
--- And current_epoch advances every time ran_at advances for the length of an epoch
--- duration. Which we set to be 1h at the beginning of this test.
+-- reruns shouldn't change anything until run time advances beyond current_epoch + epoch_duration (4 hours)
 CALL _prom_catalog.drop_metric_chunks('prom_data', 'test', E'2009-11-11 00:00:05+00');
 SELECT asserts_before_deletion('after iter 0');
 CALL _prom_catalog.drop_metric_chunks('prom_data', 'test', E'2009-11-11 00:00:05+00', now() + '1 hours');
@@ -88,9 +85,6 @@ CALL _prom_catalog.drop_metric_chunks('prom_data', 'test', E'2009-11-11 00:00:05
 SELECT asserts_before_deletion('after iter 2');
 CALL _prom_catalog.drop_metric_chunks('prom_data', 'test', E'2009-11-11 00:00:05+00', now() + '3 hours');
 SELECT asserts_before_deletion('after iter 3');
-CALL _prom_catalog.drop_metric_chunks('prom_data', 'test', E'2009-11-11 00:00:05+00', now() + '4 hours');
-SELECT asserts_before_deletion('after iter 4');
-
 
 CREATE FUNCTION asserts_after_deletion(msg TEXT)
  RETURNS SETOF TEXT
@@ -99,7 +93,7 @@ $fnc$
 BEGIN
  RETURN NEXT is(count(*), 2::BIGINT, msg || ': expired chunks are gone') FROM prom_data.test;
  RETURN NEXT is(count(*), 2::BIGINT, msg || ': one series should be removed') FROM _prom_catalog.series;
- RETURN NEXT is(count(*), 0::BIGINT, msg || ': no series should be marked for deletion') FROM _prom_catalog.series WHERE delete_epoch IS NOT NULL;
+ RETURN NEXT is(count(*), 0::BIGINT, msg || ': no series should be marked for deletion') FROM _prom_catalog.series WHERE mark_for_deletion_epoch IS NOT NULL;
  RETURN NEXT is(count(*), 2::BIGINT, msg || ': unused labels should deleted') FROM _prom_catalog.label where key='name1';
  RETURN;
 END;
@@ -119,11 +113,11 @@ SELECT asserts_after_deletion('after all iterations');
 
 SELECT throws_like(
   'SELECT
-     CASE current_epoch > 0::BIGINT + 1 WHEN true THEN _prom_catalog.epoch_abort(0) 
+     CASE current_epoch > ''1970-01-01 00:00:00''::TIMESTAMPTZ WHEN true THEN _prom_catalog.epoch_abort(''1970-01-01 00:00:00''::TIMESTAMPTZ)
      END
-   FROM _prom_catalog.ids_epoch 
+   FROM _prom_catalog.global_epoch
    LIMIT 1;',
-   'epoch 0 to old to continue INSERT, current: %',
+   'epoch 1970-01-01 00:00:00+00 to old to continue INSERT, current DB delete epoch: %',
    'Epoch has changed after a series was dropped'
  );
 

--- a/sql-tests/tests/snapshots/tests__testdata__drop_metric.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__drop_metric.sql.snap
@@ -4,7 +4,7 @@ expression: query_result
 ---
  plan  
 -------
- 1..49
+ 1..45
 (1 row)
 
                   ok                   
@@ -67,57 +67,49 @@ expression: query_result
  ok 24 - after iter 3: none of the labels should deleted yet
 (4 rows)
 
-                    asserts_before_deletion                     
-----------------------------------------------------------------
- ok 25 - after iter 4: expired chunks are gone
- ok 26 - after iter 4: none of the series should be removed yet
- ok 27 - after iter 4: one series should be marked for deletion
- ok 28 - after iter 4: none of the labels should deleted yet
+                    asserts_after_deletion                     
+---------------------------------------------------------------
+ ok 25 - after iter 5: expired chunks are gone
+ ok 26 - after iter 5: one series should be removed
+ ok 27 - after iter 5: no series should be marked for deletion
+ ok 28 - after iter 5: unused labels should deleted
 (4 rows)
 
                     asserts_after_deletion                     
 ---------------------------------------------------------------
- ok 29 - after iter 5: expired chunks are gone
- ok 30 - after iter 5: one series should be removed
- ok 31 - after iter 5: no series should be marked for deletion
- ok 32 - after iter 5: unused labels should deleted
+ ok 29 - after iter 6: expired chunks are gone
+ ok 30 - after iter 6: one series should be removed
+ ok 31 - after iter 6: no series should be marked for deletion
+ ok 32 - after iter 6: unused labels should deleted
 (4 rows)
 
                     asserts_after_deletion                     
 ---------------------------------------------------------------
- ok 33 - after iter 6: expired chunks are gone
- ok 34 - after iter 6: one series should be removed
- ok 35 - after iter 6: no series should be marked for deletion
- ok 36 - after iter 6: unused labels should deleted
+ ok 33 - after iter 7: expired chunks are gone
+ ok 34 - after iter 7: one series should be removed
+ ok 35 - after iter 7: no series should be marked for deletion
+ ok 36 - after iter 7: unused labels should deleted
 (4 rows)
 
                     asserts_after_deletion                     
 ---------------------------------------------------------------
- ok 37 - after iter 7: expired chunks are gone
- ok 38 - after iter 7: one series should be removed
- ok 39 - after iter 7: no series should be marked for deletion
- ok 40 - after iter 7: unused labels should deleted
-(4 rows)
-
-                    asserts_after_deletion                     
----------------------------------------------------------------
- ok 41 - after iter 8: expired chunks are gone
- ok 42 - after iter 8: one series should be removed
- ok 43 - after iter 8: no series should be marked for deletion
- ok 44 - after iter 8: unused labels should deleted
+ ok 37 - after iter 8: expired chunks are gone
+ ok 38 - after iter 8: one series should be removed
+ ok 39 - after iter 8: no series should be marked for deletion
+ ok 40 - after iter 8: unused labels should deleted
 (4 rows)
 
                         asserts_after_deletion                         
 -----------------------------------------------------------------------
- ok 45 - after all iterations: expired chunks are gone
- ok 46 - after all iterations: one series should be removed
- ok 47 - after all iterations: no series should be marked for deletion
- ok 48 - after all iterations: unused labels should deleted
+ ok 41 - after all iterations: expired chunks are gone
+ ok 42 - after all iterations: one series should be removed
+ ok 43 - after all iterations: no series should be marked for deletion
+ ok 44 - after all iterations: unused labels should deleted
 (4 rows)
 
                      throws_like                      
 ------------------------------------------------------
- ok 49 - Epoch has changed after a series was dropped
+ ok 45 - Epoch has changed after a series was dropped
 (1 row)
 
  finish 


### PR DESCRIPTION
## Description

This change adjusts the existing logical cache epoch mechanism to be
time-based.

Effectively the time-based epoch mechanism uses the current system time
(`now()`) to determine the current epoch. The primary advantage of this
mechanism is that it allows for exact time-based decisions to be made on
when to drop series data (the logical epoch mechanism relied on the fact
that the epoch was incremented on a fixed time schedule).

The `_prom_catalog.global_epoch` table contains one row tracking the
`current_epoch`, and `delete_epoch`, both TIMESTAMPTZ. This table
replaces `_prom_catalog.ids_epoch`.

The `delete_epoch` column in the `prom_data_series.<metric_name>` table
was replaced with the `mark_for_deletion_epoch` column.

`current_epoch` contains the timestamp of the current epoch, and is
updated every time we delete series.
`mark_for_deletion_epoch` contains either NULL, or a TIMESTAMPTZ, which
is the value of `current_epoch` when the decision was made to delete the
series in the future.
`delete_epoch` contains the maximum value of `mark_for_deletion_epoch`
for rows in `prom_data_series.<metric_name>` which were deleted.
## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation