### PR TITLE
Clarify order of operations in get_metrics_that_need_compression

### DIFF
--- a/migration/idempotent/001-base.sql
+++ b/migration/idempotent/001-base.sql
@@ -3372,15 +3372,13 @@ CREATE OR REPLACE FUNCTION _prom_catalog.get_metrics_that_need_compression()
 AS $$
 DECLARE
 BEGIN
-        RETURN QUERY
-        SELECT m.*
-        FROM _prom_catalog.metric m
-        WHERE
-          is_view = false AND
-          _prom_catalog.get_metric_compression_setting(m.metric_name) AND
-          delay_compression_until IS NULL OR delay_compression_until < now() AND
-          is_view = FALSE
-        ORDER BY random();
+    RETURN QUERY
+    SELECT m.*
+    FROM _prom_catalog.metric m
+    WHERE is_view = false
+    AND _prom_catalog.get_metric_compression_setting(m.metric_name)
+    AND (delay_compression_until IS NULL OR delay_compression_until < now())
+    ORDER BY random();
 END
 $$
 LANGUAGE PLPGSQL STABLE;


### PR DESCRIPTION
## Description

Clarify order of operations in `get_metrics_that_need_compression()`. A mixture of `AND`s and `OR`s made the code difficult to reason about. Fix it.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation