### PR TITLE
Bump pgspot, install from pypi

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -78,15 +78,8 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Checkout pgspot
-        uses: actions/checkout@v3
-        with:
-          repository: 'timescale/pgspot'
-          ref: '0.2.0'
-          path: 'pgspot'
-
-      - name: Install pgspot dependencies
-        run: python -m pip install -r pgspot/requirements.txt
+      - name: Install pgspot
+        run: pip install pgspot==0.3.3
 
       - name: Setup sccache
         run: |
@@ -117,4 +110,4 @@ jobs:
           args: schema pg14 --out /tmp/schema.sql
 
       - name: Run pgspot
-        run: ./pgspot/pgspot --sql-accepting=execute_everywhere --sql-accepting=distributed_exec --ignore PS005 /tmp/schema.sql ./sql/promscale--0.0.0.sql
+        run: pgspot --sql-accepting=execute_everywhere --sql-accepting=distributed_exec --ignore PS005 /tmp/schema.sql ./sql/promscale--0.0.0.sql


### PR DESCRIPTION
## Description

This bumps to the newest version of pgspot, and installs it from pypi (with `pip`), which was not available when we integrated pgspot.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~