### PR TITLE
Fix column "series_id" specified more than once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ We use the following categories for changes:
 ### Added
 - Telemetry for active series and last updated [#534]
 
+### Fixed
+- Column conflict when creating a metric view with a label called `series`
+  [#559]
+
 ## [0.7.0 - 2022-10-03]
 
 ### Added

--- a/migration/idempotent/001-base.sql
+++ b/migration/idempotent/001-base.sql
@@ -2430,7 +2430,7 @@ AS $func$
 DECLARE
   is_reserved boolean;
 BEGIN
-  SELECT label_key = ANY(ARRAY['time', 'value', 'series_id', 'labels'])
+  SELECT label_key = ANY(ARRAY['time', 'value', 'series_id', 'labels', 'series'])
   INTO STRICT is_reserved;
 
   IF is_reserved THEN

--- a/sql-tests/testdata/get_label_key_column_name_for_view.sql
+++ b/sql-tests/testdata/get_label_key_column_name_for_view.sql
@@ -1,0 +1,77 @@
+\unset ECHO
+\set QUIET 1
+\i 'testdata/scripts/pgtap-1.2.0.sql'
+
+SELECT * FROM plan(20);
+
+SELECT
+  is(
+    _prom_catalog.get_label_key_column_name_for_view(key_, true),
+    format('label_%s_id', key_)::NAME,
+    format('%s is a restricted keyword and sanitized. When id=true the column name is returned suffixed with `_id`', key_)
+  )
+FROM (
+  VALUES
+    ('time'),
+    ('value'),
+    ('series_id'),
+    ('labels'),
+    ('series')
+  ) as reserved_keys (key_);
+
+SELECT is(
+  _prom_catalog.get_label_key_column_name_for_view('my-key', true),
+  'my-key_id'::NAME,
+  'when id=true the column name is returned suffixed with `_id`'
+);
+
+-- Entries in _prom_catalog.label_key are created
+SELECT is(
+  k.*,
+  ROW(id, test.key_, test.key_, format('%s_id', test.key_))::_prom_catalog.label_key,
+  format('_prom_catalog.label_key entry for %s exists', test.key_)
+)
+FROM (
+  VALUES
+    ('label_time'),
+    ('label_value'),
+    ('label_series_id'),
+    ('label_labels'),
+    ('label_series'),
+    ('my-key')
+  ) as test (key_)
+LEFT JOIN _prom_catalog.label_key k on (k.key = test.key_);
+
+SELECT is(
+  count(*),
+  6::BIGINT,
+  '6 entries were created for _prom_catalog.label_key'
+) FROM _prom_catalog.label_key;
+
+SELECT is(
+  _prom_catalog.get_label_key_column_name_for_view(key_, false),
+  format('label_%s', key_)::NAME,
+  format('%s is a restricted keyword and sanitized', key_)
+)
+FROM (
+  VALUES
+    ('time'),
+    ('value'),
+    ('series_id'),
+    ('labels'),
+    ('series')
+) as reserved_keys (key_);
+
+SELECT is(
+  _prom_catalog.get_label_key_column_name_for_view('my-key', false),
+  'my-key'::NAME,
+  'column name is the same as key'
+);
+
+SELECT is(
+  count(*),
+  6::BIGINT,
+  'no additional _prom_catalog.label_key are created on subsequent calls for the same keys'
+) FROM _prom_catalog.label_key;
+
+SELECT * FROM finish();

--- a/sql-tests/tests/snapshots/tests__testdata__get_label_key_column_name_for_view.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__get_label_key_column_name_for_view.sql.snap
@@ -1,0 +1,63 @@
+---
+source: sql-tests/tests/tests.rs
+assertion_line: 49
+expression: query_result
+---
+ plan  
+-------
+ 1..20
+(1 row)
+
+                                                          is                                                          
+----------------------------------------------------------------------------------------------------------------------
+ ok 1 - time is a restricted keyword and sanitized. When id=true the column name is returned suffixed with `_id`
+ ok 2 - value is a restricted keyword and sanitized. When id=true the column name is returned suffixed with `_id`
+ ok 3 - series_id is a restricted keyword and sanitized. When id=true the column name is returned suffixed with `_id`
+ ok 4 - labels is a restricted keyword and sanitized. When id=true the column name is returned suffixed with `_id`
+ ok 5 - series is a restricted keyword and sanitized. When id=true the column name is returned suffixed with `_id`
+(5 rows)
+
+                                 is                                  
+---------------------------------------------------------------------
+ ok 6 - when id=true the column name is returned suffixed with `_id`
+(1 row)
+
+                               is                                
+-----------------------------------------------------------------
+ ok 7 - _prom_catalog.label_key entry for label_time exists
+ ok 8 - _prom_catalog.label_key entry for label_value exists
+ ok 9 - _prom_catalog.label_key entry for label_series_id exists
+ ok 10 - _prom_catalog.label_key entry for label_labels exists
+ ok 11 - _prom_catalog.label_key entry for label_series exists
+ ok 12 - _prom_catalog.label_key entry for my-key exists
+(6 rows)
+
+                             is                             
+------------------------------------------------------------
+ ok 13 - 6 entries were created for _prom_catalog.label_key
+(1 row)
+
+                           is                            
+---------------------------------------------------------
+ ok 14 - time is a restricted keyword and sanitized
+ ok 15 - value is a restricted keyword and sanitized
+ ok 16 - series_id is a restricted keyword and sanitized
+ ok 17 - labels is a restricted keyword and sanitized
+ ok 18 - series is a restricted keyword and sanitized
+(5 rows)
+
+                   is                   
+----------------------------------------
+ ok 19 - column name is the same as key
+(1 row)
+
+                                               is                                                
+-------------------------------------------------------------------------------------------------
+ ok 20 - no additional _prom_catalog.label_key are created on subsequent calls for the same keys
+(1 row)
+
+ finish 
+--------
+(0 rows)
+
+


### PR DESCRIPTION
## Description

When creating a metric view, the column names for the labels are created by the `_prom_catalog.get_label_key_column_name_for_view` function. If a given label matches one of the reserved keys, then it's sanitized by prefixing the returned column name with `label_`, thus avoiding a conflict.

The `_prom_catalog.get_label_key_column_name_for_view` function also accepts a second argument, it's a boolean that if true means that the `id_column_name` should be used. The `id_column_name` is created as the label name with the `_id` suffix.

One of the reserved keys that's checked by
`_prom_catalog.get_label_key_column_name_for_view` is `series_id`. If the value `series` is given as argument the served key validation passes since `series != series_id`, and for `id=false` this continues to be correct, but if `id=true` the resulting column name will be `series_id` which matches the reserved key and causes the conflict.

To avoid the conflict `series` is added to the reserved keys if `id=true`.

Fixes #531

Fixes https://github.com/timescale/promscale/issues/1685

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation