### PR TITLE
Bump Github Actions versions where applicable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.PROMSCALE_EXTENSION_SCCACHE_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.PROMSCALE_EXTENSION_SCCACHE_AWS_SECRET_ACCESS_KEY }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:
@@ -39,7 +39,7 @@ jobs:
 
       - name: Cache pgx
         id: cache-pgx
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.pgx
           key: dot-pgx-${{ matrix.postgres.version }}-cargo-${{ hashFiles('**/Cargo.*') }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -27,13 +27,13 @@ jobs:
         - ha
         - alpine
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -54,7 +54,7 @@ jobs:
           echo "::set-output name=build_type_suffix::${build_type_suffix}"
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         env:
           DOCKER_PUSH_REQUIRED: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'timescale' }} # Don't run docker push when this is a PR from a fork
         with:
@@ -110,7 +110,7 @@ jobs:
           git diff --exit-code
 
       - name: Login to Dockerhub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         # A dash indicates prerelease in SemVer
         if: ${{ startsWith(github.ref, 'refs/tags') && !contains(github.ref, '-') && matrix.base == 'alpine' }}
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,7 +7,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:
@@ -29,7 +29,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.PROMSCALE_EXTENSION_SCCACHE_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.PROMSCALE_EXTENSION_SCCACHE_AWS_SECRET_ACCESS_KEY }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:
@@ -71,15 +71,15 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.PROMSCALE_EXTENSION_SCCACHE_AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Checkout extension code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 
       - name: Checkout pgspot
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'timescale/pgspot'
           ref: '0.2.0'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
       run: |
         sudo gem install package_cloud --no-doc
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Gather Metadata
       id: metadata
@@ -79,13 +79,13 @@ jobs:
         echo "::set-output name=image::promscale-extension:${tag}.pg${{ matrix.postgres.version }}.${{ matrix.os.distro }}${{ matrix.os.version }}"
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Build Package
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         context: .
         load: true
@@ -138,7 +138,7 @@ jobs:
         done
 
     - name: Upload Artifact for Job
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.metadata.outputs.outfile }}
         path: artifacts/${{ steps.metadata.outputs.outfile }}
@@ -162,11 +162,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: package
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Download Packages
       id: download
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         path: packages
 


### PR DESCRIPTION
## Description

Update github actions (where applicable) to avoid node12 warnings.
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Some other actions have not yet been updated to node16.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation