### PR TITLE
Don't cache target dir

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.postgres.version }}
+          cache-targets: "false"
 
       - name: Install cargo-pgx
         run: |
@@ -60,4 +61,3 @@ jobs:
 
       - name: Show sccache stats
         run: sccache --show-stats
-

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,6 +36,8 @@ jobs:
           sccache --show-stats
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: "false"
 
       - name: Install cargo-pgx
         run: |
@@ -43,7 +45,7 @@ jobs:
 
       - name: Initialize pgx
         run: cargo pgx init --pg14 download
-      
+
       - run: cargo clippy --features pg14 -- -D warnings
 
   pgspot:


### PR DESCRIPTION
## Description

Tell Swatinem/rust-cache not to cache the target directory. It's causing issues in CI. All credit to @JamesGuthrie 

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation