### PR TITLE
Support running devenv without entr

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,6 +19,11 @@ and continually recompiles and reinstalls the promscale extension on source
 modifications. This means that you can edit the sources locally, and run SQL
 tests against the container.
 
+If you don't want the dev environment to continually recompile and reinstall the
+extension (i.e. you want to manually trigger these), run `make devenv-no-entr`.
+Then, use `make dev-build` to trigger a recompile and reinstall of the promscale 
+extension.
+
 NOTE: If `make devenv` fails with a *signal 9*, it is likely that the container
 is running out of memory. Try increasing the RAM allocated to the docker engine.
 
@@ -32,11 +37,13 @@ above, set `POSTGRES_URL=postgres://ubuntu@localhost:54321/`.
 The `devenv-url` and `devenv-export-url` make targets output the URL above in
 convenient formats, for example:
 
-- To connect to the devenv db with psql: `psql $(make devenv-url)`
+- To connect to the devenv db with psql: `psql $(make devenv-url)` or use `make dev-psql`
 - To set the `POSTGRES_URL` for all subshells: `eval $(make devenv-export-url)`
 
 To permanently configure `POSTGRES_URL` when you change into this directory,
 you may consider using a tool like [direnv](https://direnv.net/).
+
+To easily get a bash shell in the devenv container run `make dev-bash`.
 
 ## Modifying and testing SQL migrations
 
@@ -112,7 +119,7 @@ If you have already built a local docker image and your changes are limited to
 SQL migrations there is also `make docker-quick-NN` family of targets. It's faster
 but could be finicky.
 
-To run the e2e tests against the locally build image run: `cargo test -p e2e`.
+To run the e2e tests against the locally built image run: `cargo test -p e2e`.
 Further details could be found in the [corresponding document](./e2e/README.md).
 
 ## Known Issues

--- a/devenv.sh
+++ b/devenv.sh
@@ -37,13 +37,20 @@ for db in template1 postgres; do
 done
 createdb -h localhost -p "${PGPORT}" "$(whoami)"
 
-# This allows entr to work correctly on docker for mac
-export ENTR_INOTIFY_WORKAROUND=true
+if [ "$DEVENV_ENTR" -eq 1 ]; then
+  echo "entr enabled. rebuilds will be triggered on source file changes"
+  # This allows entr to work correctly on docker for mac
+  export ENTR_INOTIFY_WORKAROUND=true
 
-# Note: this is not a comprehensive list of source files, if you think one is missing, add it
-SOURCE_FILES="src migration"
-find ${SOURCE_FILES} | entr make devenv-internal-build-install > "${HOME}/compile.log" &
+  # Note: this is not a comprehensive list of source files, if you think one is missing, add it
+  SOURCE_FILES="src migration"
+  find ${SOURCE_FILES} | entr make devenv-internal-build-install > "${HOME}/compile.log" &
 
-tail -f "${HOME}/.pgx/${DEVENV_PG_VERSION}.log" "${HOME}/compile.log" &
+  tail -f "${HOME}/.pgx/${DEVENV_PG_VERSION}.log" "${HOME}/compile.log" &
+else
+  echo "entr disabled. you must trigger rebuilds manually with 'make dev-build'"
+  make devenv-internal-build-install
+  tail -f "${HOME}/.pgx/${DEVENV_PG_VERSION}.log"
+fi
 
 wait


### PR DESCRIPTION
## Description

There may be situations when manually triggering rebuilds and reinstalls of the extension in the devenv container is preferred. This provides a `make devenv-no-entr` target to disable the automatic rebuilds/reinstalls.

The new `make dev-build` is used to trigger the rebuild/reinstall manually.

`make dev-bash` is handy to get a bash shell in the devenv container.

`make dev-psql` gets a psql shell into the devenv container.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation