### PR TITLE
Optimize prom_info.metric view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ We use the following categories for changes:
 
 ## [Unreleased]
 
+### Changed
+
+- Removed disk size related columns from `prom_info.metric`. 
+  Added `prom_info.metric_detail` which includes the disk size related columns. 
+  Improved the performance of these. [#547]
+
 ## [0.7.0 - 2022-10-03]
 
 ### Added

--- a/docs/sql-api.md
+++ b/docs/sql-api.md
@@ -954,10 +954,10 @@ function boolean **_prom_catalog.match_regexp_matches**(labels label_array, _op 
 ```
 function boolean **_prom_catalog.match_regexp_not_matches**(labels label_array, _op tag_op_regexp_not_matches)
 ```
-### _prom_catalog.metric_view
-
+### _prom_catalog.metric_detail
+Returns details describing each metric table including disk sizes
 ```
-function TABLE(id integer, metric_name text, table_name text, label_keys text[], retention_period interval, chunk_interval interval, compressed_interval interval, total_interval interval, before_compression_bytes bigint, after_compression_bytes bigint, total_size_bytes bigint, total_size text, compression_ratio numeric, total_chunks bigint, compressed_chunks bigint) **_prom_catalog.metric_view**()
+function TABLE(id integer, metric_name text, table_name text, label_keys text[], retention_period interval, chunk_interval interval, compressed_interval interval, total_interval interval, before_compression_bytes bigint, after_compression_bytes bigint, total_size_bytes bigint, total_size text, compression_ratio numeric, total_chunks bigint, compressed_chunks bigint) **_prom_catalog.metric_detail**()
 ```
 ### _prom_catalog.pg_name_unique
 

--- a/migration/incremental/033-metric-view.sql
+++ b/migration/incremental/033-metric-view.sql
@@ -1,0 +1,12 @@
+DO $block$
+BEGIN
+    DROP VIEW IF EXISTS prom_info.metric;
+    DROP FUNCTION IF EXISTS _prom_catalog.metric_view();
+EXCEPTION WHEN dependent_objects_still_exist THEN
+    RAISE EXCEPTION dependent_objects_still_exist USING
+        DETAIL = 'The signature of prom_info.metric is changing. ' ||
+        'Dependent objects need to be dropped before the upgrade, and recreated afterwards.',
+        HINT = 'Drop any objects that depend on prom_info.metric'
+        ;
+END;
+$block$;

--- a/sql-tests/testdata/info_view.sql
+++ b/sql-tests/testdata/info_view.sql
@@ -17,14 +17,74 @@ INSERT INTO prom_data.cpu_total
 SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.0, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_total", "namespace":"production", "node": "pinky", "new_tag_2":"bar"}')
 FROM generate_series(1,10) g;
 
-SELECT id , metric_name , table_name, retention_period, chunk_interval > interval '7 hour', compressed_interval > interval '7 hour', before_compression_bytes, after_compression_bytes, label_keys, total_size, total_size_bytes, compression_ratio, total_chunks, compressed_chunks FROM prom_info.metric ORDER BY id;
+SELECT
+    id,
+    metric_name,
+    table_name,
+    label_keys,
+    retention_period,
+    chunk_interval > interval '7 hours',
+    compressed_interval > interval '7 hours',
+    total_chunks,
+    compressed_chunks
+FROM prom_info.metric
+ORDER BY id;
+
+SELECT
+    id,
+    metric_name,
+    table_name,
+    retention_period,
+    chunk_interval > interval '7 hour',
+    compressed_interval > interval '7 hour',
+    before_compression_bytes,
+    after_compression_bytes,
+    label_keys,
+    total_size,
+    total_size_bytes,
+    compression_ratio,
+    total_chunks,
+    compressed_chunks
+FROM prom_info.metric_detail
+ORDER BY id;
 -- compress chunks
 SELECT public.compress_chunk(public.show_chunks('prom_data.cpu_usage'));
 SELECT public.compress_chunk(public.show_chunks('prom_data.cpu_total'));
 -- fetch stats with compressed chunks
 
 SET ROLE prom_reader;
-SELECT id , metric_name , table_name, retention_period, chunk_interval > interval '7 hour', compressed_interval > interval '7 hour', before_compression_bytes, after_compression_bytes, label_keys, total_size, total_size_bytes, compression_ratio, total_chunks, compressed_chunks FROM prom_info.metric ORDER BY id;
+
+SELECT
+    id,
+    metric_name,
+    table_name,
+    label_keys,
+    retention_period,
+    chunk_interval > interval '7 hours',
+    compressed_interval > interval '7 hours',
+    total_chunks,
+    compressed_chunks
+FROM prom_info.metric
+ORDER BY id;
+
+SELECT
+    id,
+    metric_name,
+    table_name,
+    retention_period,
+    chunk_interval > interval '7 hour',
+    compressed_interval > interval '7 hour',
+    before_compression_bytes,
+    after_compression_bytes,
+    label_keys,
+    total_size,
+    total_size_bytes,
+    compression_ratio,
+    total_chunks,
+    compressed_chunks
+FROM prom_info.metric_detail
+ORDER BY id;
+
 SELECT * FROM prom_info.label ORDER BY key;
 SELECT * FROM prom_info.metric_stats ORDER BY num_series_approx;
 SELECT * FROM prom_info.system_stats;

--- a/sql-tests/tests/snapshots/tests__testdata__info_view.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__info_view.sql.snap
@@ -33,7 +33,41 @@ INSERT INTO prom_data.cpu_total
 SELECT timestamptz '2000-01-01 02:03:04'+(interval '1s' * g), 100.0, _prom_catalog.get_or_create_series_id('{"__name__": "cpu_total", "namespace":"production", "node": "pinky", "new_tag_2":"bar"}')
 FROM generate_series(1,10) g;
 INSERT 0 10
-SELECT id , metric_name , table_name, retention_period, chunk_interval > interval '7 hour', compressed_interval > interval '7 hour', before_compression_bytes, after_compression_bytes, label_keys, total_size, total_size_bytes, compression_ratio, total_chunks, compressed_chunks FROM prom_info.metric ORDER BY id;
+SELECT
+    id,
+    metric_name,
+    table_name,
+    label_keys,
+    retention_period,
+    chunk_interval > interval '7 hours',
+    compressed_interval > interval '7 hours',
+    total_chunks,
+    compressed_chunks
+FROM prom_info.metric
+ORDER BY id;
+ id | metric_name | table_name |             label_keys              | retention_period | ?column? | ?column? | total_chunks | compressed_chunks 
+----+-------------+------------+-------------------------------------+------------------+----------+----------+--------------+-------------------
+  1 | cpu_usage   | cpu_usage  | {__name__,namespace,new_tag,node}   | 90 days          | t        | f        |            1 |                 0
+  2 | cpu_total   | cpu_total  | {__name__,namespace,new_tag_2,node} | 90 days          | t        | f        |            1 |                 0
+(2 rows)
+
+SELECT
+    id,
+    metric_name,
+    table_name,
+    retention_period,
+    chunk_interval > interval '7 hour',
+    compressed_interval > interval '7 hour',
+    before_compression_bytes,
+    after_compression_bytes,
+    label_keys,
+    total_size,
+    total_size_bytes,
+    compression_ratio,
+    total_chunks,
+    compressed_chunks
+FROM prom_info.metric_detail
+ORDER BY id;
  id | metric_name | table_name | retention_period | ?column? | ?column? | before_compression_bytes | after_compression_bytes |             label_keys              | total_size | total_size_bytes | compression_ratio | total_chunks | compressed_chunks 
 ----+-------------+------------+------------------+----------+----------+--------------------------+-------------------------+-------------------------------------+------------+------------------+-------------------+--------------+-------------------
   1 | cpu_usage   | cpu_usage  | 90 days          | t        | f        |                          |                         | {__name__,namespace,new_tag,node}   | 32 kB      |            32768 |                   |            1 |                 0
@@ -56,7 +90,41 @@ SELECT public.compress_chunk(public.show_chunks('prom_data.cpu_total'));
 -- fetch stats with compressed chunks
 SET ROLE prom_reader;
 SET
-SELECT id , metric_name , table_name, retention_period, chunk_interval > interval '7 hour', compressed_interval > interval '7 hour', before_compression_bytes, after_compression_bytes, label_keys, total_size, total_size_bytes, compression_ratio, total_chunks, compressed_chunks FROM prom_info.metric ORDER BY id;
+SELECT
+    id,
+    metric_name,
+    table_name,
+    label_keys,
+    retention_period,
+    chunk_interval > interval '7 hours',
+    compressed_interval > interval '7 hours',
+    total_chunks,
+    compressed_chunks
+FROM prom_info.metric
+ORDER BY id;
+ id | metric_name | table_name |             label_keys              | retention_period | ?column? | ?column? | total_chunks | compressed_chunks 
+----+-------------+------------+-------------------------------------+------------------+----------+----------+--------------+-------------------
+  1 | cpu_usage   | cpu_usage  | {__name__,namespace,new_tag,node}   | 90 days          | t        | t        |            1 |                 1
+  2 | cpu_total   | cpu_total  | {__name__,namespace,new_tag_2,node} | 90 days          | t        | t        |            1 |                 1
+(2 rows)
+
+SELECT
+    id,
+    metric_name,
+    table_name,
+    retention_period,
+    chunk_interval > interval '7 hour',
+    compressed_interval > interval '7 hour',
+    before_compression_bytes,
+    after_compression_bytes,
+    label_keys,
+    total_size,
+    total_size_bytes,
+    compression_ratio,
+    total_chunks,
+    compressed_chunks
+FROM prom_info.metric_detail
+ORDER BY id;
  id | metric_name | table_name | retention_period | ?column? | ?column? | before_compression_bytes | after_compression_bytes |             label_keys              | total_size | total_size_bytes |  compression_ratio   | total_chunks | compressed_chunks 
 ----+-------------+------------+------------------+----------+----------+--------------------------+-------------------------+-------------------------------------+------------+------------------+----------------------+--------------+-------------------
   1 | cpu_usage   | cpu_usage  | 90 days          | t        | t        |                    24576 |                   32768 | {__name__,namespace,new_tag,node}   | 48 kB      |            49152 | -33.3333333333333300 |            1 |                 1


### PR DESCRIPTION
## Description

`prom_info.metric` can be quite slow. Part of this is due to the columns that deal with disk size. Split the view into two views - one that does not have the size columns and is optimized for speed, and the original.

`prom_info.metric` is now a SQL view (not backed by a function) and it omits the columns dealing with disk size. On a test database containing 2,500 metrics and 1.5 million chunks, it returned in ~4 seconds whereas the original was killed after running for > 20 minutes.

`prom_info.metric_detail` is a view that is backed by a function (`_prom_catalog.metric_detail`) which has the same signature as the original view. i.e. it contains the columns dealing with disk size. If this is a multinode installation (which we don't currently even support), it executes the original query. If this is a singlenode installation (which should be everyone), we use a new optimized query.

The new `prom_info.metric_detail` returns in 2.5 minutes on a test system with 2,500 metrics and 1.5 million chunks.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation