### PR TITLE
Remove Promscale connector from package smoke tests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,7 +121,6 @@ jobs:
         PACKAGE_TO_TEST: artifacts/${{ steps.metadata.outputs.outfile }}
         IMAGE_BASE: ${{ steps.metadata.outputs.image }}-test
         DOCKER_FILE: dist/${{ matrix.os.pkg_type }}.test.dockerfile
-        CONNECTOR_DOCKER_IMAGE: "timescale/promscale:0.11.0-alpha"
       run: |
         for pkg_cloud_tag in ${{ join(matrix.os.pkg_cloud_tags, ' ') }}; do \
           DISTRO=$(echo ${pkg_cloud_tag} | cut -d'/' -f 1 | sed 's/el/centos/'); \
@@ -135,7 +134,7 @@ jobs:
             -t ${EXTENSION_DOCKER_IMAGE} \
             -f ${DOCKER_FILE} \
             . ; \
-          ./tools/smoke-test "${EXTENSION_DOCKER_IMAGE}" "${CONNECTOR_DOCKER_IMAGE}" "${DOCKER_PLATFORM}"; \
+          ./tools/smoke-test "${EXTENSION_DOCKER_IMAGE}" "${DOCKER_PLATFORM}"; \
         done
 
     - name: Upload Artifact for Job

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ endif
 
 .PHONY: release-test
 release-test: release-tester ## Test the currently selected release package
-	./tools/smoke-test "$(RELEASE_IMAGE_NAME)-test" "timescale/promscale:0.11.0-alpha" $(DOCKER_PLATFORM)
+	./tools/smoke-test "$(RELEASE_IMAGE_NAME)-test" $(DOCKER_PLATFORM)
 
 .PHONY: post-release
 post-release: promscale.control

--- a/tools/smoke-test
+++ b/tools/smoke-test
@@ -7,8 +7,7 @@ set -euo pipefail
 
 # It takes three positional arguments:
 EXTENSION_DOCKER_IMAGE=$1 # e.g. ghcr.io/timescale/promscale_dev_extension:master-ts2-pg14
-CONNECTOR_DOCKER_IMAGE=$2 # e.g. timescale/promscale:0.11.0
-DOCKER_PLATFORM=$3 # e.g. linux/amd64
+DOCKER_PLATFORM=$2 # e.g. linux/amd64
 
 TESTER_NAME=$(echo "${EXTENSION_DOCKER_IMAGE}" | sed 's/[:]/-/')
 
@@ -21,7 +20,9 @@ for i in $(seq 10) ; do
   sleep 1
 done
 
-if ! docker run --rm --link "${TESTER_NAME}" --platform="${DOCKER_PLATFORM}" -i "${CONNECTOR_DOCKER_IMAGE}" -db.uri "postgres://postgres:postgres@${TESTER_NAME}:5432/postgres?sslmode=allow" -startup.only -startup.upgrade-prerelease-extensions; then
+docker exec -ti "${TESTER_NAME}" psql -c 'CREATE EXTENSION promscale;'
+
+if ! docker exec -ti "${TESTER_NAME}" psql -c '\dx promscale;' | grep 'promscale'; then
     echo "Encountered error while testing image ${EXTENSION_DOCKER_IMAGE}";
     docker logs "${TESTER_NAME}"
     docker stop "${TESTER_NAME}"


### PR DESCRIPTION
## Description

It used to be that we required the connector to smoke test the extension packages, because the extension could not be installed standalone. Since 0.5.0, this has been possible.

Using the connector to smoke test the installation causes problems when the connector is not compatible with the new extension version, which has happened when the extension minor version is incremented.

Fixes #516

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~