### PR TITLE
Make cargo use 2 jobs in devenv

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,6 +19,9 @@ and continually recompiles and reinstalls the promscale extension on source
 modifications. This means that you can edit the sources locally, and run SQL
 tests against the container.
 
+NOTE: If `make devenv` fails with a *signal 9*, it is likely that the container
+is running out of memory. Try increasing the RAM allocated to the docker engine.
+
 You can adjust the postgres version through the `DEVENV_PG_VERSION` env var,
 for example: `DEVENV_PG_VERSION=12 make devenv`
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -51,7 +51,10 @@ RUN sudo apt-get install -y vim lld
 RUN mkdir -p ~/.cargo
 # Make cargo put compile artifacts in non-bind-mounted directory
 # To re-use compiled artifacts, mount a docker volume to /tmp/target
-RUN echo -e '[build]\ntarget-dir="/tmp/target"' > ~/.cargo/config.toml
+# We have seen issues with the docker container running out of memory
+# Limiting cargo to 2 jobs ought to reduce/limit memory usage
+# 1 job led to very slow build times. 2 is hopefully a good balance
+RUN echo -e '[build]\ntarget-dir="/tmp/target"\njobs=2' > ~/.cargo/config.toml
 # Tell rustc to use a fast linker
 RUN echo 'rustflags=["-C", "link-arg=-fuse-ld=lld"]' >> ~/.cargo/config.toml
 


### PR DESCRIPTION
## Description

We have identified issues with `make devenv` and `make docker-image-14` failing due to a signal 9 when cargo is building the `pgx-pg-sys` package. We believe this is due to RAM usage exceeding what docker is allowed. This PR limits cargo to using 2 jobs which in turn ought to reduce the RAM used.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation