### PR TITLE
Add build artifact for RHEL 8

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,12 @@ jobs:
           pkg_cloud_tags:
             - el/7
           pkg_type: rpm
+        - name: linux
+          distro: centos
+          version: 8
+          pkg_cloud_tags:
+            - el/8
+          pkg_type: rpm          
         postgres:
         - version: "12"
         - version: "13"

--- a/dist/rpm.dockerfile
+++ b/dist/rpm.dockerfile
@@ -15,11 +15,10 @@ RUN <<EOF
 export OS_NAME="$(source /etc/os-release; echo "${ID}")"
 export OS_VERSION="$(source /etc/os-release; echo "${VERSION_ID}")"
 
-yum update -y
-
 # Version-specific dependencies
 case "${OS_VERSION}" in
     7)
+        yum update -y
         yum install -y epel-release scl-utils centos-release-scl centos-release-scl-rh
         yum install -y rh-ruby23 llvm-toolset-7
         # Activate rh-ruby23 and llvm-toolset-7 in the current shell session
@@ -35,7 +34,13 @@ case "${OS_VERSION}" in
         chmod a+x /etc/scl_enable
         ;;
     8|9)
+        pushd /etc/yum.repos.d/
+        sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+        popd
+        yum update -y
         yum install -y epel-release rubygems ruby-devel
+        yum -y install glibc-locale-source glibc-langpack-en
         ;;
     *)
         if [ "${OS_NAME}" = "fedora" ]; then


### PR DESCRIPTION
## Description

So far we were build rpms for RHEL 7, lets add RHEL 8 into the list as it has been around for so long[1]. Also one of our community member has also requested an artifact for the RHEL 8.

[1] https://access.redhat.com/articles/3078#RHEL8

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation