### PR TITLE
Make timescaledb mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ We use the following categories for changes:
   `_prom_catalog.lock_for_vacuum_engine`, and 
   `_prom_catalog.unlock_for_vacuum_engine()` [#511]
 
+### Changed
+
+- The timescaledb extension is now a mandatory prerequisite [#515].
+
 ### Fixed
 
 - Correctly remove all expired series [#521]

--- a/templates/promscale.control
+++ b/templates/promscale.control
@@ -6,6 +6,9 @@ default_version = '@CARGO_VERSION@'
 relocatable = false
 schema = public
 superuser = true
+{%if requires_timescaledb -%}
+requires = 'timescaledb'
+{%-endif%}
 {%if !is_pg_12 -%}
 trusted = true
 {%-endif%}


### PR DESCRIPTION
## Description

This change adds a `requires` entry to the extension control file,
making the `timescaledb` extension mandatory for installation.

We omit the `requires` entry when running `cargo pgx test`, because of
the (unnecessary) burden that it imposes on developer setup.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] ~~Updated the relevant documentation~~