### PR TITLE
Make chunks to freeze test less finicky

### DIFF
--- a/sql-tests/testdata/chunks_to_freeze.sql
+++ b/sql-tests/testdata/chunks_to_freeze.sql
@@ -8,7 +8,7 @@ select * from plan(5);
 create table metric1(id int, t timestamptz not null, val double precision) with (autovacuum_enabled = 'off');
 select create_hypertable('metric1'::regclass, 't', chunk_time_interval=>'5 minutes'::interval);
 alter table metric1 set (timescaledb.compress, timescaledb.compress_segmentby = 'id');
-select add_compression_policy('metric1', INTERVAL '7 days');
+select 1 as add_compression_policy from add_compression_policy('metric1', INTERVAL '7 days');
 
 -- load it with data
 select format($$insert into metric1 (id, t, val) values (%L, %L, %L)$$
@@ -24,7 +24,7 @@ cross join generate_series(1, 50) t
 create table metric2(id int, t timestamptz not null, val double precision) with (autovacuum_enabled = 'off');
 select create_hypertable('metric2'::regclass, 't', chunk_time_interval=>'5 minutes'::interval);
 alter table metric2 set (timescaledb.compress, timescaledb.compress_segmentby = 'id');
-select add_compression_policy('metric2', INTERVAL '7 days');
+select 1 as add_compression_policy from add_compression_policy('metric2', INTERVAL '7 days');
 
 -- load it with data
 select format($$insert into metric2 (id, t, val) values (%L, %L, %L)$$

--- a/sql-tests/tests/snapshots/tests__testdata__chunks_to_freeze.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__chunks_to_freeze.sql.snap
@@ -14,7 +14,7 @@ expression: query_result
 
  add_compression_policy 
 ------------------------
-                   1005
+                      1
 (1 row)
 
    create_hypertable   
@@ -24,7 +24,7 @@ expression: query_result
 
  add_compression_policy 
 ------------------------
-                   1006
+                      1
 (1 row)
 
          isnt_empty         


### PR DESCRIPTION

## Description

The calls to add_compression_policy can return different results depending on unrelated changes. This is causing folks to have to update this test's snapshot in PRs that have nothing to do with this test. This change fixes that issue.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation