### PR TITLE
Vacuum compressed chunks missing stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,11 @@ We use the following categories for changes:
   Improved the performance of these. [#547]
 - The metric compression job now only locks metrics which are known to have chunks
   that need to be compressed [#576]
+- Renamed `_ps_catalog.chunks_to_freeze` to `_ps_catalog.compressed_chunks_to_freeze` [#595]
 
 ### Added
 - Telemetry for active series and last updated [#534]
+- Added `_ps_catalog.compressed_chunks_missing_stats` view [#595]
 
 ### Fixed
 - Column conflict when creating a metric view with a label called `series`

--- a/migration/idempotent/016-vacuum-engine.sql
+++ b/migration/idempotent/016-vacuum-engine.sql
@@ -1,31 +1,62 @@
 DO $block$
 BEGIN
-    IF _prom_catalog.is_timescaledb_installed() THEN
-        CREATE OR REPLACE VIEW _ps_catalog.chunks_to_freeze AS
-        SELECT
-            cc.id,
-            cc.schema_name,
-            cc.table_name,
-            greatest
-            (
-                pg_catalog.pg_stat_get_last_vacuum_time(k.oid),
-                pg_catalog.pg_stat_get_last_autovacuum_time(k.oid)
-            ) as last_vacuum,
-            k.relpages,
-            k.relallvisible,
-            k.relfrozenxid
-        FROM _timescaledb_catalog.chunk c
-        INNER JOIN _timescaledb_catalog.chunk cc
-        ON (c.dropped OPERATOR(pg_catalog.=) false AND c.compressed_chunk_id OPERATOR(pg_catalog.=) cc.id)
-        INNER JOIN pg_catalog.pg_class k
-        ON (k.relname OPERATOR(pg_catalog.=) cc.table_name)
-        INNER JOIN pg_catalog.pg_namespace n
-        ON (k.relnamespace OPERATOR(pg_catalog.=) n.oid AND n.nspname OPERATOR(pg_catalog.=) cc.schema_name)
-        WHERE k.relallvisible OPERATOR(pg_catalog.<) k.relpages
-        ORDER BY pg_catalog.age(k.relfrozenxid) DESC
-        ;
-        GRANT SELECT ON _ps_catalog.chunks_to_freeze TO prom_reader;
-        COMMENT ON VIEW _ps_catalog.chunks_to_freeze IS 'Lists compressed chunks that need to be frozen';
+    IF NOT _prom_catalog.is_timescaledb_installed() THEN
+        RETURN;
     END IF;
+
+    -- https://www.postgresql.org/docs/current/storage-vm.html
+    -- we cannot tell if a rel is frozen or not without an extension (pg_visible), but a page must be
+    -- all visible in order to be all frozen, so if there are fewer all visible pages than there are total
+    -- pages, then we know that the table must not be frozen yet and a vacuum may determine that it can be
+    CREATE OR REPLACE VIEW _ps_catalog.compressed_chunks_to_freeze AS
+    SELECT
+        cc.id,
+        cc.schema_name,
+        cc.table_name,
+        greatest
+        (
+            pg_catalog.pg_stat_get_last_vacuum_time(k.oid),
+            pg_catalog.pg_stat_get_last_autovacuum_time(k.oid)
+        ) as last_vacuum,
+        k.relfrozenxid
+    FROM _timescaledb_catalog.chunk c
+    INNER JOIN _timescaledb_catalog.chunk cc
+    ON (c.dropped OPERATOR(pg_catalog.=) false AND c.compressed_chunk_id OPERATOR(pg_catalog.=) cc.id)
+    INNER JOIN pg_catalog.pg_class k
+    ON (k.relname OPERATOR(pg_catalog.=) cc.table_name)
+    INNER JOIN pg_catalog.pg_namespace n
+    ON (k.relnamespace OPERATOR(pg_catalog.=) n.oid AND n.nspname OPERATOR(pg_catalog.=) cc.schema_name)
+    WHERE k.relkind OPERATOR(pg_catalog.=) 'r'
+    AND k.relallvisible OPERATOR(pg_catalog.<) k.relpages
+    ;
+    GRANT SELECT ON _ps_catalog.compressed_chunks_to_freeze TO prom_reader;
+    COMMENT ON VIEW _ps_catalog.compressed_chunks_to_freeze IS 'Lists compressed chunks that need to be frozen';
+
+    -- if a compressed chunk is missing statistics and is never later modified after initial compression
+    -- then the autovacuum will completely ignore it until it passes vacuum_freeze_max_age
+    -- this is not ideal. if many end up in this state, we might have great performance until a bunch of
+    -- chunks hit the threshold and the autovacuum engine finally sees them and starts working them
+    CREATE OR REPLACE VIEW _ps_catalog.compressed_chunks_missing_stats AS
+    SELECT
+        cc.id,
+        cc.schema_name,
+        cc.table_name,
+        k.relfrozenxid
+    FROM _timescaledb_catalog.chunk c
+    INNER JOIN _timescaledb_catalog.chunk cc
+    ON (c.dropped OPERATOR(pg_catalog.=) false AND c.compressed_chunk_id OPERATOR(pg_catalog.=) cc.id)
+    INNER JOIN pg_catalog.pg_class k
+    ON (k.relname OPERATOR(pg_catalog.=) cc.table_name)
+    INNER JOIN pg_catalog.pg_namespace n
+    ON (k.relnamespace OPERATOR(pg_catalog.=) n.oid AND n.nspname OPERATOR(pg_catalog.=) cc.schema_name)
+    WHERE k.relkind OPERATOR(pg_catalog.=) 'r'
+    AND k.relallvisible OPERATOR(pg_catalog.<) k.relpages
+    AND pg_catalog.pg_stat_get_last_autovacuum_time(k.oid) IS NULL -- never autovacuumed
+    AND pg_catalog.pg_stat_get_last_vacuum_time(k.oid) IS NULL -- never vacuumed
+    AND k.reltuples > 0 -- there are tuples, but...
+    AND pg_catalog.pg_stat_get_live_tuples(k.oid) = 0 -- stats appear to be missing
+    ;
+    GRANT SELECT ON _ps_catalog.compressed_chunks_missing_stats TO prom_reader;
+    COMMENT ON VIEW _ps_catalog.compressed_chunks_missing_stats IS 'Lists compressed chunks that need to be vacuum';
 END;
 $block$;

--- a/migration/incremental/035-remove-func.sql
+++ b/migration/incremental/035-remove-func.sql
@@ -1,2 +1,3 @@
 
 DROP FUNCTION IF EXISTS _prom_catalog.get_metrics_that_need_compression();
+DROP VIEW IF EXISTS _ps_catalog.chunks_to_freeze;

--- a/sql-tests/testdata/vacuum_engine.sql
+++ b/sql-tests/testdata/vacuum_engine.sql
@@ -2,7 +2,7 @@
 \set QUIET 1
 \i 'testdata/scripts/pgtap-1.2.0.sql'
 
-select * from plan(5);
+select * from plan(6);
 
 -- create one hypertable
 create table metric1(id int, t timestamptz not null, val double precision) with (autovacuum_enabled = 'off');
@@ -44,7 +44,7 @@ select isnt_empty(
 
 -- there ought not be any results from the view because no chunks are compressed
 select is_empty(
-    'select * from _ps_catalog.chunks_to_freeze',
+    'select * from _ps_catalog.compressed_chunks_to_freeze',
     'zero results when no chunks compressed'
 );
 
@@ -111,9 +111,14 @@ select results_eq(
 
 -- view should return the 15 chosen compressed chunks
 select results_eq(
-    'select id from _ps_catalog.chunks_to_freeze order by id',
+    'select id from _ps_catalog.compressed_chunks_to_freeze order by id',
     'select id from pg_temp._chosen_compressed_chunks order by id',
     'view should return the 15 chosen compressed chunks'
+);
+
+select lives_ok(
+    'select * from _ps_catalog.compressed_chunks_missing_stats',
+    'compressed_chunks_missing_stats view works'
 );
 
 /*


### PR DESCRIPTION
## Description

We have seen instances in which compresses chunks are missing statistics. Autovacuum ignores tables that are missing statistics. Analyzing these tables does not help since we rarely modify chunks after they are compressed. Therefore, these chunks are ignored until they pass the vacuum_freeze_max_age. This can be bad for performance. So, the vacuum engine makes a second pass looking for these chunks and vacuums them. We only use one worker for these.

See also: https://github.com/timescale/promscale/pull/1804

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation