### PR TITLE
Make chunks_to_freeze robust when chunk does not exist

### DIFF
--- a/migration/idempotent/016-vacuum-engine.sql
+++ b/migration/idempotent/016-vacuum-engine.sql
@@ -16,9 +16,11 @@ BEGIN
             k.relfrozenxid
         FROM _timescaledb_catalog.chunk c
         INNER JOIN _timescaledb_catalog.chunk cc
-        ON (c.dropped OPERATOR(pg_catalog.=) false and c.compressed_chunk_id OPERATOR(pg_catalog.=) cc.id)
+        ON (c.dropped OPERATOR(pg_catalog.=) false AND c.compressed_chunk_id OPERATOR(pg_catalog.=) cc.id)
         INNER JOIN pg_catalog.pg_class k
-        ON (k.oid OPERATOR(pg_catalog.=) format('%I.%I', cc.schema_name, cc.table_name)::regclass::oid)
+        ON (k.relname OPERATOR(pg_catalog.=) cc.table_name)
+        INNER JOIN pg_catalog.pg_namespace n
+        ON (k.relnamespace OPERATOR(pg_catalog.=) n.oid AND n.nspname OPERATOR(pg_catalog.=) cc.schema_name)
         WHERE k.relallvisible OPERATOR(pg_catalog.<) k.relpages
         ORDER BY pg_catalog.age(k.relfrozenxid) DESC
         ;


### PR DESCRIPTION
## Description

The prior implementation of the `chunks_to_freeze` view would fail if a compressed chunk is listed in the timescaledb catalog but does not actually exist in the database. The `::regclass::oid` cast fails with the below error.

```
ERROR:  42P01: relation "_timescaledb_internal._hyper_7837_1586360_chunk" does not exist
CONTEXT:  parallel worker
LOCATION:  RangeVarGetRelidExtended, namespace.c:428
```

This change makes the view robust to this edge case.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation