### PR TITLE
Reuse ingestion temp tables across batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ We use the following categories for changes:
 ### Changed
 
 - The timescaledb extension is now a mandatory prerequisite [#515].
+- Reuse ingestion temp tables across batches [#526]
 
 ### Fixed
 

--- a/migration/idempotent/001-base.sql
+++ b/migration/idempotent/001-base.sql
@@ -3462,7 +3462,7 @@ DECLARE
 BEGIN
     SET LOCAL log_statement = 'none';
     temp_table := left(CONCAT(table_prefix, table_name), 62);
-    EXECUTE format($sql$CREATE TEMPORARY TABLE IF NOT EXISTS %I (LIKE %I.%I) ON COMMIT DROP$sql$,
+    EXECUTE format($sql$CREATE TEMPORARY TABLE IF NOT EXISTS %I (LIKE %I.%I) ON COMMIT DELETE ROWS$sql$,
                  temp_table, schema_name, table_name);
     EXECUTE format($sql$GRANT SELECT, INSERT ON TABLE %I TO prom_writer$sql$,
                  temp_table);


### PR DESCRIPTION
## Description

The temp table is currently created with ON COMMIT DROP, which requires that the temp table be recreated with each transaction. This incurs significant pg_catalog churn/bloat. With this change, the temp tables are created with ON COMMIT DELETE ROWS. This essentially truncates the table at the end of the transaction, but the table remains.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation