### PR TITLE
Correctly remove all expired series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ We use the following categories for changes:
   `_prom_catalog.lock_for_vacuum_engine`, and 
   `_prom_catalog.unlock_for_vacuum_engine()` [#511]
 
+### Fixed
+
+- Correctly remove all expired series [#521]
+
 ## [0.6.0] - 2022-08-25
 
 ### Added


### PR DESCRIPTION
## Description

The logic in `_prom_catalog.delete_expired_series` mixed two unrelated concepts resulting in a bug.

Calling `delete_expired_series` should both:
1. Delete series belonging to the metric `metric_table` which have been marked for deletion, and which are old enough.
2. Increment the cache epoch every `epoch_duration`.

The bug meant that we would only delete the series (for one metric) if the cache epoch could also be incremented. This effectively meant that we would drop the expired series for one metric every `epoch_duration`.

This change ensures that expired series are always deleted, but the cache epoch is only incremented every `epoch_duration`.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] ~~Updated the relevant documentation~~