### PR TITLE
Increase the default number of compression jobs and prevent a "thundering herd" scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ We use the following categories for changes:
   for each job type (e.g. parallism 2 means each job type has 2 jobs, not 2 jobs in total).
   There is also the new `prom_api.config_maintenance_jobs` that allows configuring
   them individually. Finally, the new default worker allocation is 2 metrics retention
-  jobs, 1 job for metrics compression and 1 job for traces retention. [#555]
+  jobs, 4 jobs for metrics compression and 1 job for traces retention. [#555] [#588]
 - Removed disk size related columns from `prom_info.metric`. 
   Added `prom_info.metric_detail` which includes the disk size related columns. 
   Improved the performance of these. [#547]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ We use the following categories for changes:
   for each job type (e.g. parallism 2 means each job type has 2 jobs, not 2 jobs in total).
   There is also the new `prom_api.config_maintenance_jobs` that allows configuring
   them individually. Finally, the new default worker allocation is 2 metrics retention
-  jobs, 4 jobs for metrics compression and 1 job for traces retention. [#555] [#588]
+  jobs, 3 jobs for metrics compression and 1 job for traces retention. [#555] [#588]
 - Removed disk size related columns from `prom_info.metric`. 
   Added `prom_info.metric_detail` which includes the disk size related columns. 
   Improved the performance of these. [#547]

--- a/migration/idempotent/011-maintenance.sql
+++ b/migration/idempotent/011-maintenance.sql
@@ -613,9 +613,11 @@ BEGIN
             public.add_job(
                 '_prom_catalog.execute_maintenance_job', 
                 -- shift schedules a little to avoid multiple jobs starting in a lockstep
+                -- new_schedule_interval + random[30s; 1m]
                 new_schedule_interval + (random() / 2.0 + 0.5) * interval '1 min', 
                 config=>final_config,
                 -- shift the inital start time to avoid a thundering herd
+                -- now + random[new_schedule_interval / 2; new_schedule_interval]
                 initial_start=>now() + (random() / 2.0 + 0.5) * new_schedule_interval
             )
         FROM generate_series(1, number_jobs-cnt);

--- a/migration/incremental/034-maintenance-job-stats.sql
+++ b/migration/incremental/034-maintenance-job-stats.sql
@@ -19,19 +19,18 @@ BEGIN
        -- delete jobs with the old config style
        PERFORM public.delete_job(job_id)
        FROM timescaledb_information.jobs
-	WHERE proc_schema = '_prom_catalog' 
-	  AND proc_name = 'execute_maintenance_job' 
-	  AND NOT coalesce(config, '{}'::jsonb) ?& ARRAY['signal', 'type'];
+        WHERE proc_schema = '_prom_catalog' 
+        AND proc_name = 'execute_maintenance_job' 
+        AND NOT coalesce(config, '{}'::jsonb) ?& ARRAY['signal', 'type'];
        -- 2 metric retention jobs
-       PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '30 min', config=>'{"signal": "metrics", "type": "retention"}');
-       PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '30 min', config=>'{"signal": "metrics", "type": "retention"}');
-       -- 4 metric compression jobs
-       PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '30 min', config=>'{"signal": "metrics", "type": "compression"}');
-       PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '30 min', config=>'{"signal": "metrics", "type": "compression"}');
-       PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '30 min', config=>'{"signal": "metrics", "type": "compression"}');
-       PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '30 min', config=>'{"signal": "metrics", "type": "compression"}');
+       PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '30 min', config=>'{"signal": "metrics", "type": "retention"}', initial_start=>now() + random() * interval '30 min' + interval '1 min');
+       PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '31 min', config=>'{"signal": "metrics", "type": "retention"}', initial_start=>now() + random() * interval '30 min' + interval '1 min');
+       -- 3 metric compression jobs
+       PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '29 min', config=>'{"signal": "metrics", "type": "compression"}', initial_start=>now() + random() * interval '30 min' + interval '1 min');
+       PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '30 min', config=>'{"signal": "metrics", "type": "compression"}', initial_start=>now() + random() * interval '30 min' + interval '1 min');
+       PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '31 min', config=>'{"signal": "metrics", "type": "compression"}', initial_start=>now() + random() * interval '30 min' + interval '1 min');
        -- 1 traces retention job
-       PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '30 min', config=>'{"signal": "traces", "type": "retention"}');
+       PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '30 min', config=>'{"signal": "traces", "type": "retention"}', initial_start=>now() + random() * interval '30 min' + interval '1 min');
     END IF;
 END
 $$;

--- a/migration/incremental/034-maintenance-job-stats.sql
+++ b/migration/incremental/034-maintenance-job-stats.sql
@@ -22,10 +22,16 @@ BEGIN
 	WHERE proc_schema = '_prom_catalog' 
 	  AND proc_name = 'execute_maintenance_job' 
 	  AND NOT coalesce(config, '{}'::jsonb) ?& ARRAY['signal', 'type'];
+       -- 2 metric retention jobs
        PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '30 min', config=>'{"signal": "metrics", "type": "retention"}');
        PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '30 min', config=>'{"signal": "metrics", "type": "retention"}');
-       PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '30 min', config=>'{"signal": "traces", "type": "retention"}');
+       -- 4 metric compression jobs
        PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '30 min', config=>'{"signal": "metrics", "type": "compression"}');
+       PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '30 min', config=>'{"signal": "metrics", "type": "compression"}');
+       PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '30 min', config=>'{"signal": "metrics", "type": "compression"}');
+       PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '30 min', config=>'{"signal": "metrics", "type": "compression"}');
+       -- 1 traces retention job
+       PERFORM public.add_job('_prom_catalog.execute_maintenance_job', '30 min', config=>'{"signal": "traces", "type": "retention"}');
     END IF;
 END
 $$;

--- a/sql-tests/testdata/maintenance_jobs_separation.sql
+++ b/sql-tests/testdata/maintenance_jobs_separation.sql
@@ -26,7 +26,7 @@ WHERE proc_schema = '_prom_catalog'
   AND config ->> 'signal' = 'metrics' 
   AND config ->> 'type' = 'retention';
 
-SELECT ok(COUNT(*) = 1, 'One metrics compression job by default.')
+SELECT ok(COUNT(*) = 4, 'Four metrics compression jobs by default.')
 FROM timescaledb_information.jobs 
 WHERE proc_schema = '_prom_catalog'
   AND config ->> 'signal' = 'metrics' 

--- a/sql-tests/testdata/maintenance_jobs_separation.sql
+++ b/sql-tests/testdata/maintenance_jobs_separation.sql
@@ -26,7 +26,7 @@ WHERE proc_schema = '_prom_catalog'
   AND config ->> 'signal' = 'metrics' 
   AND config ->> 'type' = 'retention';
 
-SELECT ok(COUNT(*) = 4, 'Four metrics compression jobs by default.')
+SELECT ok(COUNT(*) = 3, 'Three metrics compression jobs by default.')
 FROM timescaledb_information.jobs 
 WHERE proc_schema = '_prom_catalog'
   AND config ->> 'signal' = 'metrics' 
@@ -53,7 +53,7 @@ WHERE proc_schema = '_prom_catalog'
 SELECT ok(COUNT(*) = 3, 'Only the new-style configurations should be present')
 FROM timescaledb_information.jobs 
 WHERE proc_schema = '_prom_catalog'
-  AND schedule_interval = '10 min';
+  AND (schedule_interval >= '10 min' OR schedule_interval < '15 min');
 
 -- Increase the number of jobs
 SELECT prom_api.config_maintenance_jobs(2, '15 min', '{"log_verbose": true}');
@@ -61,7 +61,7 @@ SELECT prom_api.config_maintenance_jobs(2, '15 min', '{"log_verbose": true}');
 SELECT ok(COUNT(*) = 6) FROM timescaledb_information.jobs 
 WHERE proc_schema = '_prom_catalog'
   AND config ?& ARRAY ['signal', 'type']
-  AND schedule_interval = '15 min'
+  AND (schedule_interval >= '15 min' OR schedule_interval < '17 min')
   AND coalesce(config ->> 'log_verbose', 'false')::boolean = true;
 
 -- Decrease the number of jobs
@@ -70,7 +70,7 @@ SELECT prom_api.config_maintenance_jobs(1, '16 min', '{"log_verbose": false}');
 SELECT ok(COUNT(*) = 3) FROM timescaledb_information.jobs 
 WHERE proc_schema = '_prom_catalog'
   AND config ?& ARRAY ['signal', 'type']
-  AND schedule_interval = '16 min'
+  AND (schedule_interval >= '16 min' OR schedule_interval < '18 min')
   AND coalesce(config ->> 'log_verbose', 'true')::boolean = false;
 
 SELECT throws_like(


### PR DESCRIPTION
## Description

It seems like 1 metric compression job is almost never enough and our benchmarks show that 3 should be sufficient for thousands of metrics with 30min chunks.

In addition, this PR addresses a thundering herd scenario when reconfiguring maintenance jobs.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] ~Updated the relevant documentation~