### PR TITLE
Fix: Exception when scanning for new rollups & compressing Caggs

### DIFF
--- a/migration/idempotent/017-metric-rollup.sql
+++ b/migration/idempotent/017-metric-rollup.sql
@@ -139,8 +139,8 @@ BEGIN
         rollup_view_created := FALSE;
         new_rollups_created := 0;
         FOR m IN
-            SELECT id, metric_name, table_name FROM _prom_catalog.metric m WHERE NOT is_view AND NOT EXISTS (
-                SELECT 1 FROM _prom_catalog.metric_rollup mr WHERE mr.rollup_id = r.id AND mr.metric_id = id
+            SELECT id, metric_name, table_name FROM _prom_catalog.metric mt WHERE NOT is_view AND NOT EXISTS (
+                SELECT 1 FROM _prom_catalog.metric_rollup mr WHERE mr.rollup_id = r.id AND mr.metric_id = mt.id
             ) -- Get metric names that have a pending rollup creation.
         LOOP
             SELECT INTO rollup_view_created _prom_catalog.create_metric_rollup_view(r.schema_name, m.metric_name, m.table_name, r.resolution);

--- a/migration/idempotent/018-metric-rollup-maintenance.sql
+++ b/migration/idempotent/018-metric-rollup-maintenance.sql
@@ -85,7 +85,7 @@ BEGIN
         WHERE
             cagg.compression_enabled AND m.is_view
     LOOP
-        PERFORM public.compress_chunk(public.show_chunks(r.compressible_cagg, older_than => 100 * r.refresh_interval));
+        PERFORM public.compress_chunk(public.show_chunks(r.compressible_cagg, older_than => 100 * r.refresh_interval), true);
     END LOOP;
 END;
 $$

--- a/sql-tests/testdata/custom_downsample_refresh.sql
+++ b/sql-tests/testdata/custom_downsample_refresh.sql
@@ -53,3 +53,6 @@ $$;
 
 -- Check samples after the refresh.
 SELECT ok(count(*) = 340, 'samples in custom downsample after refresh') FROM custom.test; -- 2 samples increased, i.e, from 333 -> 336 which is expected, since last 2 buckets are only updated.
+
+-- The end
+SELECT * FROM finish(true);

--- a/sql-tests/testdata/metric_rollups_maintenance.sql
+++ b/sql-tests/testdata/metric_rollups_maintenance.sql
@@ -32,6 +32,9 @@ CALL _prom_catalog.execute_caggs_compression_policy(3, '{}'::jsonb);
 SELECT ok(compressed_chunks_exist('ps_short.test') = true);
 SELECT ok(compressed_chunks_exist('ps_long.test') = true);
 
+-- Compress again to ensure we don't error when touching compressed chunks.
+SET client_min_messages to 'ERROR'; -- So that the snapshot does not get filled with debug logs.
+CALL _prom_catalog.execute_caggs_compression_policy(3, '{}'::jsonb);
 
 -- # Test retaining metric-rollups.
 

--- a/sql-tests/testdata/metric_rollups_refresh.sql
+++ b/sql-tests/testdata/metric_rollups_refresh.sql
@@ -52,3 +52,6 @@ $$;
 -- Check samples after the refresh.
 SELECT ok(count(*) = 2019, 'samples in 5m metric-rollup') FROM ps_short.test; -- Note: Only 2 samples increased, since refresh only accounts for last 2 buckets
 SELECT ok(count(*) = 171, 'samples in 1h metric-rollup') FROM ps_long.test;
+
+-- The end
+SELECT * FROM finish(true);

--- a/sql-tests/testdata/metric_rollups_scan_for_new_rollups.sql
+++ b/sql-tests/testdata/metric_rollups_scan_for_new_rollups.sql
@@ -1,0 +1,53 @@
+\unset ECHO
+\set QUIET 1
+\i 'testdata/scripts/pgtap-1.2.0.sql'
+
+SELECT * FROM plan(3);
+
+-- Scan should not error when there are no rollups.
+CALL _prom_catalog.scan_for_new_rollups(1, '{}'::jsonb);
+
+CALL _prom_catalog.create_rollup('test', INTERVAL '5 minutes', INTERVAL '1 day');
+
+-- Scan should not error when there are no metrics.
+CALL _prom_catalog.scan_for_new_rollups(1, '{}'::jsonb);
+
+\i 'testdata/scripts/generate-test-metric.sql'
+
+-- Scan when there are metrics. This will create new rollups.
+CALL _prom_catalog.scan_for_new_rollups(1, '{}'::jsonb);
+
+SELECT ok(count(*) = 2017) FROM ps_test.test;
+
+-- Scan again when there aren't any new metrics.
+CALL _prom_catalog.scan_for_new_rollups(1, '{}'::jsonb);
+
+SELECT ok(count(*) = 2017) FROM ps_test.test;
+
+-- Add a new metric.
+DO $$
+BEGIN
+    PERFORM _prom_catalog.get_or_create_metric_table_name('test_2');
+    INSERT INTO _prom_catalog.metadata VALUES (to_timestamp(0), 'test_2', 'GAUGE', '', 'Test metric 2.');
+
+    -- Insert samples for 1 month.
+    INSERT INTO prom_data.test_2
+    SELECT
+        time,
+        floor(random()*1000) AS value,
+        _prom_catalog.get_or_create_series_id('{"__name__": "test_2", "job":"promscale", "instance": "localhost:9090"}')
+    FROM generate_series(
+        '2022-10-01 00:00:00',
+        '2022-10-08 00:00:00',
+        interval '30 seconds'
+    ) as time;
+END;
+$$;
+
+-- Scan for newly added metric test_2.
+CALL _prom_catalog.scan_for_new_rollups(1, '{}'::jsonb);
+
+SELECT ok(count(*) = 2017) FROM ps_test.test_2;
+
+-- The end
+SELECT * FROM finish(true);

--- a/sql-tests/tests/snapshots/tests__testdata__custom_downsample_refresh.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__custom_downsample_refresh.sql.snap
@@ -39,4 +39,8 @@ HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate o
  ok 5 - samples in custom downsample after refresh
 (1 row)
 
+ finish 
+--------
+(0 rows)
+
 

--- a/sql-tests/tests/snapshots/tests__testdata__metric_rollups_refresh.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__metric_rollups_refresh.sql.snap
@@ -58,4 +58,8 @@ psql:testdata/metric_rollups_refresh.sql:17: NOTICE:  table "_pending_registrati
  ok 10 - samples in 1h metric-rollup
 (1 row)
 
+ finish 
+--------
+(0 rows)
+
 

--- a/sql-tests/tests/snapshots/tests__testdata__metric_rollups_scan_for_new_rollups.sql.snap
+++ b/sql-tests/tests/snapshots/tests__testdata__metric_rollups_scan_for_new_rollups.sql.snap
@@ -1,0 +1,34 @@
+---
+source: sql-tests/tests/tests.rs
+expression: query_result
+---
+ plan 
+------
+ 1..3
+(1 row)
+
+psql:testdata/metric_rollups_scan_for_new_rollups.sql:8: NOTICE:  table "_pending_registration" does not exist, skipping
+psql:testdata/metric_rollups_scan_for_new_rollups.sql:13: NOTICE:  table "_pending_registration" does not exist, skipping
+psql:testdata/metric_rollups_scan_for_new_rollups.sql:18: NOTICE:  table "_pending_registration" does not exist, skipping
+  ok  
+------
+ ok 1
+(1 row)
+
+psql:testdata/metric_rollups_scan_for_new_rollups.sql:23: NOTICE:  table "_pending_registration" does not exist, skipping
+  ok  
+------
+ ok 2
+(1 row)
+
+psql:testdata/metric_rollups_scan_for_new_rollups.sql:48: NOTICE:  table "_pending_registration" does not exist, skipping
+  ok  
+------
+ ok 3
+(1 row)
+
+ finish 
+--------
+(0 rows)
+
+


### PR DESCRIPTION
## Description

This PR does 2 things:
1. Fixes the exception `Caggs already exists` that was caused when a cagg for one resolution was again created when the `scan_for_new_rollups()` was re-executed. Added a test under `metric_rollups_scan_for_new_rollups` to ensure correct behaviour.
2. `execute_caggs_compression_policy()` used to panic when looping over already compressed chunk of a Cagg that has some uncompressed chunks that need compression. Added rerunning compression policy to ensure correct behaviour.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation