### PR TITLE
Drop non empty span name check constraint from `_ps_trace.operation` table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ We use the following categories for changes:
 
 - Correctly remove all expired series [#521]
 
+### Changed
+
+- Drop non empty span name check constraint from `_ps_trace.operation` table [#520]
+
 ## [0.6.0] - 2022-08-25
 
 ### Added

--- a/migration/incremental/032-remove-non-empty-span-name-constraint.sql
+++ b/migration/incremental/032-remove-non-empty-span-name-constraint.sql
@@ -1,0 +1,10 @@
+-- Our tracing implementation is based on OTLP spec, though OTLP spec
+-- doesn't mandate span name to be non empty[1], we have a constraint
+-- in the _ps_trace.operation table which raises error on empty span name.
+-- On the other hand, Jaeger span name can be empty and their storage
+-- integration tests validates the same[2]. Jaeger author even suggested to
+-- remove[3] the constraint as it shouldn't trouble any part of the system.
+-- [1] https://github.com/open-telemetry/opentelemetry-proto/blob/724e427879e3d2bae2edc0218fff06e37b9eb46e/opentelemetry/proto/trace/v1/trace.proto#L110-L121
+-- [2] https://github.com/jaegertracing/jaeger/blob/7872d1b07439c3f2d316065b1fd53e885b26a66f/plugin/storage/integration/fixtures/traces/default.json#L6
+-- [3] https://github.com/jaegertracing/jaeger/pull/3922#issuecomment-1256505785
+ALTER TABLE _ps_trace.operation DROP CONSTRAINT operation_span_name_check;


### PR DESCRIPTION

## Description

Our tracing implementation is based on OTLP spec, though OTLP spec doesn't mandate span name to be non empty[1], we have a constraint in the _ps_trace.operation table which raises error on empty span name. On the other hand, Jaeger span name can be empty and their storage integration tests validates the same[2]. Jaeger author even suggested to remove[3] the constraint as it shouldn't trouble any part of the system.

[1] https://github.com/open-telemetry/opentelemetry-proto/blob/724e427879e3d2bae2edc0218fff06e37b9eb46e/opentelemetry/proto/trace/v1/trace.proto#L110-L121 
[2] https://github.com/jaegertracing/jaeger/blob/7872d1b07439c3f2d316065b1fd53e885b26a66f/plugin/storage/integration/fixtures/traces/default.json#L6 
[3] https://github.com/jaegertracing/jaeger/pull/3922#issuecomment-1256505785

Signed-off-by: Arunprasad Rajkumar <ar.arunprasad@gmail.com>

Fixes https://github.com/timescale/promscale/issues/1621#issuecomment-1239182178


## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation