### PR TITLE
Fix package build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,8 +3,8 @@ on:
   pull_request:
     paths:
     - '.github/workflows/release.yaml'
-    - 'dist/*'
-    - 'tools/*'
+    - 'dist/**'
+    - 'tools/**'
   push:
     branches:
     - main

--- a/dist/debian/lintian-ignore
+++ b/dist/debian/lintian-ignore
@@ -1,3 +1,5 @@
 initial-upload-closes-no-bugs
 extended-description-is-empty
 unknown-field
+syntax-error-in-debian-changelog
+package-contains-timestamped-gzip


### PR DESCRIPTION
## Description

It seems as though the Debian linter (Lintian) has new lints which fpm cannot fulfill, so we ignore the lints.

More details:

syntac-error-in-debian-changelog is for the generated `changelog.Debian.gz`, which is the standard fpm boilerplate Debian changelog. Somehow it still fails lintian.

package-contains-timestamped-gzip is a lint around reproducible builds, and fpm doesn't support reproducible builds [1].

[1]: https://github.com/jordansissel/fpm/issues/1232

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~