### PR TITLE
Add active_series and last_updated as telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ We use the following categories for changes:
   Added `prom_info.metric_detail` which includes the disk size related columns. 
   Improved the performance of these. [#547]
 
+### Added
+- Telemetry for active series and last updated [#534]
+
 ## [0.7.0 - 2022-10-03]
 
 ### Added
@@ -31,7 +34,6 @@ We use the following categories for changes:
   `_prom_catalog.lock_for_vacuum_engine`, and
   `_prom_catalog.unlock_for_vacuum_engine()` [#511]
 - Added ability for database owners to override security checks in script migrating from Promscale < 0.10.0 [#524]
-- Added telemetry for active series for Promscale [#534]
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ We use the following categories for changes:
   `_prom_catalog.lock_for_vacuum_engine`, and
   `_prom_catalog.unlock_for_vacuum_engine()` [#511]
 - Added ability for database owners to override security checks in script migrating from Promscale < 0.10.0 [#524]
+- Added telemetry for active series for Promscale [#534]
 
 ### Changed
 

--- a/migration/idempotent/010-telemetry.sql
+++ b/migration/idempotent/010-telemetry.sql
@@ -143,6 +143,9 @@ $$
 
         SELECT count(*)::TEXT INTO result FROM timescaledb_information.data_nodes;
         PERFORM _ps_catalog.apply_telemetry('db_node_count', result);
+
+        SELECT current_timestamp::TEXT INTO result; -- UTC timestamp.
+        PERFORM _ps_catalog.apply_telemetry('telemetry_last_updated', result);
     END;
 $$
 LANGUAGE PLPGSQL;


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

Implements `Number of active series` in https://github.com/timescale/promscale/issues/1616

## Description

<!--Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.-->

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation