### PR TITLE
Maintenance jobs metrics without backend local side channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ We use the following categories for changes:
   `prom_api.config_maintenance_jobs` call changed and it sets identical parameters
   for each job type (e.g. parallism 2 means each job type has 2 jobs, not 2 jobs in total).
   There is also the new `prom_api.config_maintenance_jobs` that allows configuring
-  them individually.
+  them individually. Finally, the new default worker allocation is 2 metrics retention
+  jobs, 1 job for metrics compression and 1 job for traces retention. [#555]
 - Removed disk size related columns from `prom_info.metric`. 
   Added `prom_info.metric_detail` which includes the disk size related columns. 
   Improved the performance of these. [#547]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ We use the following categories for changes:
 
 ### Changed
 
+- Maintenance jobs were separated from one another. The bejaviour of the old 
+  `prom_api.config_maintenance_jobs` call changed and it sets identical parameters
+  for each job type (e.g. parallism 2 means each job type has 2 jobs, not 2 jobs in total).
+  There is also the new `prom_api.config_maintenance_jobs` that allows configuring
+  them individually.
 - Removed disk size related columns from `prom_info.metric`. 
   Added `prom_info.metric_detail` which includes the disk size related columns. 
   Improved the performance of these. [#547]

--- a/docs/sql-api.md
+++ b/docs/sql-api.md
@@ -7,9 +7,14 @@
 procedure void **prom_api.add_prom_node**(IN node_name text, IN attach_to_existing_metrics boolean DEFAULT true)
 ```
 ### prom_api.config_maintenance_jobs
-Configure the number of maintenance jobs run by the job scheduler, as well as their scheduled interval
+Configure the number of maintenance jobs run by the job scheduler, as well as their scheduled interval. Sets identical settings for all job types.
 ```
 function boolean **prom_api.config_maintenance_jobs**(number_jobs integer, new_schedule_interval interval, new_config jsonb DEFAULT NULL::jsonb)
+```
+### prom_api.config_maintenance_jobs
+Configure the number of maintenance jobs run by the job scheduler, as well as their scheduled interval
+```
+function boolean **prom_api.config_maintenance_jobs**(signal _ps_catalog.signal_type, job_type _ps_catalog.job_type, number_jobs integer, new_schedule_interval interval, new_config jsonb DEFAULT NULL::jsonb)
 ```
 ### prom_api.drop_metric
 
@@ -32,9 +37,15 @@ returns true if the label array and matchers are equal, there should not be a ma
 function boolean **prom_api.eq**(labels1 label_array, matchers matcher_positive)
 ```
 ### prom_api.execute_maintenance
-Execute maintenance tasks like dropping data according to retention policy. This procedure should be run regularly in a cron job
+Execute maintenance tasks like dropping data according to retention policy.
+ This function exists for backwards compatiblity and executes all types of jobs except trace compression at once
 ```
 procedure void **prom_api.execute_maintenance**(IN log_verbose boolean DEFAULT false)
+```
+### prom_api.execute_maintenance
+Executes a specified maintenance job type like dropping data according to retention policy. This procedure should be run regularly in a cron job
+```
+procedure void **prom_api.execute_maintenance**(IN signal _ps_catalog.signal_type, IN job_type _ps_catalog.job_type, IN log_verbose boolean DEFAULT false)
 ```
 ### prom_api.get_default_chunk_interval
 Get the default chunk interval for all metrics

--- a/migration/idempotent/011-maintenance.sql
+++ b/migration/idempotent/011-maintenance.sql
@@ -447,9 +447,9 @@ GRANT EXECUTE ON PROCEDURE _prom_catalog.execute_data_retention_policy(boolean) 
 CREATE OR REPLACE PROCEDURE prom_api.execute_maintenance(log_verbose boolean = false)
 AS $$
 BEGIN
-    CALL prom_api.execute_maintenance('metrics', 'compression', log_verbose);
     CALL prom_api.execute_maintenance('metrics', 'retention', log_verbose);
     CALL prom_api.execute_maintenance('traces', 'retention', log_verbose);
+    CALL prom_api.execute_maintenance('metrics', 'compression', log_verbose);
 END;
 $$ LANGUAGE PLPGSQL;
 COMMENT ON PROCEDURE prom_api.execute_maintenance(boolean)

--- a/migration/idempotent/011-maintenance.sql
+++ b/migration/idempotent/011-maintenance.sql
@@ -444,12 +444,25 @@ COMMENT ON PROCEDURE _prom_catalog.execute_data_retention_policy(boolean)
 IS 'drops old data according to the data retention policy. This procedure should be run regularly in a cron job';
 GRANT EXECUTE ON PROCEDURE _prom_catalog.execute_data_retention_policy(boolean) TO prom_maintenance;
 
+CREATE OR REPLACE PROCEDURE prom_api.execute_maintenance(log_verbose boolean = false)
+AS $$
+BEGIN
+    CALL prom_api.execute_maintenance('metrics', 'compression', log_verbose);
+    CALL prom_api.execute_maintenance('metrics', 'retention', log_verbose);
+    CALL prom_api.execute_maintenance('traces', 'retention', log_verbose);
+END;
+$$ LANGUAGE PLPGSQL;
+COMMENT ON PROCEDURE prom_api.execute_maintenance(boolean)
+IS 'Execute maintenance tasks like dropping data according to retention policy.
+ This function exists for backwards compatiblity and executes all types of jobs except trace compression at once';
+GRANT EXECUTE ON PROCEDURE prom_api.execute_maintenance(boolean) TO prom_maintenance;
+
 --public procedure to be called by cron
---right now just does data retention but name is generic so that
---we can add stuff later without needing people to change their cron scripts
 --should be the last thing run in a session so that all session locks
 --are guaranteed released on error.
-CREATE OR REPLACE PROCEDURE prom_api.execute_maintenance(log_verbose boolean = false)
+CREATE OR REPLACE PROCEDURE prom_api.execute_maintenance(signal _ps_catalog.signal_type,
+                                                         job_type _ps_catalog.job_type,
+                                                         log_verbose boolean = false)
 AS $$
 DECLARE
    startT TIMESTAMPTZ;
@@ -460,40 +473,44 @@ BEGIN
 
     startT := clock_timestamp();
     IF log_verbose THEN
-        RAISE LOG 'promscale maintenance: data retention: starting';
+        RAISE LOG 'promscale maintenance: % %: starting', signal, job_type;
     END IF;
 
-    PERFORM _prom_catalog.set_app_name( format('promscale maintenance: data retention'));
-    CALL _prom_catalog.execute_data_retention_policy(log_verbose=>log_verbose);
-    CALL _ps_trace.execute_data_retention_policy(log_verbose=>log_verbose);
-
-    IF NOT _prom_catalog.is_timescaledb_oss() THEN
-        IF log_verbose THEN
-            RAISE LOG 'promscale maintenance: compression: starting';
+    IF job_type = 'retention' THEN
+        PERFORM _prom_catalog.set_app_name('promscale maintenance: data retention');
+        IF signal = 'metrics' THEN
+            CALL _prom_catalog.execute_data_retention_policy(log_verbose=>log_verbose);
         END IF;
+        IF signal = 'traces' THEN
+            CALL _ps_trace.execute_data_retention_policy(log_verbose=>log_verbose);
+        END IF;
+    END IF;
 
-        PERFORM _prom_catalog.set_app_name( format('promscale maintenance: compression'));
+    IF NOT _prom_catalog.is_timescaledb_oss() AND job_type = 'compression' THEN
+        PERFORM _prom_catalog.set_app_name('promscale maintenance: compression');
         CALL _prom_catalog.execute_compression_policy(log_verbose=>log_verbose);
     END IF;
 
     IF log_verbose THEN
-        RAISE LOG 'promscale maintenance: finished in %', clock_timestamp()-startT;
+        RAISE LOG 'promscale maintenance: % % finished in %', signal, job_type, clock_timestamp()-startT;
     END IF;
 
     IF clock_timestamp()-startT > INTERVAL '12 hours' THEN
-        RAISE WARNING 'promscale maintenance jobs are taking too long (one run took %)', clock_timestamp()-startT
+        RAISE WARNING 'promscale maintenance % % job took too long (%)', signal, job_type, clock_timestamp()-startT
               USING HINT = 'Please consider increasing the number of maintenance jobs using config_maintenance_jobs()';
     END IF;
 END;
 $$ LANGUAGE PLPGSQL;
-COMMENT ON PROCEDURE prom_api.execute_maintenance(boolean)
-IS 'Execute maintenance tasks like dropping data according to retention policy. This procedure should be run regularly in a cron job';
-GRANT EXECUTE ON PROCEDURE prom_api.execute_maintenance(boolean) TO prom_maintenance;
+COMMENT ON PROCEDURE prom_api.execute_maintenance(_ps_catalog.signal_type, _ps_catalog.job_type, boolean)
+IS 'Executes a specified maintenance job type like dropping data according to retention policy. This procedure should be run regularly in a cron job';
+GRANT EXECUTE ON PROCEDURE prom_api.execute_maintenance(_ps_catalog.signal_type, _ps_catalog.job_type, boolean) TO prom_maintenance;
 
 CREATE OR REPLACE PROCEDURE _prom_catalog.execute_maintenance_job(job_id int, config jsonb)
 AS $$
 DECLARE
    log_verbose boolean;
+   signal _ps_catalog.signal_type;
+   job_type _ps_catalog.job_type;
    ae_key text;
    ae_value text;
    ae_load boolean := FALSE;
@@ -502,6 +519,8 @@ BEGIN
     -- and we can _only_ use SET LOCAL in a procedure which _does_ transaction control
     SET LOCAL search_path = pg_catalog, pg_temp;
     log_verbose := coalesce(config->>'log_verbose', 'false')::boolean;
+    signal := coalesce(config->>'signal', 'metrics')::_ps_catalog.signal_type;
+    job_type := coalesce(config->>'type', 'retention')::_ps_catalog.job_type;
 
     --if auto_explain enabled in config, turn it on in a best-effort way
     --i.e. if it fails (most likely due to lack of superuser priviliges) move on anyway.
@@ -521,7 +540,7 @@ BEGIN
     END;
 
 
-    CALL prom_api.execute_maintenance(log_verbose=>log_verbose);
+    CALL prom_api.execute_maintenance(signal, job_type, log_verbose=>log_verbose);
 END
 $$ LANGUAGE PLPGSQL;
 GRANT EXECUTE ON PROCEDURE _prom_catalog.execute_maintenance_job(int, jsonb) TO prom_maintenance;
@@ -533,34 +552,10 @@ CREATE OR REPLACE FUNCTION prom_api.config_maintenance_jobs(number_jobs int, new
     VOLATILE
     SET search_path = pg_catalog, pg_temp
 AS $func$
-DECLARE
-  cnt int;
-  log_verbose boolean;
 BEGIN
-    --check format of config
-    log_verbose := coalesce(new_config->>'log_verbose', 'false')::boolean;
-
-    PERFORM public.delete_job(job_id)
-    FROM timescaledb_information.jobs
-    WHERE proc_schema = '_prom_catalog' AND proc_name = 'execute_maintenance_job' AND (schedule_interval != new_schedule_interval OR new_config IS DISTINCT FROM config) ;
-
-
-    SELECT count(*) INTO cnt
-    FROM timescaledb_information.jobs
-    WHERE proc_schema = '_prom_catalog' AND proc_name = 'execute_maintenance_job';
-
-    IF cnt < number_jobs THEN
-        PERFORM public.add_job('_prom_catalog.execute_maintenance_job', new_schedule_interval, config=>new_config)
-        FROM generate_series(1, number_jobs-cnt);
-    END IF;
-
-    IF cnt > number_jobs THEN
-        PERFORM public.delete_job(job_id)
-        FROM timescaledb_information.jobs
-        WHERE proc_schema = '_prom_catalog' AND proc_name = 'execute_maintenance_job'
-        LIMIT (cnt-number_jobs);
-    END IF;
-
+    PERFORM prom_api.config_maintenance_jobs('metrics', 'retention', number_jobs, new_schedule_interval, new_config);
+    PERFORM prom_api.config_maintenance_jobs('traces', 'retention', number_jobs, new_schedule_interval, new_config);
+    PERFORM prom_api.config_maintenance_jobs('metrics', 'compression', number_jobs, new_schedule_interval, new_config);
     RETURN TRUE;
 END
 $func$
@@ -569,6 +564,73 @@ LANGUAGE PLPGSQL;
 REVOKE ALL ON FUNCTION prom_api.config_maintenance_jobs(int, interval, jsonb) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION prom_api.config_maintenance_jobs(int, interval, jsonb) TO prom_admin;
 COMMENT ON FUNCTION prom_api.config_maintenance_jobs(int, interval, jsonb)
+IS 'Configure the number of maintenance jobs run by the job scheduler, as well as their scheduled interval. Sets identical settings for all job types.';
+
+CREATE OR REPLACE FUNCTION prom_api.config_maintenance_jobs(signal _ps_catalog.signal_type,
+                                                            job_type _ps_catalog.job_type, 
+                                                            number_jobs int,
+                                                            new_schedule_interval interval, 
+                                                            new_config jsonb = NULL)
+    RETURNS BOOLEAN
+    --security definer to add jobs as the logged-in user
+    SECURITY DEFINER
+    VOLATILE
+    SET search_path = pg_catalog, pg_temp
+AS $func$
+DECLARE
+  cnt int;
+  log_verbose boolean;
+  final_config jsonb;
+BEGIN
+    --check format of config
+    log_verbose := coalesce(new_config->>'log_verbose', 'false')::boolean;
+    final_config := coalesce(new_config, '{}'::jsonb) || jsonb_build_object('signal', signal::text) || jsonb_build_object('type', job_type::text);
+
+    -- delete jobs with the old config style
+    PERFORM public.delete_job(job_id)
+    FROM timescaledb_information.jobs
+    WHERE proc_schema = '_prom_catalog' 
+      AND proc_name = 'execute_maintenance_job' 
+      AND NOT coalesce(config, '{}'::jsonb) ?& ARRAY['signal', 'type'];
+
+    PERFORM public.delete_job(job_id)
+    FROM timescaledb_information.jobs
+    WHERE proc_schema = '_prom_catalog' 
+      AND proc_name = 'execute_maintenance_job' 
+      AND coalesce(config->>'signal', '') = signal::text
+      AND coalesce(config->>'type', '') = job_type::text
+      AND (schedule_interval != new_schedule_interval OR final_config IS DISTINCT FROM config);
+
+    SELECT count(*) INTO cnt
+    FROM timescaledb_information.jobs
+    WHERE proc_schema = '_prom_catalog'
+      AND proc_name = 'execute_maintenance_job'
+      AND coalesce(config->>'signal', '') = signal::text
+      AND coalesce(config->>'type', '') = job_type::text;
+
+    IF cnt < number_jobs THEN
+        PERFORM public.add_job('_prom_catalog.execute_maintenance_job', new_schedule_interval, config=>final_config)
+        FROM generate_series(1, number_jobs-cnt);
+    END IF;
+
+    IF cnt > number_jobs THEN
+        PERFORM public.delete_job(job_id)
+        FROM timescaledb_information.jobs
+        WHERE proc_schema = '_prom_catalog'
+          AND proc_name = 'execute_maintenance_job'
+          AND coalesce(config->>'signal', '') = signal::text
+          AND coalesce(config->>'type', '') = job_type::text
+        LIMIT (cnt-number_jobs);
+    END IF;
+
+    RETURN TRUE;
+END
+$func$
+LANGUAGE PLPGSQL;
+--redundant given schema settings but extra caution for security definers
+REVOKE ALL ON FUNCTION prom_api.config_maintenance_jobs(_ps_catalog.signal_type, _ps_catalog.job_type, int, interval, jsonb) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION prom_api.config_maintenance_jobs(_ps_catalog.signal_type, _ps_catalog.job_type, int, interval, jsonb) TO prom_admin;
+COMMENT ON FUNCTION prom_api.config_maintenance_jobs(_ps_catalog.signal_type, _ps_catalog.job_type, int, interval, jsonb)
 IS 'Configure the number of maintenance jobs run by the job scheduler, as well as their scheduled interval';
 
 CREATE OR REPLACE FUNCTION prom_api.promscale_post_restore()

--- a/migration/incremental/034-maintenance-job-stats.sql
+++ b/migration/incremental/034-maintenance-job-stats.sql
@@ -1,8 +1,10 @@
 CREATE TYPE _ps_catalog.signal_type
      AS ENUM ('metrics', 'traces');
+GRANT USAGE ON TYPE _ps_catalog.signal_type TO prom_maintenance;
 
 CREATE TYPE _ps_catalog.job_type
      AS ENUM ('retention', 'compression');
+GRANT USAGE ON TYPE _ps_catalog.job_type TO prom_maintenance;
 
 --add jobs for each workload executing every 30 min by default 
 DO $$

--- a/migration/incremental/034-maintenance-job-stats.sql
+++ b/migration/incremental/034-maintenance-job-stats.sql
@@ -1,0 +1,29 @@
+CREATE TYPE _ps_catalog.signal_type
+     AS ENUM ('metrics', 'traces');
+
+CREATE TYPE _ps_catalog.job_type
+     AS ENUM ('retention', 'compression');
+
+--add jobs for each workload executing every 30 min by default 
+DO $$
+DECLARE
+    _is_restore_in_progress boolean = false;
+BEGIN
+    _is_restore_in_progress = coalesce((SELECT setting::boolean from pg_catalog.pg_settings where name = 'timescaledb.restoring'), false);
+    IF  NOT _prom_catalog.is_timescaledb_oss()
+        AND _prom_catalog.get_timescale_major_version() >= 2
+        AND NOT _is_restore_in_progress
+        THEN
+       -- delete jobs with the old config style
+       PERFORM public.delete_job(job_id)
+       FROM timescaledb_information.jobs
+	WHERE proc_schema = '_prom_catalog' 
+	  AND proc_name = 'execute_maintenance_job' 
+	  AND NOT coalesce(config, '{}'::jsonb) ?& ARRAY['signal', 'type'];
+       PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '30 min', config=>'{"signal": "metrics", "type": "retention"}');
+       PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '30 min', config=>'{"signal": "metrics", "type": "retention"}');
+       PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '30 min', config=>'{"signal": "traces", "type": "retention"}');
+       PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '30 min', config=>'{"signal": "metrics", "type": "compression"}');
+    END IF;
+END
+$$;

--- a/sql-tests/testdata/maintenance_jobs_separation.sql
+++ b/sql-tests/testdata/maintenance_jobs_separation.sql
@@ -1,0 +1,51 @@
+\unset ECHO
+\set QUIET 1
+\set ON_ERROR_STOP 1
+\i 'testdata/scripts/pgtap-1.2.0.sql'
+
+-- Make sure backwards compatible call works
+CALL prom_api.execute_maintenance();
+
+-- None of the new maintenance job configurations fail to parse or start
+CALL _prom_catalog.execute_maintenance_job(0, '{"signal": "metrics", "type": "retention"}'::jsonb);
+CALL _prom_catalog.execute_maintenance_job(0, '{"signal": "traces", "type": "retention"}'::jsonb);
+CALL _prom_catalog.execute_maintenance_job(0, '{"signal": "metrics", "type": "compression"}'::jsonb);
+
+
+SELECT * FROM plan(5);
+
+-- No old-style configurations are present at the beginning
+SELECT ok(COUNT(*) = 0) FROM timescaledb_information.jobs 
+WHERE proc_schema = '_prom_catalog' 
+  AND NOT coalesce(config, '{}'::jsonb) ?& ARRAY ['signal', 'type'];
+
+-- Add two old-style configurations
+SELECT public.add_job('_prom_catalog.execute_maintenance_job', '30 min');
+SELECT public.add_job('_prom_catalog.execute_maintenance_job', '30 min');
+
+-- Run config maintenance reconfiguration
+SELECT prom_api.config_maintenance_jobs(1, '10 min');
+
+-- Only the new-style configurations should be present
+SELECT ok(COUNT(*) = 0) FROM timescaledb_information.jobs 
+WHERE proc_schema = '_prom_catalog' 
+  AND NOT coalesce(config, '{}'::jsonb) ?& ARRAY ['signal', 'type'];
+
+SELECT ok(COUNT(*) = 3) FROM timescaledb_information.jobs 
+WHERE proc_schema = '_prom_catalog';
+
+-- Increase the number of jobs
+SELECT prom_api.config_maintenance_jobs(2, '15 min', '{"log_verbose": false}');
+
+SELECT ok(COUNT(*) = 6) FROM timescaledb_information.jobs 
+WHERE proc_schema = '_prom_catalog'
+  AND coalesce(config, '{}'::jsonb) ?& ARRAY ['signal', 'type'];
+
+-- Decrease the number of jobs
+SELECT prom_api.config_maintenance_jobs(1, '15 min', '{"log_verbose": false}');
+
+SELECT ok(COUNT(*) = 3) FROM timescaledb_information.jobs 
+WHERE proc_schema = '_prom_catalog'
+  AND coalesce(config, '{}'::jsonb) ?& ARRAY ['signal', 'type'];
+
+SELECT * FROM finish(true);

--- a/sql-tests/testdata/maintenance_jobs_separation.sql
+++ b/sql-tests/testdata/maintenance_jobs_separation.sql
@@ -12,12 +12,31 @@ CALL _prom_catalog.execute_maintenance_job(0, '{"signal": "traces", "type": "ret
 CALL _prom_catalog.execute_maintenance_job(0, '{"signal": "metrics", "type": "compression"}'::jsonb);
 
 
-SELECT * FROM plan(5);
+SELECT * FROM plan(9);
 
 -- No old-style configurations are present at the beginning
-SELECT ok(COUNT(*) = 0) FROM timescaledb_information.jobs 
+SELECT ok(COUNT(*) = 0, 'No old-style configurations are present at the beginning') 
+FROM timescaledb_information.jobs 
 WHERE proc_schema = '_prom_catalog' 
   AND NOT coalesce(config, '{}'::jsonb) ?& ARRAY ['signal', 'type'];
+
+SELECT ok(COUNT(*) = 2, 'Two metrics retention jobs by default.')
+FROM timescaledb_information.jobs 
+WHERE proc_schema = '_prom_catalog'
+  AND config ->> 'signal' = 'metrics' 
+  AND config ->> 'type' = 'retention';
+
+SELECT ok(COUNT(*) = 1, 'One metrics compression job by default.')
+FROM timescaledb_information.jobs 
+WHERE proc_schema = '_prom_catalog'
+  AND config ->> 'signal' = 'metrics' 
+  AND config ->> 'type' = 'compression';
+
+SELECT ok(COUNT(*) = 1, 'And one traces retention job by default.')
+FROM timescaledb_information.jobs 
+WHERE proc_schema = '_prom_catalog'
+  AND config ->> 'signal' = 'traces' 
+  AND config ->> 'type' = 'retention';
 
 -- Add two old-style configurations
 SELECT public.add_job('_prom_catalog.execute_maintenance_job', '30 min');
@@ -26,26 +45,37 @@ SELECT public.add_job('_prom_catalog.execute_maintenance_job', '30 min');
 -- Run config maintenance reconfiguration
 SELECT prom_api.config_maintenance_jobs(1, '10 min');
 
--- Only the new-style configurations should be present
-SELECT ok(COUNT(*) = 0) FROM timescaledb_information.jobs 
+SELECT ok(COUNT(*) = 0, 'Old-style config jobs should be deleted by config_maintenance_jobs')
+FROM timescaledb_information.jobs 
 WHERE proc_schema = '_prom_catalog' 
   AND NOT coalesce(config, '{}'::jsonb) ?& ARRAY ['signal', 'type'];
 
-SELECT ok(COUNT(*) = 3) FROM timescaledb_information.jobs 
-WHERE proc_schema = '_prom_catalog';
+SELECT ok(COUNT(*) = 3, 'Only the new-style configurations should be present')
+FROM timescaledb_information.jobs 
+WHERE proc_schema = '_prom_catalog'
+  AND schedule_interval = '10 min';
 
 -- Increase the number of jobs
-SELECT prom_api.config_maintenance_jobs(2, '15 min', '{"log_verbose": false}');
+SELECT prom_api.config_maintenance_jobs(2, '15 min', '{"log_verbose": true}');
 
 SELECT ok(COUNT(*) = 6) FROM timescaledb_information.jobs 
 WHERE proc_schema = '_prom_catalog'
-  AND coalesce(config, '{}'::jsonb) ?& ARRAY ['signal', 'type'];
+  AND config ?& ARRAY ['signal', 'type']
+  AND schedule_interval = '15 min'
+  AND coalesce(config ->> 'log_verbose', 'false')::boolean = true;
 
 -- Decrease the number of jobs
-SELECT prom_api.config_maintenance_jobs(1, '15 min', '{"log_verbose": false}');
+SELECT prom_api.config_maintenance_jobs(1, '16 min', '{"log_verbose": false}');
 
 SELECT ok(COUNT(*) = 3) FROM timescaledb_information.jobs 
 WHERE proc_schema = '_prom_catalog'
-  AND coalesce(config, '{}'::jsonb) ?& ARRAY ['signal', 'type'];
+  AND config ?& ARRAY ['signal', 'type']
+  AND schedule_interval = '16 min'
+  AND coalesce(config ->> 'log_verbose', 'true')::boolean = false;
+
+SELECT throws_like(
+	$$SELECT prom_api.config_maintenance_jobs(1, '100 min', '{"log_verbose": "err"}')$$,
+	'invalid input syntax for type boolean: "err"'
+	);
 
 SELECT * FROM finish(true);

--- a/sql-tests/tests/snapshots/tests__testdata__chunks_to_freeze.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__chunks_to_freeze.sql.snap
@@ -14,7 +14,7 @@ expression: query_result
 
  add_compression_policy 
 ------------------------
-                   1005
+                   1009
 (1 row)
 
    create_hypertable   
@@ -24,7 +24,7 @@ expression: query_result
 
  add_compression_policy 
 ------------------------
-                   1006
+                   1010
 (1 row)
 
          isnt_empty         

--- a/sql-tests/tests/snapshots/tests__testdata__maintenance_jobs_separation.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__maintenance_jobs_separation.sql.snap
@@ -4,12 +4,27 @@ expression: query_result
 ---
  plan 
 ------
- 1..5
+ 1..9
 (1 row)
 
-  ok  
-------
- ok 1
+                               ok                                
+-----------------------------------------------------------------
+ ok 1 - No old-style configurations are present at the beginning
+(1 row)
+
+                      ok                       
+-----------------------------------------------
+ ok 2 - Two metrics retention jobs by default.
+(1 row)
+
+                       ok                       
+------------------------------------------------
+ ok 3 - One metrics compression job by default.
+(1 row)
+
+                       ok                        
+-------------------------------------------------
+ ok 4 - And one traces retention job by default.
 (1 row)
 
  add_job 
@@ -27,24 +42,14 @@ expression: query_result
  t
 (1 row)
 
-  ok  
-------
- ok 2
+                                    ok                                     
+---------------------------------------------------------------------------
+ ok 5 - Old-style config jobs should be deleted by config_maintenance_jobs
 (1 row)
 
-  ok  
-------
- ok 3
-(1 row)
-
- config_maintenance_jobs 
--------------------------
- t
-(1 row)
-
-  ok  
-------
- ok 4
+                             ok                             
+------------------------------------------------------------
+ ok 6 - Only the new-style configurations should be present
 (1 row)
 
  config_maintenance_jobs 
@@ -54,7 +59,22 @@ expression: query_result
 
   ok  
 ------
- ok 5
+ ok 7
+(1 row)
+
+ config_maintenance_jobs 
+-------------------------
+ t
+(1 row)
+
+  ok  
+------
+ ok 8
+(1 row)
+
+                                    throws_like                                    
+-----------------------------------------------------------------------------------
+ ok 9 - Should throw exception like 'invalid input syntax for type boolean: "err"'
 (1 row)
 
  finish 

--- a/sql-tests/tests/snapshots/tests__testdata__maintenance_jobs_separation.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__maintenance_jobs_separation.sql.snap
@@ -1,0 +1,64 @@
+---
+source: sql-tests/tests/tests.rs
+expression: query_result
+---
+ plan 
+------
+ 1..5
+(1 row)
+
+  ok  
+------
+ ok 1
+(1 row)
+
+ add_job 
+---------
+    1009
+(1 row)
+
+ add_job 
+---------
+    1010
+(1 row)
+
+ config_maintenance_jobs 
+-------------------------
+ t
+(1 row)
+
+  ok  
+------
+ ok 2
+(1 row)
+
+  ok  
+------
+ ok 3
+(1 row)
+
+ config_maintenance_jobs 
+-------------------------
+ t
+(1 row)
+
+  ok  
+------
+ ok 4
+(1 row)
+
+ config_maintenance_jobs 
+-------------------------
+ t
+(1 row)
+
+  ok  
+------
+ ok 5
+(1 row)
+
+ finish 
+--------
+(0 rows)
+
+


### PR DESCRIPTION
## Description

When I started down the backend buffer approach, I didn't realize just how much transaction control happens in our background jobs. Carefully threading instrumentation through it proved an unreadable mess. But while doing so, I figured that separating maintenance jobs by type wouldn't require quite as big of a refactoring as I initially presumed and would allow us to implement 90% of what we wanted. E.g.

```SQL
SELECT
    coalesce(config ->> 'signal', 'traces') AS signal_type,
    coalesce(config ->> 'type', 'compression') AS job_type,
    MAX(js.last_run_duration) AS last_duration,
    SUM(js.total_failures) AS failures_count,
    SUM(js.total_runs) AS total_runs_count
FROM timescaledb_information.job_stats js
JOIN timescaledb_information.jobs j ON j.job_id = js.job_id
WHERE proc_schema = '_prom_catalog' OR proc_schema = '_ps_trace'
GROUP BY 1, 2;
```

Gets us all that's left unchecked in #492 except for breakdown by a failure type. Of course, we can't go more granular in the future, nor can we ship logs that way, but overall it seems to be the better option after all.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation