### PR TITLE
Add retry mechanism to connection creation in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,6 +2272,7 @@ dependencies = [
 name = "test-common"
 version = "0.1.0"
 dependencies = [
+ "log",
  "postgres",
  "pretty_env_logger",
  "rand 0.8.5",

--- a/test-common/Cargo.toml
+++ b/test-common/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+log = "0.4.17"
 postgres = "0.19.2"
 pretty_env_logger = "0.4"
 testcontainers = "0.14.0"


### PR DESCRIPTION
## Description

We've observed connection establishment failing numerous times in CI with "Connection reset by peer" (see [1], [2], [3]). For lack of a better alternative, I'm assuming that retrying it might fix the problem.

[1]: https://github.com/timescale/promscale_extension/issues/385#issuecomment-1226951114
[2]: https://github.com/timescale/promscale_extension/issues/385#issuecomment-1227213636
[3]: https://github.com/timescale/promscale_extension/issues/385#issuecomment-1248345194

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~