### PR TITLE
Clean generated files on devenv (re)builds

### DIFF
--- a/devenv.sh
+++ b/devenv.sh
@@ -42,7 +42,7 @@ export ENTR_INOTIFY_WORKAROUND=true
 
 # Note: this is not a comprehensive list of source files, if you think one is missing, add it
 SOURCE_FILES="src migration"
-find ${SOURCE_FILES} | entr cargo pgx install --features="pg${DEVENV_PG_VERSION}" > "${HOME}/compile.log" &
+find ${SOURCE_FILES} | entr make devenv-internal-build-install > "${HOME}/compile.log" &
 
 tail -f "${HOME}/.pgx/${DEVENV_PG_VERSION}.log" "${HOME}/compile.log" &
 


### PR DESCRIPTION
## Description

Addressing a devenv footgun documented in https://github.com/timescale/promscale_extension/issues/585
- Firstly, I don't see a reason for make build to generate a versioned SQL
  file in the first place. This action normally takes place during
  the packaging step.
- Secondly, make clean and make devenv targets will be removing generated
  files moving forward.
  
I didn't test this very exhaustively but it seems to help and I expect it to resolve #585
  
## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~CHANGELOG entry for user-facing changes~
- [ ] ~Updated the relevant documentation~